### PR TITLE
Add claimable hash-lock flow with RPC and CLI support

### DIFF
--- a/cmd/nhb-cli/claimable_cmd.go
+++ b/cmd/nhb-cli/claimable_cmd.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+var claimableRPCCall = callEscrowRPC
+
+func runClaimableCommand(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, claimableUsage())
+		return 1
+	}
+	switch args[0] {
+	case "create":
+		return runClaimableCreate(args[1:], stdout, stderr)
+	case "claim":
+		return runClaimableClaim(args[1:], stdout, stderr)
+	case "cancel":
+		return runClaimableCancel(args[1:], stdout, stderr)
+	case "get":
+		return runClaimableGet(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "Unknown claimable subcommand: %s\n", args[0])
+		fmt.Fprintln(stderr, claimableUsage())
+		return 1
+	}
+}
+
+func runClaimableCreate(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("claimable create", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var (
+		payer     string
+		token     string
+		amountStr string
+		deadline  string
+		hashLock  string
+	)
+	fs.StringVar(&payer, "payer", "", "payer bech32 address")
+	fs.StringVar(&token, "token", "", "token symbol (NHB or ZNHB)")
+	fs.StringVar(&amountStr, "amount", "", "claimable amount (supports 100e18 shorthand)")
+	fs.StringVar(&deadline, "deadline", "", "deadline as +duration or RFC3339 timestamp")
+	fs.StringVar(&hashLock, "hash-lock", "", "hash lock as 0x-prefixed 32-byte hex string")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "Error: unexpected positional arguments")
+		return 1
+	}
+	if payer == "" {
+		fmt.Fprintln(stderr, "Error: --payer is required")
+		return 1
+	}
+	normalizedToken := strings.ToUpper(strings.TrimSpace(token))
+	if normalizedToken != "NHB" && normalizedToken != "ZNHB" {
+		fmt.Fprintln(stderr, "Error: --token must be NHB or ZNHB")
+		return 1
+	}
+	if strings.TrimSpace(amountStr) == "" {
+		fmt.Fprintln(stderr, "Error: --amount is required")
+		return 1
+	}
+	normalizedAmount, err := normalizeEscrowAmount(amountStr)
+	if err != nil {
+		fmt.Fprintln(stderr, "Error:", err)
+		return 1
+	}
+	if strings.TrimSpace(deadline) == "" {
+		fmt.Fprintln(stderr, "Error: --deadline is required")
+		return 1
+	}
+	deadlineUnix, err := parseEscrowDeadline(deadline, escrowNow())
+	if err != nil {
+		fmt.Fprintln(stderr, "Error:", err)
+		return 1
+	}
+	if err := validateHashLock(hashLock); err != nil {
+		fmt.Fprintln(stderr, "Error:", err)
+		return 1
+	}
+	payload := map[string]interface{}{
+		"payer":    payer,
+		"token":    normalizedToken,
+		"amount":   normalizedAmount,
+		"deadline": deadlineUnix,
+		"hashLock": strings.TrimPrefix(strings.TrimPrefix(hashLock, "0x"), "0X"),
+	}
+	result, rpcErr, err := claimableRPCCall("claimable_create", payload, true)
+	if err != nil {
+		return handleRPCCallError(stderr, err)
+	}
+	if rpcErr != nil {
+		return handleRPCError(stderr, rpcErr)
+	}
+	writeRPCResult(stdout, result)
+	return 0
+}
+
+func runClaimableClaim(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("claimable claim", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var (
+		id       string
+		preimage string
+		payee    string
+	)
+	fs.StringVar(&id, "id", "", "claimable identifier")
+	fs.StringVar(&preimage, "preimage", "", "preimage as 0x-prefixed hex string")
+	fs.StringVar(&payee, "payee", "", "payee bech32 address")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "Error: unexpected positional arguments")
+		return 1
+	}
+	if err := validateEscrowID(id); err != nil {
+		fmt.Fprintln(stderr, "Error:", err)
+		return 1
+	}
+	if payee == "" {
+		fmt.Fprintln(stderr, "Error: --payee is required")
+		return 1
+	}
+	if _, err := parseHex(preimage); err != nil {
+		fmt.Fprintln(stderr, "Error: --preimage must be hex-encoded")
+		return 1
+	}
+	payload := map[string]interface{}{
+		"id":       id,
+		"preimage": strings.TrimPrefix(strings.TrimPrefix(preimage, "0x"), "0X"),
+		"payee":    payee,
+	}
+	result, rpcErr, err := claimableRPCCall("claimable_claim", payload, true)
+	if err != nil {
+		return handleRPCCallError(stderr, err)
+	}
+	if rpcErr != nil {
+		return handleRPCError(stderr, rpcErr)
+	}
+	writeRPCResult(stdout, result)
+	return 0
+}
+
+func runClaimableCancel(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("claimable cancel", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var (
+		id     string
+		caller string
+	)
+	fs.StringVar(&id, "id", "", "claimable identifier")
+	fs.StringVar(&caller, "caller", "", "caller bech32 address")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "Error: unexpected positional arguments")
+		return 1
+	}
+	if err := validateEscrowID(id); err != nil {
+		fmt.Fprintln(stderr, "Error:", err)
+		return 1
+	}
+	if caller == "" {
+		fmt.Fprintln(stderr, "Error: --caller is required")
+		return 1
+	}
+	payload := map[string]interface{}{
+		"id":     id,
+		"caller": caller,
+	}
+	result, rpcErr, err := claimableRPCCall("claimable_cancel", payload, true)
+	if err != nil {
+		return handleRPCCallError(stderr, err)
+	}
+	if rpcErr != nil {
+		return handleRPCError(stderr, rpcErr)
+	}
+	writeRPCResult(stdout, result)
+	return 0
+}
+
+func runClaimableGet(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("claimable get", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var id string
+	fs.StringVar(&id, "id", "", "claimable identifier")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "Error: unexpected positional arguments")
+		return 1
+	}
+	if err := validateEscrowID(id); err != nil {
+		fmt.Fprintln(stderr, "Error:", err)
+		return 1
+	}
+	payload := map[string]interface{}{"id": id}
+	result, rpcErr, err := claimableRPCCall("claimable_get", payload, false)
+	if err != nil {
+		return handleRPCCallError(stderr, err)
+	}
+	if rpcErr != nil {
+		return handleRPCError(stderr, rpcErr)
+	}
+	writeRPCResult(stdout, result)
+	return 0
+}
+
+func claimableUsage() string {
+	return "Usage: nhb-cli claimable <create|claim|cancel|get> [--flags]"
+}
+
+func validateHashLock(value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("--hash-lock is required")
+	}
+	cleaned := strings.TrimPrefix(strings.TrimPrefix(trimmed, "0x"), "0X")
+	if len(cleaned) != 64 {
+		return fmt.Errorf("--hash-lock must be a 0x-prefixed 32-byte hex string")
+	}
+	if _, err := hex.DecodeString(cleaned); err != nil {
+		return fmt.Errorf("--hash-lock must contain only hexadecimal characters")
+	}
+	return nil
+}
+
+func parseHex(value string) ([]byte, error) {
+	trimmed := strings.TrimSpace(value)
+	cleaned := strings.TrimPrefix(strings.TrimPrefix(trimmed, "0x"), "0X")
+	if cleaned == "" {
+		return []byte{}, nil
+	}
+	return hex.DecodeString(cleaned)
+}

--- a/cmd/nhb-cli/main.go
+++ b/cmd/nhb-cli/main.go
@@ -96,17 +96,23 @@ func main() {
 			os.Exit(code)
 		}
 		return
-	case "escrow":
-		code := runEscrowCommand(args[1:], os.Stdout, os.Stderr)
-		if code != 0 {
-			os.Exit(code)
-		}
-		return
-	case "p2p":
-		code := runP2PCommand(args[1:], os.Stdout, os.Stderr)
-		if code != 0 {
-			os.Exit(code)
-		}
+        case "escrow":
+                code := runEscrowCommand(args[1:], os.Stdout, os.Stderr)
+                if code != 0 {
+                        os.Exit(code)
+                }
+                return
+        case "claimable":
+                code := runClaimableCommand(args[1:], os.Stdout, os.Stderr)
+                if code != 0 {
+                        os.Exit(code)
+                }
+                return
+        case "p2p":
+                code := runP2PCommand(args[1:], os.Stdout, os.Stderr)
+                if code != 0 {
+                        os.Exit(code)
+                }
 		return
 	case "loyalty-create-business":
 		if len(args) < 3 {
@@ -781,7 +787,8 @@ func printUsage() {
 	fmt.Println("  un-stake <amount> <path_to_key_file> - Un-stakes a specified amount of ZapNHB")
 	fmt.Println("  heartbeat <path_to_key_file>        - Sends a heartbeat to increase engagement score")
 	fmt.Println("  deploy <bytecode_file> <key_file>    - Deploys a smart contract")
-	fmt.Println("  id                                 - Identity alias management subcommands")
-	fmt.Println("  escrow                             - Escrow management subcommands")
-	fmt.Println("  p2p                                - P2P trade orchestration subcommands")
+        fmt.Println("  id                                 - Identity alias management subcommands")
+        fmt.Println("  escrow                             - Escrow management subcommands")
+        fmt.Println("  claimable                          - Hash-lock claimable subcommands")
+        fmt.Println("  p2p                                - P2P trade orchestration subcommands")
 }

--- a/core/claimable/claimable.go
+++ b/core/claimable/claimable.go
@@ -1,0 +1,75 @@
+package claimable
+
+import (
+	"errors"
+	"math/big"
+)
+
+type ClaimStatus uint8
+
+const (
+	ClaimStatusInit ClaimStatus = iota
+	ClaimStatusClaimed
+	ClaimStatusCancelled
+	ClaimStatusExpired
+)
+
+func (s ClaimStatus) Valid() bool {
+	switch s {
+	case ClaimStatusInit, ClaimStatusClaimed, ClaimStatusCancelled, ClaimStatusExpired:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s ClaimStatus) String() string {
+	switch s {
+	case ClaimStatusInit:
+		return "init"
+	case ClaimStatusClaimed:
+		return "claimed"
+	case ClaimStatusCancelled:
+		return "cancelled"
+	case ClaimStatusExpired:
+		return "expired"
+	default:
+		return "unknown"
+	}
+}
+
+var (
+	ErrNotFound          = errors.New("claimable: not found")
+	ErrInvalidToken      = errors.New("claimable: invalid token")
+	ErrInvalidAmount     = errors.New("claimable: amount must be positive")
+	ErrInvalidPreimage   = errors.New("claimable: invalid preimage")
+	ErrUnauthorized      = errors.New("claimable: unauthorized")
+	ErrDeadlineExceeded  = errors.New("claimable: deadline exceeded")
+	ErrNotExpired        = errors.New("claimable: not expired")
+	ErrInvalidState      = errors.New("claimable: invalid state")
+	ErrInsufficientFunds = errors.New("claimable: insufficient funds")
+)
+
+type Claimable struct {
+	ID        [32]byte
+	Payer     [20]byte
+	Token     string
+	Amount    *big.Int
+	HashLock  [32]byte
+	Deadline  int64
+	CreatedAt int64
+	Status    ClaimStatus
+}
+
+func (c *Claimable) Clone() *Claimable {
+	if c == nil {
+		return nil
+	}
+	out := *c
+	if c.Amount != nil {
+		out.Amount = new(big.Int).Set(c.Amount)
+	} else {
+		out.Amount = big.NewInt(0)
+	}
+	return &out
+}

--- a/core/events/claimable.go
+++ b/core/events/claimable.go
@@ -1,0 +1,117 @@
+package events
+
+import (
+	"encoding/hex"
+	"math/big"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+const (
+	TypeClaimableCreated   = "claimable.created"
+	TypeClaimableClaimed   = "claimable.claimed"
+	TypeClaimableCancelled = "claimable.cancelled"
+	TypeClaimableExpired   = "claimable.expired"
+)
+
+type ClaimableCreated struct {
+	ID        [32]byte
+	Payer     [20]byte
+	Token     string
+	Amount    *big.Int
+	Deadline  int64
+	CreatedAt int64
+}
+
+func (ClaimableCreated) EventType() string { return TypeClaimableCreated }
+
+func (e ClaimableCreated) Event() *types.Event {
+	return &types.Event{
+		Type: TypeClaimableCreated,
+		Attributes: map[string]string{
+			"id":        hex.EncodeToString(e.ID[:]),
+			"payer":     crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
+			"token":     e.Token,
+			"amount":    formatAmount(e.Amount),
+			"deadline":  intToString(e.Deadline),
+			"createdAt": intToString(e.CreatedAt),
+		},
+	}
+}
+
+type ClaimableClaimed struct {
+	ID     [32]byte
+	Payer  [20]byte
+	Payee  [20]byte
+	Token  string
+	Amount *big.Int
+}
+
+func (ClaimableClaimed) EventType() string { return TypeClaimableClaimed }
+
+func (e ClaimableClaimed) Event() *types.Event {
+	return &types.Event{
+		Type: TypeClaimableClaimed,
+		Attributes: map[string]string{
+			"id":     hex.EncodeToString(e.ID[:]),
+			"payer":  crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
+			"payee":  crypto.NewAddress(crypto.NHBPrefix, e.Payee[:]).String(),
+			"token":  e.Token,
+			"amount": formatAmount(e.Amount),
+		},
+	}
+}
+
+type ClaimableCancelled struct {
+	ID     [32]byte
+	Payer  [20]byte
+	Token  string
+	Amount *big.Int
+}
+
+func (ClaimableCancelled) EventType() string { return TypeClaimableCancelled }
+
+func (e ClaimableCancelled) Event() *types.Event {
+	return &types.Event{
+		Type: TypeClaimableCancelled,
+		Attributes: map[string]string{
+			"id":     hex.EncodeToString(e.ID[:]),
+			"payer":  crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
+			"token":  e.Token,
+			"amount": formatAmount(e.Amount),
+		},
+	}
+}
+
+type ClaimableExpired struct {
+	ID     [32]byte
+	Payer  [20]byte
+	Token  string
+	Amount *big.Int
+}
+
+func (ClaimableExpired) EventType() string { return TypeClaimableExpired }
+
+func (e ClaimableExpired) Event() *types.Event {
+	return &types.Event{
+		Type: TypeClaimableExpired,
+		Attributes: map[string]string{
+			"id":     hex.EncodeToString(e.ID[:]),
+			"payer":  crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
+			"token":  e.Token,
+			"amount": formatAmount(e.Amount),
+		},
+	}
+}
+
+func formatAmount(v *big.Int) string {
+	if v == nil {
+		return "0"
+	}
+	return v.String()
+}
+
+func intToString(v int64) string {
+	return big.NewInt(v).String()
+}

--- a/core/state/claimable.go
+++ b/core/state/claimable.go
@@ -1,0 +1,406 @@
+package state
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math/big"
+	"time"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"nhbchain/core/claimable"
+	"nhbchain/core/types"
+	"nhbchain/native/escrow"
+)
+
+func claimableStorageKey(id [32]byte) []byte {
+	buf := make([]byte, len(claimableRecordPrefix)+len(id))
+	copy(buf, claimableRecordPrefix)
+	copy(buf[len(claimableRecordPrefix):], id[:])
+	return ethcrypto.Keccak256(buf)
+}
+
+func claimableNonceKey(payer [20]byte) []byte {
+	buf := make([]byte, len(claimableNoncePrefix)+len(payer))
+	copy(buf, claimableNoncePrefix)
+	copy(buf[len(claimableNoncePrefix):], payer[:])
+	return ethcrypto.Keccak256(buf)
+}
+
+type storedClaimable struct {
+	ID        [32]byte
+	Payer     [20]byte
+	Token     string
+	Amount    *big.Int
+	HashLock  [32]byte
+	Deadline  *big.Int
+	CreatedAt *big.Int
+	Status    uint8
+}
+
+func newStoredClaimable(c *claimable.Claimable) *storedClaimable {
+	if c == nil {
+		return nil
+	}
+	amount := big.NewInt(0)
+	if c.Amount != nil {
+		amount = new(big.Int).Set(c.Amount)
+	}
+	return &storedClaimable{
+		ID:        c.ID,
+		Payer:     c.Payer,
+		Token:     c.Token,
+		Amount:    amount,
+		HashLock:  c.HashLock,
+		Deadline:  big.NewInt(c.Deadline),
+		CreatedAt: big.NewInt(c.CreatedAt),
+		Status:    uint8(c.Status),
+	}
+}
+
+func (s *storedClaimable) toClaimable() (*claimable.Claimable, error) {
+	if s == nil {
+		return nil, fmt.Errorf("claimable: nil storage record")
+	}
+	normalized, err := escrow.NormalizeToken(s.Token)
+	if err != nil {
+		return nil, claimable.ErrInvalidToken
+	}
+	out := &claimable.Claimable{
+		ID:       s.ID,
+		Payer:    s.Payer,
+		Token:    normalized,
+		Amount:   big.NewInt(0),
+		HashLock: s.HashLock,
+		Status:   claimable.ClaimStatus(s.Status),
+	}
+	if s.Amount != nil {
+		out.Amount = new(big.Int).Set(s.Amount)
+	}
+	if s.Deadline != nil {
+		out.Deadline = s.Deadline.Int64()
+	}
+	if s.CreatedAt != nil {
+		out.CreatedAt = s.CreatedAt.Int64()
+	}
+	if !out.Status.Valid() {
+		return nil, claimable.ErrInvalidState
+	}
+	return out, nil
+}
+
+func cloneAccount(acc *types.Account) *types.Account {
+	if acc == nil {
+		return &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}
+	}
+	cloned := *acc
+	if acc.BalanceNHB != nil {
+		cloned.BalanceNHB = new(big.Int).Set(acc.BalanceNHB)
+	} else {
+		cloned.BalanceNHB = big.NewInt(0)
+	}
+	if acc.BalanceZNHB != nil {
+		cloned.BalanceZNHB = new(big.Int).Set(acc.BalanceZNHB)
+	} else {
+		cloned.BalanceZNHB = big.NewInt(0)
+	}
+	if acc.Stake != nil {
+		cloned.Stake = new(big.Int).Set(acc.Stake)
+	} else {
+		cloned.Stake = big.NewInt(0)
+	}
+	return &cloned
+}
+
+func (m *Manager) nextClaimableID(payer [20]byte) ([32]byte, uint64, error) {
+	key := claimableNonceKey(payer)
+	current, err := m.loadBigInt(key)
+	if err != nil {
+		return [32]byte{}, 0, err
+	}
+	if current.Sign() < 0 {
+		return [32]byte{}, 0, fmt.Errorf("claimable: negative nonce state")
+	}
+	if current.BitLen() > 63 {
+		return [32]byte{}, 0, fmt.Errorf("claimable: nonce overflow")
+	}
+	nonce := current.Uint64()
+	buf := make([]byte, len(payer)+8)
+	copy(buf, payer[:])
+	binary.BigEndian.PutUint64(buf[len(payer):], nonce)
+	hash := ethcrypto.Keccak256(buf)
+	var id [32]byte
+	copy(id[:], hash)
+	next := new(big.Int).SetUint64(nonce + 1)
+	if err := m.writeBigInt(key, next); err != nil {
+		return [32]byte{}, 0, err
+	}
+	return id, nonce, nil
+}
+
+func (m *Manager) revertClaimableNonce(payer [20]byte, nonce uint64) {
+	key := claimableNonceKey(payer)
+	_ = m.writeBigInt(key, new(big.Int).SetUint64(nonce))
+}
+
+func (m *Manager) ClaimablePut(c *claimable.Claimable) error {
+	if c == nil {
+		return fmt.Errorf("claimable: nil value")
+	}
+	if !c.Status.Valid() {
+		return fmt.Errorf("claimable: invalid status")
+	}
+	normalized, err := escrow.NormalizeToken(c.Token)
+	if err != nil {
+		return claimable.ErrInvalidToken
+	}
+	record := newStoredClaimable(&claimable.Claimable{
+		ID:        c.ID,
+		Payer:     c.Payer,
+		Token:     normalized,
+		Amount:    c.Amount,
+		HashLock:  c.HashLock,
+		Deadline:  c.Deadline,
+		CreatedAt: c.CreatedAt,
+		Status:    c.Status,
+	})
+	encoded, err := rlp.EncodeToBytes(record)
+	if err != nil {
+		return err
+	}
+	return m.trie.Update(claimableStorageKey(c.ID), encoded)
+}
+
+func (m *Manager) ClaimableGet(id [32]byte) (*claimable.Claimable, bool) {
+	data, err := m.trie.Get(claimableStorageKey(id))
+	if err != nil || len(data) == 0 {
+		return nil, false
+	}
+	stored := new(storedClaimable)
+	if err := rlp.DecodeBytes(data, stored); err != nil {
+		return nil, false
+	}
+	record, err := stored.toClaimable()
+	if err != nil {
+		return nil, false
+	}
+	return record, true
+}
+
+func (m *Manager) ClaimableCredit(payer [20]byte, token string, amt *big.Int) error {
+	if amt == nil || amt.Sign() <= 0 {
+		return claimable.ErrInvalidAmount
+	}
+	normalized, err := escrow.NormalizeToken(token)
+	if err != nil {
+		return claimable.ErrInvalidToken
+	}
+	vault, err := escrowModuleAddress(normalized)
+	if err != nil {
+		return err
+	}
+	payerAcc, err := m.GetAccount(payer[:])
+	if err != nil {
+		return err
+	}
+	vaultAcc, err := m.GetAccount(vault[:])
+	if err != nil {
+		return err
+	}
+	payerAcc = cloneAccount(payerAcc)
+	vaultAcc = cloneAccount(vaultAcc)
+	switch normalized {
+	case "NHB":
+		if payerAcc.BalanceNHB.Cmp(amt) < 0 {
+			return claimable.ErrInsufficientFunds
+		}
+		payerAcc.BalanceNHB = new(big.Int).Sub(payerAcc.BalanceNHB, amt)
+		vaultAcc.BalanceNHB = new(big.Int).Add(vaultAcc.BalanceNHB, amt)
+	case "ZNHB":
+		if payerAcc.BalanceZNHB.Cmp(amt) < 0 {
+			return claimable.ErrInsufficientFunds
+		}
+		payerAcc.BalanceZNHB = new(big.Int).Sub(payerAcc.BalanceZNHB, amt)
+		vaultAcc.BalanceZNHB = new(big.Int).Add(vaultAcc.BalanceZNHB, amt)
+	default:
+		return claimable.ErrInvalidToken
+	}
+	if err := m.PutAccount(payer[:], payerAcc); err != nil {
+		return err
+	}
+	if err := m.PutAccount(vault[:], vaultAcc); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) ClaimableDebit(token string, amt *big.Int, recipient [20]byte) error {
+	if amt == nil || amt.Sign() <= 0 {
+		return claimable.ErrInvalidAmount
+	}
+	normalized, err := escrow.NormalizeToken(token)
+	if err != nil {
+		return claimable.ErrInvalidToken
+	}
+	vault, err := escrowModuleAddress(normalized)
+	if err != nil {
+		return err
+	}
+	vaultAcc, err := m.GetAccount(vault[:])
+	if err != nil {
+		return err
+	}
+	recipientAcc, err := m.GetAccount(recipient[:])
+	if err != nil {
+		return err
+	}
+	vaultAcc = cloneAccount(vaultAcc)
+	recipientAcc = cloneAccount(recipientAcc)
+	switch normalized {
+	case "NHB":
+		if vaultAcc.BalanceNHB.Cmp(amt) < 0 {
+			return claimable.ErrInsufficientFunds
+		}
+		vaultAcc.BalanceNHB = new(big.Int).Sub(vaultAcc.BalanceNHB, amt)
+		recipientAcc.BalanceNHB = new(big.Int).Add(recipientAcc.BalanceNHB, amt)
+	case "ZNHB":
+		if vaultAcc.BalanceZNHB.Cmp(amt) < 0 {
+			return claimable.ErrInsufficientFunds
+		}
+		vaultAcc.BalanceZNHB = new(big.Int).Sub(vaultAcc.BalanceZNHB, amt)
+		recipientAcc.BalanceZNHB = new(big.Int).Add(recipientAcc.BalanceZNHB, amt)
+	default:
+		return claimable.ErrInvalidToken
+	}
+	if err := m.PutAccount(vault[:], vaultAcc); err != nil {
+		return err
+	}
+	if err := m.PutAccount(recipient[:], recipientAcc); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) CreateClaimable(payer [20]byte, token string, amount *big.Int, hashLock [32]byte, deadline int64) (*claimable.Claimable, error) {
+	if amount == nil || amount.Sign() <= 0 {
+		return nil, claimable.ErrInvalidAmount
+	}
+	normalized, err := escrow.NormalizeToken(token)
+	if err != nil {
+		return nil, claimable.ErrInvalidToken
+	}
+	id, nonce, err := m.nextClaimableID(payer)
+	if err != nil {
+		return nil, err
+	}
+	rollback := func() {
+		m.revertClaimableNonce(payer, nonce)
+	}
+	if err := m.ClaimableCredit(payer, normalized, amount); err != nil {
+		rollback()
+		return nil, err
+	}
+	record := &claimable.Claimable{
+		ID:        id,
+		Payer:     payer,
+		Token:     normalized,
+		Amount:    new(big.Int).Set(amount),
+		HashLock:  hashLock,
+		Deadline:  deadline,
+		CreatedAt: time.Now().Unix(),
+		Status:    claimable.ClaimStatusInit,
+	}
+	if err := m.ClaimablePut(record); err != nil {
+		_ = m.ClaimableDebit(normalized, amount, payer)
+		rollback()
+		return nil, err
+	}
+	return record, nil
+}
+
+func (m *Manager) ClaimableClaim(id [32]byte, preimage []byte, payee [20]byte) (*claimable.Claimable, bool, error) {
+	record, ok := m.ClaimableGet(id)
+	if !ok {
+		return nil, false, claimable.ErrNotFound
+	}
+	if record.Status == claimable.ClaimStatusClaimed {
+		return record, false, nil
+	}
+	if record.Status != claimable.ClaimStatusInit {
+		return record, false, claimable.ErrInvalidState
+	}
+	hash := ethcrypto.Keccak256(preimage)
+	if !bytes.Equal(hash, record.HashLock[:]) {
+		return nil, false, claimable.ErrInvalidPreimage
+	}
+	if err := m.ClaimableDebit(record.Token, record.Amount, payee); err != nil {
+		return nil, false, err
+	}
+	record.Status = claimable.ClaimStatusClaimed
+	if err := m.ClaimablePut(record); err != nil {
+		_ = m.ClaimableCredit(payee, record.Token, record.Amount)
+		return nil, false, err
+	}
+	return record, true, nil
+}
+
+func (m *Manager) ClaimableCancel(id [32]byte, caller [20]byte, now int64) (*claimable.Claimable, bool, error) {
+	record, ok := m.ClaimableGet(id)
+	if !ok {
+		return nil, false, claimable.ErrNotFound
+	}
+	if record.Status == claimable.ClaimStatusCancelled {
+		return record, false, nil
+	}
+	if record.Status == claimable.ClaimStatusExpired {
+		return record, false, nil
+	}
+	if record.Status != claimable.ClaimStatusInit {
+		return record, false, claimable.ErrInvalidState
+	}
+	if caller != record.Payer {
+		return nil, false, claimable.ErrUnauthorized
+	}
+	if now > record.Deadline {
+		return nil, false, claimable.ErrDeadlineExceeded
+	}
+	if err := m.ClaimableDebit(record.Token, record.Amount, record.Payer); err != nil {
+		return nil, false, err
+	}
+	record.Status = claimable.ClaimStatusCancelled
+	if err := m.ClaimablePut(record); err != nil {
+		_ = m.ClaimableCredit(record.Payer, record.Token, record.Amount)
+		return nil, false, err
+	}
+	return record, true, nil
+}
+
+func (m *Manager) ClaimableExpire(id [32]byte, now int64) (*claimable.Claimable, bool, error) {
+	record, ok := m.ClaimableGet(id)
+	if !ok {
+		return nil, false, claimable.ErrNotFound
+	}
+	if record.Status == claimable.ClaimStatusExpired {
+		return record, false, nil
+	}
+	if record.Status == claimable.ClaimStatusCancelled {
+		return record, false, nil
+	}
+	if record.Status != claimable.ClaimStatusInit {
+		return record, false, claimable.ErrInvalidState
+	}
+	if now < record.Deadline {
+		return nil, false, claimable.ErrNotExpired
+	}
+	if err := m.ClaimableDebit(record.Token, record.Amount, record.Payer); err != nil {
+		return nil, false, err
+	}
+	record.Status = claimable.ClaimStatusExpired
+	if err := m.ClaimablePut(record); err != nil {
+		_ = m.ClaimableCredit(record.Payer, record.Token, record.Amount)
+		return nil, false, err
+	}
+	return record, true, nil
+}

--- a/core/state/claimable_test.go
+++ b/core/state/claimable_test.go
@@ -1,0 +1,162 @@
+package state
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	"nhbchain/core/claimable"
+	"nhbchain/core/types"
+)
+
+func fundAccount(t *testing.T, manager *Manager, addr [20]byte, nhb, znhb int64) {
+	t.Helper()
+	account := &types.Account{
+		BalanceNHB:  big.NewInt(nhb),
+		BalanceZNHB: big.NewInt(znhb),
+		Stake:       big.NewInt(0),
+	}
+	if err := manager.PutAccount(addr[:], account); err != nil {
+		t.Fatalf("put account: %v", err)
+	}
+}
+
+func TestClaimableCreateAndClaim(t *testing.T) {
+	manager := newTestManager(t)
+	var payer [20]byte
+	payer[19] = 1
+	fundAccount(t, manager, payer, 1000, 0)
+
+	preimage := []byte("super-secret")
+	hash := ethcrypto.Keccak256(preimage)
+	var hashLock [32]byte
+	copy(hashLock[:], hash)
+
+	deadline := int64(500)
+	claim, err := manager.CreateClaimable(payer, "NHB", big.NewInt(100), hashLock, deadline)
+	if err != nil {
+		t.Fatalf("create claimable: %v", err)
+	}
+	if claim.Status != claimable.ClaimStatusInit {
+		t.Fatalf("expected status init, got %v", claim.Status)
+	}
+
+	var payee [20]byte
+	payee[19] = 2
+
+	if _, _, err := manager.ClaimableClaim(claim.ID, []byte("bad"), payee); !errors.Is(err, claimable.ErrInvalidPreimage) {
+		t.Fatalf("expected invalid preimage error, got %v", err)
+	}
+
+	updated, changed, err := manager.ClaimableClaim(claim.ID, preimage, payee)
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected state change on first claim")
+	}
+	if updated.Status != claimable.ClaimStatusClaimed {
+		t.Fatalf("expected claimed status, got %v", updated.Status)
+	}
+
+	payerAcc, err := manager.GetAccount(payer[:])
+	if err != nil {
+		t.Fatalf("get payer: %v", err)
+	}
+	if want := big.NewInt(900); payerAcc.BalanceNHB.Cmp(want) != 0 {
+		t.Fatalf("unexpected payer balance: got %s want %s", payerAcc.BalanceNHB, want)
+	}
+	payeeAcc, err := manager.GetAccount(payee[:])
+	if err != nil {
+		t.Fatalf("get payee: %v", err)
+	}
+	if want := big.NewInt(100); payeeAcc.BalanceNHB.Cmp(want) != 0 {
+		t.Fatalf("unexpected payee balance: got %s want %s", payeeAcc.BalanceNHB, want)
+	}
+
+	_, replayChanged, err := manager.ClaimableClaim(claim.ID, preimage, payee)
+	if err != nil {
+		t.Fatalf("claim replay: %v", err)
+	}
+	if replayChanged {
+		t.Fatalf("expected replay claim to be no-op")
+	}
+}
+
+func TestClaimableCancelAndExpire(t *testing.T) {
+	manager := newTestManager(t)
+	var payer [20]byte
+	payer[19] = 3
+	fundAccount(t, manager, payer, 0, 1000)
+
+	var hashLock [32]byte
+	deadline := int64(100)
+	claim, err := manager.CreateClaimable(payer, "ZNHB", big.NewInt(200), hashLock, deadline)
+	if err != nil {
+		t.Fatalf("create claimable: %v", err)
+	}
+
+	// Cancel before deadline
+	cancelled, changed, err := manager.ClaimableCancel(claim.ID, payer, deadline-1)
+	if err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected cancel to change state")
+	}
+	if cancelled.Status != claimable.ClaimStatusCancelled {
+		t.Fatalf("expected cancelled status, got %v", cancelled.Status)
+	}
+	payerAcc, err := manager.GetAccount(payer[:])
+	if err != nil {
+		t.Fatalf("get payer: %v", err)
+	}
+	if want := big.NewInt(1000); payerAcc.BalanceZNHB.Cmp(want) != 0 {
+		t.Fatalf("payer balance not restored after cancel: got %s want %s", payerAcc.BalanceZNHB, want)
+	}
+
+	_, replayCancel, err := manager.ClaimableCancel(claim.ID, payer, deadline-1)
+	if err != nil {
+		t.Fatalf("cancel replay: %v", err)
+	}
+	if replayCancel {
+		t.Fatalf("expected cancel replay to be no-op")
+	}
+
+	// Expire path
+	fundAccount(t, manager, payer, 500, 1000) // replenish NHB for second claimable
+	deadlineExpire := int64(50)
+	second, err := manager.CreateClaimable(payer, "NHB", big.NewInt(300), hashLock, deadlineExpire)
+	if err != nil {
+		t.Fatalf("create second claimable: %v", err)
+	}
+	if _, _, err := manager.ClaimableExpire(second.ID, deadlineExpire-1); !errors.Is(err, claimable.ErrNotExpired) {
+		t.Fatalf("expected not expired error, got %v", err)
+	}
+	expired, changed, err := manager.ClaimableExpire(second.ID, deadlineExpire)
+	if err != nil {
+		t.Fatalf("expire: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected expire to change state")
+	}
+	if expired.Status != claimable.ClaimStatusExpired {
+		t.Fatalf("expected expired status, got %v", expired.Status)
+	}
+	payerAcc, err = manager.GetAccount(payer[:])
+	if err != nil {
+		t.Fatalf("get payer after expire: %v", err)
+	}
+	if want := big.NewInt(500); payerAcc.BalanceNHB.Cmp(want) != 0 {
+		t.Fatalf("payer NHB balance not restored after expire: got %s want %s", payerAcc.BalanceNHB, want)
+	}
+	_, replayExpire, err := manager.ClaimableExpire(second.ID, deadlineExpire+10)
+	if err != nil {
+		t.Fatalf("expire replay: %v", err)
+	}
+	if replayExpire {
+		t.Fatalf("expected expire replay to be no-op")
+	}
+}

--- a/core/state/manager.go
+++ b/core/state/manager.go
@@ -54,6 +54,8 @@ var (
 	escrowRecordPrefix         = []byte("escrow/record/")
 	escrowVaultPrefix          = []byte("escrow/vault/")
 	escrowModuleSeedPrefix     = "module/escrow/vault/"
+	claimableRecordPrefix      = []byte("claimable/record/")
+	claimableNoncePrefix       = []byte("claimable/nonce/")
 	tradeRecordPrefix          = []byte("trade/record/")
 	tradeEscrowIndexPrefix     = []byte("trade/index/escrow/")
 	identityAliasPrefix        = []byte("identity/alias/")

--- a/rpc/claimable_handlers.go
+++ b/rpc/claimable_handlers.go
@@ -1,0 +1,284 @@
+package rpc
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"nhbchain/core/claimable"
+	"nhbchain/crypto"
+)
+
+const (
+	codeClaimableInvalidParams = -32041
+	codeClaimableNotFound      = -32042
+	codeClaimableForbidden     = -32043
+	codeClaimableConflict      = -32044
+	codeClaimableInternal      = -32045
+)
+
+type claimableCreateParams struct {
+	Payer    string `json:"payer"`
+	Token    string `json:"token"`
+	Amount   string `json:"amount"`
+	Deadline int64  `json:"deadline"`
+	HashLock string `json:"hashLock"`
+}
+
+type claimableIDParams struct {
+	ID string `json:"id"`
+}
+
+type claimableClaimParams struct {
+	ID       string `json:"id"`
+	Preimage string `json:"preimage"`
+	Payee    string `json:"payee"`
+}
+
+type claimableCancelParams struct {
+	ID     string `json:"id"`
+	Caller string `json:"caller"`
+}
+
+type claimableCreateResult struct {
+	ID string `json:"id"`
+}
+
+type claimableOKResult struct {
+	OK bool `json:"ok"`
+}
+
+type claimableJSON struct {
+	ID        string `json:"id"`
+	Payer     string `json:"payer"`
+	Token     string `json:"token"`
+	Amount    string `json:"amount"`
+	HashLock  string `json:"hashLock"`
+	Deadline  int64  `json:"deadline"`
+	CreatedAt int64  `json:"createdAt"`
+	Status    string `json:"status"`
+}
+
+func (s *Server) handleClaimableCreate(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", "exactly one parameter object expected")
+		return
+	}
+	var params claimableCreateParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	payer, err := parseBech32Address(params.Payer)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	token := strings.ToUpper(strings.TrimSpace(params.Token))
+	if token != "NHB" && token != "ZNHB" {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", "token must be NHB or ZNHB")
+		return
+	}
+	amount, err := parsePositiveBigInt(params.Amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	now := time.Now().Unix()
+	if params.Deadline < now-deadlineSkewSeconds {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", "deadline must be in the future")
+		return
+	}
+	hashLock, err := parseHashLock(params.HashLock)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	id, err := s.node.ClaimableCreate(payer, token, amount, hashLock, params.Deadline)
+	if err != nil {
+		writeClaimableError(w, req.ID, err)
+		return
+	}
+	writeResult(w, req.ID, claimableCreateResult{ID: formatClaimableID(id)})
+}
+
+func (s *Server) handleClaimableClaim(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", "exactly one parameter object expected")
+		return
+	}
+	var params claimableClaimParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	id, err := parseClaimableID(params.ID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	payee, err := parseBech32Address(params.Payee)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	preimage, err := parseHexBytes(params.Preimage)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	if err := s.node.ClaimableClaim(id, preimage, payee); err != nil {
+		writeClaimableError(w, req.ID, err)
+		return
+	}
+	writeResult(w, req.ID, claimableOKResult{OK: true})
+}
+
+func (s *Server) handleClaimableCancel(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", "exactly one parameter object expected")
+		return
+	}
+	var params claimableCancelParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	id, err := parseClaimableID(params.ID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	caller, err := parseBech32Address(params.Caller)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	if err := s.node.ClaimableCancel(id, caller); err != nil {
+		writeClaimableError(w, req.ID, err)
+		return
+	}
+	writeResult(w, req.ID, claimableOKResult{OK: true})
+}
+
+func (s *Server) handleClaimableGet(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", "exactly one parameter object expected")
+		return
+	}
+	var params claimableIDParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	id, err := parseClaimableID(params.ID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	record, err := s.node.ClaimableGet(id)
+	if err != nil {
+		writeClaimableError(w, req.ID, err)
+		return
+	}
+	writeResult(w, req.ID, formatClaimableJSON(record))
+}
+
+func parseHashLock(value string) ([32]byte, error) {
+	var out [32]byte
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return out, fmt.Errorf("hashLock required")
+	}
+	cleaned := strings.TrimPrefix(strings.TrimPrefix(trimmed, "0x"), "0X")
+	if len(cleaned) != 64 {
+		return out, fmt.Errorf("hashLock must be 32 bytes")
+	}
+	decoded, err := hex.DecodeString(cleaned)
+	if err != nil {
+		return out, err
+	}
+	copy(out[:], decoded)
+	return out, nil
+}
+
+func parseHexBytes(value string) ([]byte, error) {
+	trimmed := strings.TrimSpace(value)
+	cleaned := strings.TrimPrefix(strings.TrimPrefix(trimmed, "0x"), "0X")
+	if cleaned == "" {
+		return []byte{}, nil
+	}
+	return hex.DecodeString(cleaned)
+}
+
+func parseClaimableID(id string) ([32]byte, error) {
+	return parseEscrowID(id)
+}
+
+func formatClaimableID(id [32]byte) string {
+	return "0x" + hex.EncodeToString(id[:])
+}
+
+func formatClaimableJSON(record *claimable.Claimable) claimableJSON {
+	amount := "0"
+	if record.Amount != nil {
+		amount = record.Amount.String()
+	}
+	return claimableJSON{
+		ID:        formatClaimableID(record.ID),
+		Payer:     crypto.NewAddress(crypto.NHBPrefix, record.Payer[:]).String(),
+		Token:     record.Token,
+		Amount:    amount,
+		HashLock:  "0x" + hex.EncodeToString(record.HashLock[:]),
+		Deadline:  record.Deadline,
+		CreatedAt: record.CreatedAt,
+		Status:    record.Status.String(),
+	}
+}
+
+func writeClaimableError(w http.ResponseWriter, id interface{}, err error) {
+	if err == nil {
+		return
+	}
+	status := http.StatusInternalServerError
+	code := codeClaimableInternal
+	message := "internal_error"
+	data := err.Error()
+	switch {
+	case errors.Is(err, claimable.ErrNotFound):
+		status = http.StatusNotFound
+		code = codeClaimableNotFound
+		message = "not_found"
+	case errors.Is(err, claimable.ErrUnauthorized):
+		status = http.StatusForbidden
+		code = codeClaimableForbidden
+		message = "forbidden"
+	case errors.Is(err, claimable.ErrInvalidToken) || errors.Is(err, claimable.ErrInvalidAmount):
+		status = http.StatusBadRequest
+		code = codeClaimableInvalidParams
+		message = "invalid_params"
+	case errors.Is(err, claimable.ErrInvalidPreimage) || errors.Is(err, claimable.ErrInvalidState) ||
+		errors.Is(err, claimable.ErrDeadlineExceeded) || errors.Is(err, claimable.ErrNotExpired) ||
+		errors.Is(err, claimable.ErrInsufficientFunds):
+		status = http.StatusConflict
+		code = codeClaimableConflict
+		message = "conflict"
+	}
+	writeError(w, status, id, code, message, data)
+}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -209,6 +209,14 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handleIdentityResolve(w, r, req)
 	case "identity_reverse":
 		s.handleIdentityReverse(w, r, req)
+	case "claimable_create":
+		s.handleClaimableCreate(w, r, req)
+	case "claimable_claim":
+		s.handleClaimableClaim(w, r, req)
+	case "claimable_cancel":
+		s.handleClaimableCancel(w, r, req)
+	case "claimable_get":
+		s.handleClaimableGet(w, r, req)
 	case "escrow_create":
 		s.handleEscrowCreate(w, r, req)
 	case "escrow_get":


### PR DESCRIPTION
## Summary
- add core claimable types, state transitions, and unit tests covering create/claim/cancel/expire flows
- extend node, RPC, and event wiring to support claimable lifecycle plus CLI subcommands

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d339b6c96c832db7785ceefe657417