### PR TITLE
docs: add identity alias directory documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# NHBChain Documentation Index
+
+## Core Modules
+
+* [Escrow & P2P Developer Guide](./escrow.md)
+* [Codex Escrow Gateway](./codex-epic-escrow-gateway.md)
+* [Loyalty Module](./loyalty.md)
+
+## Identity & Username Directory
+
+The identity subsystem introduces human-readable aliases, email discovery, avatars, and claimables for pay-by-username UX.
+
+* [Identity Concepts & State Model](./identity.md)
+* [JSON-RPC API Reference](./identity-api.md)
+* [Gateway REST API](./identity-gateway.md)
+* [Pay-by-Username & Email Flows](./pay-by-username.md)
+* [Avatar Specification](./avatars.md)
+* [CLI Usage (`nhb-cli id`)](./identity-cli.md)
+* [Security, Privacy & Compliance Brief](./identity-security-compliance.md)
+* [OpenAPI 3.1 Schema](./openapi/identity.yaml)
+* [HTTP Examples](./examples/identity)
+
+### 10-Minute Quickstart
+
+1. **Register an alias** using the JSON-RPC method or `nhb-cli id register`.
+2. **Link additional addresses** with `identity_addAddress` to support multi-device payouts.
+3. **Upload an avatar** via the gateway and set it on-chain with `identity_setAvatar`.
+4. **Bind a verified email** so friends can pay you even before knowing your alias.
+5. **Test pay-by-username** in a wallet by resolving your alias and sending a small transfer.
+6. **Simulate pay-by-email** by creating a claimable and claiming it with a second account.
+
+For escrow integration details, see [escrow.md](./escrow.md). Contributions and feedback are welcome via governance proposals or the
+engineering forum.

--- a/docs/avatars.md
+++ b/docs/avatars.md
@@ -1,0 +1,47 @@
+# Avatar Specification
+
+Aliases can present avatars to improve recognition and reduce payment errors. Avatars are referenced on-chain as immutable
+strings (`avatarRef`) and retrieved via HTTPS or on-chain blob storage.
+
+## Allowed Sources
+
+| Source | Format | Notes |
+| --- | --- | --- |
+| HTTPS URL | `https://cdn.nhb/...` or partner CDN. | Must use TLS 1.2+. Wallets should enforce HTTPS and check MIME type. |
+| Blob reference | `blob://<cid>` referencing on-chain stored blob. | CIDs follow NHBChain blob module rules; wallets fetch via node
+  blob RPC. |
+
+## Size & Content Rules
+
+* Maximum file size: **512 KB** for HTTPS uploads; **256 KB** for on-chain blobs.
+* Supported MIME types: `image/png`, `image/jpeg`, `image/webp`, `image/svg+xml` (SVG sanitized server-side).
+* Aspect ratio: ideally 1:1. Wallets should display within a 128×128 px circle or rounded square.
+* Content policy forbids violence, nudity, hateful symbols, QR codes, or misleading brand usage. Gateway rejects uploads failing
+  automated or manual review.
+
+## Caching Guidance
+
+* Wallets may cache avatars for 24 hours. Include `ETag` or `Last-Modified` headers.
+* Respect CDN caching directives; avoid hotlinking third-party domains outside partner registry.
+* Provide blurhash or placeholder color derived from aliasId for offline UX.
+
+## Updating Avatars
+
+1. Owner uploads media via [`POST /identity/avatars/upload`](./identity-gateway.md#post-identityavatarsupload).
+2. Gateway returns canonical `avatarRef` (HTTPS URL or `blob://` reference) after validation.
+3. Owner signs `identity_setAvatar(alias, avatarRef, sig)` to update on-chain record.
+4. Event `identity.alias.avatarUpdated` notifies subscribers to refresh caches.
+
+## Recommended Client Behavior
+
+* Fallback to generated identicon (e.g., BLAKE3 aliasId hashed to color palette) when no avatar set.
+* Preload avatars when scanning QR codes or directory listings.
+* Display moderation badges for avatars flagged by governance (future field `avatarFlag`).
+
+## Security Notes
+
+* Wallets must enforce content type after download; reject mismatched MIME signatures.
+* Avoid embedding avatar binary directly into QR codes or URIs; rely on references to prevent bloat.
+* For blob references, validate CID before fetching to avoid SSRF.
+
+For additional context on alias management, see [identity.md](./identity.md) and [identity-gateway.md](./identity-gateway.md).

--- a/docs/examples/identity/add-address.http
+++ b/docs/examples/identity/add-address.http
@@ -1,0 +1,14 @@
+### Add linked address (JSON-RPC)
+POST {{NODE_RPC_URL}}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "method": "identity_addAddress",
+  "params": [
+    "frankrocks",
+    "nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y",
+    "0xSIG"
+  ]
+}

--- a/docs/examples/identity/claim.http
+++ b/docs/examples/identity/claim.http
@@ -1,0 +1,13 @@
+### Claim funds (JSON-RPC)
+POST {{NODE_RPC_URL}}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 43,
+  "method": "identity_claim",
+  "params": [
+    "0x92fd...",
+    "0xRECIP_SIG"
+  ]
+}

--- a/docs/examples/identity/create-claimable.http
+++ b/docs/examples/identity/create-claimable.http
@@ -1,0 +1,16 @@
+### Create claimable for email hash (JSON-RPC)
+POST {{NODE_RPC_URL}}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "identity_createClaimable",
+  "params": [
+    "0x5e2c...",
+    "NHB",
+    "10.00",
+    1718736000,
+    "0xPAYER_SIG"
+  ]
+}

--- a/docs/examples/identity/email-verify.http
+++ b/docs/examples/identity/email-verify.http
@@ -1,0 +1,24 @@
+### Start email verification (REST)
+POST {{GATEWAY_URL}}/identity/email/register
+Content-Type: application/json
+X-API-Key: {{API_KEY}}
+X-API-Timestamp: {{TIMESTAMP}}
+X-API-Signature: {{HMAC_SIG}}
+Idempotency-Key: {{UUID}}
+
+{
+  "email": "frank@example.com",
+  "aliasHint": "frankrocks"
+}
+
+### Complete email verification (REST)
+POST {{GATEWAY_URL}}/identity/email/verify
+Content-Type: application/json
+X-API-Key: {{API_KEY}}
+X-API-Timestamp: {{TIMESTAMP}}
+X-API-Signature: {{HMAC_SIG}}
+
+{
+  "email": "frank@example.com",
+  "code": "483921"
+}

--- a/docs/examples/identity/register-alias.http
+++ b/docs/examples/identity/register-alias.http
@@ -1,0 +1,14 @@
+### Register alias (JSON-RPC)
+POST {{NODE_RPC_URL}}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "identity_registerAlias",
+  "params": [
+    "frankrocks",
+    "nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpxxx",
+    "0xSIG"
+  ]
+}

--- a/docs/examples/identity/resolve.http
+++ b/docs/examples/identity/resolve.http
@@ -1,0 +1,10 @@
+### Resolve alias (JSON-RPC)
+POST {{NODE_RPC_URL}}
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 21,
+  "method": "identity_resolve",
+  "params": ["frankrocks"]
+}

--- a/docs/identity-api.md
+++ b/docs/identity-api.md
@@ -1,0 +1,434 @@
+# Identity JSON-RPC Reference
+
+> Endpoint: `POST /rpc` (same port as core node RPC) • Namespace: `identity_*`
+
+The identity module exposes deterministic JSON-RPC methods for registering aliases, managing linked addresses, configuring
+avatars, and handling claimables. All write operations require an owner signature following the NHBChain EIP-191-style scheme
+described below.
+
+## Authentication & Signature Scheme
+
+* **Scheme:** EIP-191 (`\x19NHB Signed Message:\n${len}|payload`), hashed with keccak256 prior to secp256k1 signing.
+* **Payload format:** `${method}|${paramsHash}|${chainId}|${nonce}|${expiry}`.
+  * `paramsHash` = keccak256 of canonical JSON-serialized params (sorted keys, no whitespace).
+  * `nonce` sourced from `identity_get(aliasOrId).version + 1` or monotonic wallet counter.
+  * `expiry` = unix timestamp (seconds) after which the signature is invalid.
+* **Verification:** Nodes recompute the payload and recover the signer. The recovered address must match the alias owner.
+
+Example signing payload for `identity_registerAlias`:
+
+```
+method = "identity_registerAlias"
+params = {"alias":"frankrocks","ownerBech32":"nhb1...","primaryAddr":"nhb1..."}
+paramsHash = keccak256("{\"alias\":\"frankrocks\",\"ownerBech32\":\"nhb1...\"}")
+chainId = 187001
+nonce = 7
+expiry = 1718131261
+payload = "identity_registerAlias|0x4fb6...|187001|7|1718131261"
+```
+
+Wallets should display the decoded payload before signing. Include `expiry` that matches UX expectations (typically 5 minutes).
+
+### Common Error Codes
+
+| Code | Message | Description | Suggested Remediation |
+| --- | --- | --- | --- |
+| `IDN-001` | `name_taken` | Alias reserved or already registered. | Prompt user to pick another alias or appeal via governance. |
+| `IDN-002` | `invalid_alias` | Alias fails normalization or policy checks. | Sanitize input, enforce length/charset before submission. |
+| `IDN-003` | `not_owner` | Caller signature does not match alias owner. | Re-authenticate with owner key or transfer ownership. |
+| `IDN-004` | `bad_signature` | Signature fails verification. | Recompute payload, ensure nonce/expiry correct. |
+| `IDN-005` | `address_not_linked` | Address not currently linked to alias. | Fetch alias details, link address first. |
+| `IDN-006` | `claim_expired` | Claimable expired before claim. | Instruct payer to recreate claimable. |
+| `IDN-007` | `alias_not_found` | Alias or ID cannot be resolved. | Prompt user to register alias or check spelling. |
+| `IDN-008` | `replay_detected` | Nonce already used or signature expired. | Generate new nonce/expiry and re-sign. |
+| `IDN-009` | `gateway_required` | Operation requires off-chain verification (e.g., email binding). | Complete verification via gateway. |
+
+All errors include `{code, message, data}` fields; `data` may contain contextual hints (`{"aliasId":"0x.."}`).
+
+---
+
+## Method Reference
+
+Each method below includes parameters, return schema, and request/response examples. Replace `NODE_RPC_URL` with your node
+endpoint. All examples use JSON-RPC 2.0.
+
+### `identity_registerAlias`
+
+Registers a new alias and sets the initial primary address.
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `alias` | string | ✓ | Desired alias (normalized client-side). |
+| `ownerBech32` | string | ✓ | Owner account that signs subsequent mutations. |
+| `sig` | string | ✓ | Hex-encoded signature per scheme above. |
+
+**Returns**
+
+```json
+{
+  "aliasId": "0x5e2c...",
+  "alias": "frankrocks",
+  "owner": "nhb1...",
+  "primaryAddr": "nhb1...",
+  "createdAt": 1718131200
+}
+```
+
+**Example Request**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "identity_registerAlias",
+  "params": ["frankrocks", "nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpxxx", "0xSIG"]
+}
+```
+
+**Example Error Response**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32001,
+    "message": "identity error",
+    "data": {"code": "IDN-001", "message": "name_taken"}
+  }
+}
+```
+
+### `identity_addAddress`
+
+Links a new Bech32 address to an alias.
+
+**Parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `aliasOrId` | string | ✓ | Alias string or hex aliasId. |
+| `addressBech32` | string | ✓ | Address to link. |
+| `sig` | string | ✓ | Owner signature. |
+
+**Returns**
+
+```json
+{"ok": true, "addresses": ["nhb1...", "nhb1alt..."]}
+```
+
+**Request Example**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 11,
+  "method": "identity_addAddress",
+  "params": ["frankrocks", "nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y", "0xSIG"]
+}
+```
+
+### `identity_removeAddress`
+
+Removes a linked address. Cannot remove the current primary address; set a new primary first.
+
+**Parameters**: same as `identity_addAddress`.
+
+**Returns**
+
+```json
+{"ok": true, "addresses": ["nhb1..."]}
+```
+
+**Request Example**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "method": "identity_removeAddress",
+  "params": ["frankrocks", "nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y", "0xSIG"]
+}
+```
+
+### `identity_setPrimary`
+
+Sets the primary payout address.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `aliasOrId` | string | ✓ | Alias or aliasId. |
+| `addressBech32` | string | ✓ | Address that must already be linked. |
+| `sig` | string | ✓ | Owner signature. |
+
+**Returns**
+
+```json
+{"ok": true, "primaryAddr": "nhb1..."}
+```
+
+If the address is not linked, the method fails with `IDN-005`.
+
+**Request Example**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 13,
+  "method": "identity_setPrimary",
+  "params": ["frankrocks", "nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y", "0xSIG"]
+}
+```
+
+### `identity_setAvatar`
+
+Updates the avatar reference. Accepts HTTPS URL or on-chain blob reference (`blob://{cid}`).
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `aliasOrId` | string | ✓ | Alias or aliasId. |
+| `avatarUrlOrBlobRef` | string | ✓ | Avatar reference per [Avatar spec](./avatars.md). |
+| `sig` | string | ✓ | Owner signature. |
+
+**Returns**: `{ "ok": true, "avatarRef": "https://..." }`
+
+**Request Example**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 14,
+  "method": "identity_setAvatar",
+  "params": ["frankrocks", "https://cdn.nhb/avatars/frankrocks.png", "0xSIG"]
+}
+```
+
+### `identity_rename`
+
+Renames an alias without changing `aliasId`.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `aliasId` | string | ✓ | Hex aliasId (canonical). |
+| `newAlias` | string | ✓ | New alias candidate. |
+| `sig` | string | ✓ | Owner signature. |
+
+**Returns**: `{ "ok": true, "alias": "frankr0cks" }`
+
+**Request Example**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 15,
+  "method": "identity_rename",
+  "params": ["0x5e2c...", "frankr0cks", "0xSIG"]
+}
+```
+
+### `identity_get`
+
+Fetches the full alias record.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `aliasOrId` | string | ✓ | Alias or aliasId. |
+
+**Returns**
+
+```json
+{
+  "aliasId": "0x5e2c...",
+  "alias": "frankrocks",
+  "owner": "nhb1...",
+  "primaryAddr": "nhb1...",
+  "addresses": ["nhb1...", "nhb1alt..."],
+  "avatarRef": "https://cdn.nhb/id/frankrocks.png",
+  "createdAt": 1718131200,
+  "updatedAt": 1718132200,
+  "version": 4
+}
+```
+
+**Request Example**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 16,
+  "method": "identity_get",
+  "params": ["frankrocks"]
+}
+```
+
+### `identity_resolve`
+
+Resolves an alias to linked addresses.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `nameOrAlias` | string | ✓ | Alias string (with or without leading `@`). |
+
+**Returns**
+
+```json
+{
+  "aliasId": "0x5e2c...",
+  "alias": "frankrocks",
+  "primary": "nhb1...",
+  "addresses": ["nhb1...", "nhb1alt..."],
+  "avatarRef": "https://cdn.nhb/id/frankrocks.png",
+  "createdAt": 1718131200
+}
+```
+
+**Request Example**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 21,
+  "method": "identity_resolve",
+  "params": ["frankrocks"]
+}
+```
+
+### `identity_reverseResolve`
+
+Reverse-lookup of alias by address.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `addressBech32` | string | ✓ | Address to resolve. |
+
+**Returns**: `{ "alias": "frankrocks", "aliasId": "0x5e2c..." }`
+
+**Request Example**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 22,
+  "method": "identity_reverseResolve",
+  "params": ["nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y"]
+}
+```
+
+### `identity_createClaimable`
+
+Creates a claimable escrow for an unresolved alias or email hash.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `recipientAliasOrEmailHash` | string | ✓ | Alias string/aliasId or salted email hash (hex). |
+| `token` | string | ✓ | Token denom (e.g., `NHB`, `ZNHB`). |
+| `amount` | string | ✓ | Decimal string. |
+| `expiry` | integer | ✓ | Unix timestamp expiry. |
+| `payerSig` | string | ✓ | Signature from payer address authorizing hold. |
+
+**Returns**
+
+```json
+{
+  "claimId": "0x92fd...",
+  "expiresAt": 1718137200
+}
+```
+
+**Request Example**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "identity_createClaimable",
+  "params": ["0x5e2c...", "NHB", "10.00", 1718736000, "0xPAYER_SIG"]
+}
+```
+
+### `identity_claim`
+
+Claims an existing claimable once alias/email resolves.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `claimId` | string | ✓ | Claimable identifier. |
+| `recipientSig` | string | ✓ | Signature from alias owner proving control. |
+
+**Returns**
+
+```json
+{
+  "ok": true,
+  "settledTx": "0xabc123...",
+  "amount": "10.0",
+  "token": "NHB",
+  "to": "nhb1primary..."
+}
+```
+
+On success, the claimable is removed and the escrow vault transfers funds to the alias primary address.
+
+**Request Example**
+
+```http
+POST NODE_RPC_URL
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "id": 43,
+  "method": "identity_claim",
+  "params": ["0x92fd...", "0xRECIP_SIG"]
+}
+```
+
+---
+
+## Batch & Pagination Guidance
+
+* JSON-RPC batch requests are supported; include nonces/expiries per call.
+* `identity_get` and `identity_resolve` support future pagination of addresses via optional `offset`, `limit` params (reserved).
+
+## Monitoring & Events
+
+Consumers can subscribe to `identity.*` events via `eth_subscribe` (`logs`) and filter by topic (`identity.alias.registered`,
+`identity.claimable.created`). Each event log encodes `aliasId`, addresses, and metadata hashes. Use this for audit trails.
+
+## Related Documents
+
+* [Identity Concepts](./identity.md)
+* [Identity Gateway REST API](./identity-gateway.md)
+* [CLI Usage](./identity-cli.md)

--- a/docs/identity-cli.md
+++ b/docs/identity-cli.md
@@ -1,0 +1,158 @@
+# `nhb-cli` Identity Commands
+
+The `nhb-cli` tool includes subcommands under `nhb-cli id` for interacting with the identity module. Ensure your CLI is
+configured with the correct node endpoint (`--node`) and chain ID.
+
+## Common Flags
+
+* `--node`: JSON-RPC endpoint (default from config).
+* `--chain-id`: chain ID (e.g., `187001`).
+* `--key`: local key name or path to signing key.
+* `--expiry`: optional signature expiry override (seconds from now).
+
+All mutating commands prompt for confirmation before broadcasting unless `--yes` is provided.
+
+## Register Alias
+
+```bash
+nhb-cli id register \
+  --alias frankrocks \
+  --owner nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpxxx \
+  --primary nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpprm \
+  --sig 0xSIG
+```
+
+**Response**
+
+```
+✔ Alias registered
+Alias ID    : 0x5e2c4fd5...
+Primary     : nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpprm
+Created At  : 2024-06-12T18:20:00Z
+```
+
+## Add Address
+
+```bash
+nhb-cli id add-address \
+  --alias frankrocks \
+  --addr nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y \
+  --sig 0xSIG
+```
+
+**Response**
+
+```
+✔ Address linked
+Addresses: nhb1qyqszqgp..., nhb1alt4vrc6...
+```
+
+## Remove Address
+
+```bash
+nhb-cli id remove-address \
+  --alias frankrocks \
+  --addr nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y \
+  --sig 0xSIG
+```
+
+## Set Primary Address
+
+```bash
+nhb-cli id set-primary \
+  --alias frankrocks \
+  --addr nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y \
+  --sig 0xSIG
+```
+
+**Output**
+
+```
+✔ Primary address updated: nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y
+```
+
+## Rename Alias
+
+```bash
+nhb-cli id rename \
+  --id 0x5e2c4fd5... \
+  --new frankr0cks \
+  --sig 0xSIG
+```
+
+## Fetch Alias Record
+
+```bash
+nhb-cli id get --alias frankrocks
+```
+
+**Sample Output**
+
+```
+Alias       : frankrocks
+Alias ID    : 0x5e2c4fd5...
+Owner       : nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpxxx
+Primary     : nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpprm
+Addresses   :
+  - nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpprm (primary)
+  - nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y
+Avatar      : https://cdn.nhb/id/frankrocks.png
+Created At  : 2024-06-12T18:20:00Z
+Updated At  : 2024-06-12T18:45:10Z
+Version     : 4
+```
+
+## Resolve Alias
+
+```bash
+nhb-cli id resolve --alias frankrocks
+```
+
+**Output**
+
+```
+Alias   : frankrocks
+Primary : nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpprm
+Addresses:
+  - nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpprm
+  - nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y
+Avatar  : https://cdn.nhb/id/frankrocks.png
+```
+
+## Create Claimable (Pay by Email)
+
+```bash
+nhb-cli id create-claimable \
+  --email-hash 0x92fd... \
+  --token NHB \
+  --amount 10.00 \
+  --expiry 1718736000 \
+  --sig 0xSIG
+```
+
+CLI prints the `claimId` and expiry timestamp. Notify the recipient with the claim information.
+
+## Claim Funds
+
+```bash
+nhb-cli id claim \
+  --claim-id 0x92fd... \
+  --sig 0xRECIPSIG
+```
+
+**Output**
+
+```
+✔ Claim settled
+Amount : 10.00 NHB
+To     : nhb1primary...
+Tx     : 0xabc123...
+```
+
+---
+
+Tips:
+
+* Use `--json` flag on any command to get machine-readable responses.
+* Combine with `nhb-cli events tail --topic identity.*` to monitor alias activity.
+* For advanced scripting, pipe outputs into `jq`.

--- a/docs/identity-gateway.md
+++ b/docs/identity-gateway.md
@@ -1,0 +1,238 @@
+# Identity Gateway REST API
+
+> Base URL: `https://gateway.dev.nhbchain.com` (replace with environment) • Version: v0
+
+The identity gateway manages off-chain verification (email, avatar uploads) and provides public lookup endpoints for wallets. All
+mutating endpoints require HMAC-authenticated API keys issued to partner applications.
+
+## Authentication & Headers
+
+* **API Key**: `X-API-Key: <key>` issued per tenant. Use distinct keys for server-side and client-side integrations.
+* **HMAC Signature**: `X-API-Signature` header computed as `hex(HMAC_SHA256(secret, method + "\n" + path + "\n" + bodySha256 +
+  "\n" + timestamp))`.
+* **Timestamp**: `X-API-Timestamp` (unix seconds). Requests older than 300s are rejected (`IDN-401`).
+* **Idempotency**: `Idempotency-Key` header (UUID v4). Repeating the same key returns the initial response.
+* **Rate Limits**: Default 60 write requests/minute per API key, 600 public lookups/minute. Limit headers:
+  * `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`.
+
+### Error Format
+
+```json
+{
+  "error": {
+    "code": "IDN-4xx",
+    "message": "description",
+    "details": {}
+  }
+}
+```
+
+`IDN-400` (bad request), `IDN-401` (auth), `IDN-404` (not found), `IDN-409` (conflict/idempotent replay), `IDN-429` (rate limit).
+
+---
+
+## Endpoints
+
+### POST `/identity/email/register`
+
+Initiates email verification by sending a one-time code.
+
+**Headers**: `X-API-Key`, `X-API-Signature`, `X-API-Timestamp`, `Content-Type: application/json`, `Idempotency-Key` (optional).
+
+**Request Body**
+
+```json
+{
+  "email": "frank@example.com",
+  "aliasHint": "frankrocks"
+}
+```
+
+**Response**
+
+```json
+{
+  "status": "pending",
+  "expiresIn": 600
+}
+```
+
+**Notes**
+
+* `aliasHint` is optional; when provided it is included in verification emails.
+* Rate limited to 5 attempts/hour per email hash.
+
+### POST `/identity/email/verify`
+
+Marks an email as verified using the code delivered out-of-band.
+
+**Request Body**
+
+```json
+{
+  "email": "frank@example.com",
+  "code": "483921"
+}
+```
+
+**Response**
+
+```json
+{
+  "status": "verified",
+  "verifiedAt": "2024-06-12T18:20:00Z",
+  "emailHash": "0xabcd..."
+}
+```
+
+On success, the gateway stores the salted hash and marks the email as eligible for alias binding.
+
+### POST `/identity/alias/bind-email`
+
+Binds a verified email to an alias ID for opt-in lookup.
+
+**Request Body**
+
+```json
+{
+  "aliasId": "0x5e2c...",
+  "email": "frank@example.com",
+  "consent": true
+}
+```
+
+**Response**
+
+```json
+{
+  "status": "linked",
+  "aliasId": "0x5e2c...",
+  "emailHash": "0xabcd...",
+  "publicLookup": true
+}
+```
+
+If the email was not previously verified, the endpoint returns `IDN-401`.
+
+### GET `/identity/resolve?username=<alias>`
+
+Public lookup that resolves an alias to addresses and avatar.
+
+**Example Request**
+
+```http
+GET /identity/resolve?username=frankrocks HTTP/1.1
+Host: gateway.dev.nhbchain.com
+Accept: application/json
+```
+
+**Response**
+
+```json
+{
+  "alias": "frankrocks",
+  "aliasId": "0x5e2c...",
+  "primary": "nhb1...",
+  "addresses": ["nhb1...", "nhb1alt..."],
+  "avatarUrl": "https://cdn.nhb/id/frankrocks.png",
+  "createdAt": "2024-05-01T12:00:00Z"
+}
+```
+
+No authentication required, but requests are rate-limited per IP.
+
+### GET `/identity/reverse?address=<bech32>`
+
+Returns alias metadata for a linked address.
+
+**Response**
+
+```json
+{
+  "alias": "frankrocks",
+  "aliasId": "0x5e2c..."
+}
+```
+
+If no alias is found, returns `404` with `IDN-404` payload.
+
+### POST `/identity/avatars/upload`
+
+Uploads avatar media and returns a canonical avatar reference.
+
+**Headers**: include API auth and `Content-Type: multipart/form-data`.
+
+**Multipart Fields**
+
+* `file`: binary image (PNG, JPEG, WebP), max 512 KB.
+* `aliasId`: hex aliasId (optional; if supplied, gateway enforces owner signature header `X-Alias-Signature`).
+
+**Response**
+
+```json
+{
+  "avatarRef": "https://cdn.nhb/avatars/0x5e2c/20240612.png",
+  "contentType": "image/png",
+  "size": 183421,
+  "etag": "\"f0d-1c2\""
+}
+```
+
+Uploaded avatars undergo content scanning (nudity, violence, malware). Non-compliant uploads return `IDN-422`.
+
+---
+
+## Usage Examples
+
+### HMAC Signature Example (pseudo-code)
+
+```python
+import hashlib, hmac, time, json
+
+body = json.dumps({"email": "frank@example.com"})
+body_hash = hashlib.sha256(body.encode()).hexdigest()
+ts = str(int(time.time()))
+message = "POST\n/identity/email/register\n" + body_hash + "\n" + ts
+signature = hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+```
+
+### cURL – Start Email Verification
+
+```bash
+curl -X POST "$GATEWAY/identity/email/register" \
+  -H "X-API-Key: $API_KEY" \
+  -H "X-API-Timestamp: $(date +%s)" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d '{"email":"frank@example.com","aliasHint":"frankrocks"}'
+```
+
+### cURL – Resolve Alias
+
+```bash
+curl "$GATEWAY/identity/resolve?username=frankrocks" | jq
+```
+
+### cURL – Upload Avatar
+
+```bash
+curl -X POST "$GATEWAY/identity/avatars/upload" \
+  -H "X-API-Key: $API_KEY" \
+  -H "X-API-Timestamp: $(date +%s)" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "X-API-Signature: $SIG" \
+  -F "file=@avatar.png" \
+  -F "aliasId=0x5e2c..."
+```
+
+## OpenAPI Specification
+
+A machine-readable schema for these endpoints is provided at [`./openapi/identity.yaml`](./openapi/identity.yaml). Use it with
+`redocly lint` or `swagger-cli validate` to ensure compatibility.
+
+## Related Docs
+
+* [Identity Concepts](./identity.md)
+* [JSON-RPC Reference](./identity-api.md)
+* [Avatar Specification](./avatars.md)
+* [Security & Compliance](./identity-security-compliance.md)

--- a/docs/identity-security-compliance.md
+++ b/docs/identity-security-compliance.md
@@ -1,0 +1,74 @@
+# Identity Security, Privacy & Compliance Brief
+
+This document summarizes the controls surrounding the NHBChain identity subsystem for review by security teams, regulators, and
+investors.
+
+## Roles & Authorization
+
+| Role | Capabilities | Controls |
+| --- | --- | --- |
+| Alias Owner | Register alias, link/unlink addresses, set primary, update avatar, rename. | Must sign EIP-191 payloads tied to
+  aliasId, nonce, and expiry. Signatures verified on-chain. |
+| Governance | Manage reserved list, adjudicate disputes, freeze aliases in extreme abuse scenarios. | Multisig governance module
+  with on-chain proposals and audit logs. |
+| Gateway Operator | Verify emails, manage API keys, moderate avatars. | Access via HMAC-authenticated admin console with hardware
+  MFA and audit trails. |
+| Watchers / Indexers | Subscribe to events for analytics. | Read-only; no privileged actions. |
+
+## Authentication Requirements
+
+* All JSON-RPC mutating calls require secp256k1 signatures from the alias owner (`identity_*` methods).
+* Gateway write APIs require API key + HMAC signature (`X-API-Key`, `X-API-Signature`, timestamp).
+* Avatar uploads optionally include `X-Alias-Signature` (owner-signed nonce) to prove authorization when uploading from third-party
+  services.
+
+## PII Boundary & Data Minimization
+
+* On-chain: only alias string, aliasId, owner, linked addresses, avatarRef timestamps.
+* Off-chain (Gateway): salted email hashes, verification timestamps, consent flags, API key metadata, audit logs.
+* No plaintext emails leave the gateway. Hashing uses per-environment salt rotated quarterly.
+* Claimables reference aliasId or hashed email only; no raw PII.
+
+## Privacy Program
+
+* Data retention: email verification logs retained 18 months, purge requests processed within 30 days (subject to legal holds).
+* Data subject rights (DSAR): request triggers lookup by email hash; removal severs alias binding and deletes verification logs.
+* Transparency: Wallets display whether alias opted in to email lookup; gateway exposes `/privacy/export` (future) for user export.
+* Incident response: 4-hour SLA to acknowledge, 24-hour to provide mitigation status.
+
+## Abuse & Fraud Controls
+
+* Alias squatting mitigated with reserved names, staking deposits, and dispute resolution process.
+* Email verification throttled per IP + per email hash; verification codes expire in 10 minutes and are rate-limited.
+* Avatars scanned for malware and explicit content; flagged avatars can be replaced by governance action.
+* Claimables protected via expiry (default 7 days) and signature binding; replayed signatures rejected (`IDN-008`).
+* Comprehensive audit logs: `identity.alias.*` and `identity.claimable.*` events preserved for 365 days in archival nodes.
+
+## Regulatory & Investor Notes
+
+* Identity subsystem does **not** mint tokens; claimables simply escrow existing funds and settle deterministically upon claim.
+* Alias operations are deterministic state transitions recorded on-chain; event logs include block height, tx hash, aliasId for
+  audit reproducibility.
+* Gateway services operate off-chain but expose signed audit trails (HMAC logs) and idempotent request IDs for reconciliation.
+* Mint authority, consensus, and escrow modules remain unchanged. Identity module can be upgraded via governance without chain
+  halt.
+* Replay protection and nonce-based signatures satisfy standard replay-prevention requirements under financial regulations.
+* Logs and proofs support AML monitoring; alias metadata can be correlated with on-chain transfers through deterministic IDs.
+
+## Compliance Checklist
+
+| Requirement | Status | Notes |
+| --- | --- | --- |
+| GDPR / CCPA data rights | ✅ | DSAR process documented; hashed emails minimize exposure. |
+| SOC 2 logging | ✅ | Audit logs stored immutably with tamper-proof retention. |
+| PCI scope | ✅ (out-of-scope) | No payment card data processed. |
+| FinCEN guidance | ✅ | Claimables function as escrow, not custody change; standard SAR triggers available via events. |
+| KYC dependency | Optional | Alias system integrates with external KYC providers if required by jurisdiction. |
+
+## Incident Response & Monitoring
+
+* Alerts on repeated failed HMAC signatures, sudden spike in alias registrations, or avatar moderation failures.
+* Governance has emergency proposal to freeze alias (prevents transfers but preserves data) in case of phishing campaigns.
+* Backups: Gateway database replicated across regions with point-in-time recovery; salts stored in HSM-backed secrets manager.
+
+For engineering detail, see [identity.md](./identity.md) and [identity-gateway.md](./identity-gateway.md).

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -1,0 +1,187 @@
+# Identity & Username Directory
+
+> Version: v0 • Module: `identity`
+
+## Overview
+
+The NHBChain identity subsystem provides human-readable aliases (usernames) that map to on-chain account addresses, opt-in email
+association for discovery, avatar references for consistent presentation, and "pay-by-username" user experiences. Aliases are
+first-class state objects recorded on-chain, while sensitive metadata such as email verification is handled off-chain by the
+identity gateway service. Together they allow wallets, gateways, and merchants to offer:
+
+* Deterministic resolution of `@aliases` to primary settlement addresses.
+* Rich sender safety cues (avatar, created-at timestamp, address fingerprint).
+* Pay-by-email flows that bridge new users through claimable escrows.
+* A consistent UX that complements existing escrow flows (see [Escrow Guide](./escrow.md)).
+
+## Terminology
+
+| Term | Description |
+| --- | --- |
+| **Alias** | Human-readable username, globally unique, referenced as `@alias` in UX. |
+| **Alias ID** | Stable 32-byte identifier for an alias record; used internally and exposed in APIs as `aliasId`. |
+| **Owner** | Bech32 account that controls the alias, signs mutation requests, and receives governance actions. |
+| **Primary Address** | Address flagged as the default payout target for `pay-by-username` flows. |
+| **Linked Addresses** | Additional Bech32 addresses controlled by the owner. |
+| **AvatarRef** | HTTPS URL or on-chain blob reference representing the alias avatar. |
+| **Claimable** | Escrow-like placeholder created when paying an unresolved alias/email; funds become available once the recipient
+  claims or creates an alias. |
+
+## Normalization & Uniqueness Rules
+
+* Aliases are normalized to lower-case and NFC (`unicode.org/reports/tr15/`), with secondary NFKC pass for compatibility.
+* Allowed characters: ASCII letters (`a–z`), digits (`0–9`), dot (`.`), underscore (`_`), and slash (`/`).
+* Length: minimum 3, maximum 32 Unicode code points after normalization.
+* Uniqueness is case-insensitive (`FrankRocks` and `frankrocks` resolve to the same canonical alias).
+* Reserved names: governance publishes a list (e.g., `admin`, `support`, trademarks). Reserved names throw `IDN-001`.
+* Confusable/homoglyph aliases are blocked (leverages Unicode security profile). Punycode-only names are rejected; users should
+  choose ASCII-native aliases. Guidance is provided in CLI and RPC error payloads.
+
+## Alias State Model (On-Chain)
+
+Alias records are stored deterministically by ID, and mutation requires an owner-signed message.
+
+```go
+// Pseudocode representation
+type AliasRecord struct {
+  ID           [32]byte
+  Alias        string
+  Owner        [20]byte
+  PrimaryAddr  [20]byte
+  Addresses    [[20]byte]
+  AvatarRef    string
+  CreatedAt    int64
+  UpdatedAt    int64
+  Version      uint32
+}
+```
+
+* `ID`: keccak256 hash of canonical alias string.
+* `Addresses`: includes `PrimaryAddr`; duplicates are prevented by enforcement at mutation.
+* `Version`: increments with each mutating event, enabling replay protection and optimistic concurrency.
+
+### Lifecycle Events
+
+The chain emits events for watchers and analytics:
+
+| Event | Trigger |
+| --- | --- |
+| `identity.alias.registered` | Alias first registered, includes alias, owner, primaryAddr. |
+| `identity.alias.renamed` | Alias string changed (ID persists, record version increments). |
+| `identity.alias.addressAdded` | New address linked. |
+| `identity.alias.addressRemoved` | Linked address removed. |
+| `identity.alias.primarySet` | Primary address updated. |
+| `identity.alias.avatarUpdated` | AvatarRef changed.
+
+Mermaid sequence for alias registration:
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Wallet
+  participant Node
+  User->>Wallet: enter alias + owner address
+  Wallet->>Wallet: normalize alias, build params
+  Wallet->>User: request signature (EIP-191 payload)
+  User-->>Wallet: signature
+  Wallet->>Node: identity_registerAlias(alias, owner, sig)
+  Node-->>Wallet: {aliasId, primaryAddr}
+  Wallet-->>User: success, show alias summary
+```
+
+## Off-Chain Email Directory & Gateway
+
+* Verified emails are stored off-chain by the identity gateway.
+* Each entry stores a salted hash (`H = HMAC(salt, emailLowerNFKC)`) and verification metadata (`verifiedAt`, `method`).
+* Mapping: `emailHash -> aliasId`. Users must opt-in to expose alias lookups by email.
+* No plaintext emails are stored on-chain; the alias record only stores the `aliasId`.
+
+## Claimables (Escrow Holds for New Users)
+
+Pay-by-email and unclaimed alias scenarios rely on claimables, interoperable with the escrow module.
+
+```go
+type Claimable struct {
+  ClaimID       [32]byte
+  Payer         [20]byte
+  Token         string
+  Amount        *big.Int
+  AliasOrHash   [32]byte // aliasId or email hash
+  Expiry        int64
+  CreatedAt     int64
+}
+```
+
+* Claimables are created by senders when the recipient alias/email cannot yet resolve.
+* Funds are held in the identity escrow submodule. Upon `identity_claim`, the amount is released to the recipient's primary
+  address (or specified linked address when claiming).
+* Events emitted: `identity.claimable.created`, `identity.claimable.claimed`, `identity.claimable.expired`.
+* Claimables integrate with the [Escrow module](./escrow.md#1-overview) for audit and settlement guarantees.
+
+### Pay-by-Username Flow
+
+```mermaid
+sequenceDiagram
+  participant Sender
+  participant Wallet
+  participant Node
+  Sender->>Wallet: choose @frankrocks, enter amount
+  Wallet->>Node: identity_resolve("frankrocks")
+  Node-->>Wallet: {primaryAddr, avatarRef, createdAt}
+  Wallet->>Sender: display confirmation (alias, avatar, fingerprint)
+  Sender->>Wallet: confirm payment
+  Wallet->>Node: submit transfer to primaryAddr
+  Node-->>Wallet: transfer receipt + events
+```
+
+### Pay-by-Email (Claimable) Flow
+
+```mermaid
+sequenceDiagram
+  participant Sender
+  participant Wallet
+  participant Node
+  participant Gateway
+  Sender->>Wallet: enter recipient email
+  Wallet->>Gateway: POST /identity/email/register
+  Gateway-->>Wallet: verification initiated (code sent)
+  Note over Sender,Wallet: Sender informs recipient to verify email
+  Recipient->>Gateway: POST /identity/email/verify
+  Gateway-->>Recipient: verification success
+  Sender->>Wallet: create claimable (payerSig)
+  Wallet->>Node: identity_createClaimable(emailHash,...)
+  Node-->>Wallet: {claimId}
+  Recipient->>Wallet: register alias + claim
+  Wallet->>Node: identity_claim(claimId, recipientSig)
+  Node-->>Wallet: funds released to primary address
+```
+
+## Threat Model & Mitigations
+
+| Threat | Mitigation |
+| --- | --- |
+| Alias squatting | Governance-managed reserved list; cooldown periods after release; optional staking deposit. |
+| Homoglyph spoofing | Unicode confusable detection and strict ASCII policy; wallets display creation timestamp & address
+  fingerprint. |
+| Unauthorized mutations | All mutating RPCs require owner signatures (EIP-191) with nonce + expiry; replay protection enforced. |
+| Rate-based abuse | Gateway enforces per-IP/user rate limits and API-key HMAC auth. |
+| Avatar abuse | Content policy scanning (size/type), moderated by gateway; on-chain references may be flagged by governance. |
+| Email harvesting | Only salted hashes stored; lookup requires opt-in; DSAR processes allow deletion. |
+| Claimable hijack | Claim requires recipient signature bound to aliasId/email hash; expiry auto-refunds payer; audit logs track
+  claims.
+
+---
+
+## Deterministic State Transition Guarantees
+
+* Every alias mutation increments `version` and emits an event with `txHash` for audit trails.
+* On-chain storage enforces deterministic ordering by `blockHeight` and `txIndex`.
+* Claimable settlements leverage escrow vaults, ensuring funds are never minted or destroyed outside normal transfer logic.
+
+## Related Documents
+
+* [Identity JSON-RPC Reference](./identity-api.md)
+* [Identity Gateway REST API](./identity-gateway.md)
+* [Pay by Username & Email Flows](./pay-by-username.md)
+* [Avatar Specification](./avatars.md)
+* [Security, Privacy & Compliance Brief](./identity-security-compliance.md)

--- a/docs/openapi/identity.yaml
+++ b/docs/openapi/identity.yaml
@@ -1,0 +1,418 @@
+openapi: 3.1.0
+info:
+  title: NHBChain Identity Gateway API
+  version: "0.1.0"
+  description: REST interface for email verification, alias binding, avatar upload, and public identity lookups.
+  license:
+    name: CC BY 4.0
+    url: https://creativecommons.org/licenses/by/4.0/
+servers:
+  - url: https://gateway.dev.nhbchain.com
+    description: Development gateway
+  - url: https://gateway.staging.nhbchain.com
+    description: Staging gateway
+  - url: https://gateway.nhbchain.com
+    description: Production gateway
+security:
+  - ApiKeyAuth: []
+    HmacSignature: []
+paths:
+  /identity/email/register:
+    post:
+      summary: Initiate email verification
+      description: Sends a verification code to the provided email address.
+      operationId: emailRegister
+      security:
+        - ApiKeyAuth: []
+          HmacSignature: []
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailRegisterRequest'
+      responses:
+        '200':
+          description: Verification initiated
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/XRateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/XRateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/XRateLimitReset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailRegisterResponse'
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '409':
+          $ref: '#/components/responses/Error409'
+        '429':
+          $ref: '#/components/responses/Error429'
+  /identity/email/verify:
+    post:
+      summary: Complete email verification
+      description: Confirms the one-time code and returns the salted email hash.
+      operationId: emailVerify
+      security:
+        - ApiKeyAuth: []
+          HmacSignature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailVerifyRequest'
+      responses:
+        '200':
+          description: Email verified
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailVerifyResponse'
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '429':
+          $ref: '#/components/responses/Error429'
+  /identity/alias/bind-email:
+    post:
+      summary: Bind verified email to aliasId
+      description: Links a verified email hash to an alias for opt-in lookup.
+      operationId: bindEmail
+      security:
+        - ApiKeyAuth: []
+          HmacSignature: []
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BindEmailRequest'
+      responses:
+        '200':
+          description: Email linked to alias
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BindEmailResponse'
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '409':
+          $ref: '#/components/responses/Error409'
+        '429':
+          $ref: '#/components/responses/Error429'
+  /identity/resolve:
+    get:
+      summary: Resolve alias to addresses
+      description: Public lookup that returns alias metadata and linked addresses.
+      operationId: resolveAlias
+      security: []
+      parameters:
+        - name: username
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Alias string to resolve (without leading @).
+      responses:
+        '200':
+          description: Alias resolved
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/XRateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/XRateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/XRateLimitReset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResolveResponse'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '429':
+          $ref: '#/components/responses/Error429'
+  /identity/reverse:
+    get:
+      summary: Reverse lookup alias by address
+      description: Returns alias metadata for a Bech32 address.
+      operationId: reverseResolve
+      security: []
+      parameters:
+        - name: address
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Bech32 address to reverse-resolve.
+      responses:
+        '200':
+          description: Alias found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReverseResponse'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '429':
+          $ref: '#/components/responses/Error429'
+  /identity/avatars/upload:
+    post:
+      summary: Upload avatar image
+      description: Validates avatar content and returns canonical avatar reference.
+      operationId: uploadAvatar
+      security:
+        - ApiKeyAuth: []
+          HmacSignature: []
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: Avatar image file (PNG, JPEG, WebP, SVG)
+                aliasId:
+                  type: string
+                  pattern: '^0x[a-fA-F0-9]{6,}$'
+                  description: Optional aliasId to enforce ownership verification
+              required:
+                - file
+      responses:
+        '200':
+          description: Avatar uploaded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AvatarUploadResponse'
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '422':
+          $ref: '#/components/responses/Error422'
+        '429':
+          $ref: '#/components/responses/Error429'
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    HmacSignature:
+      type: apiKey
+      in: header
+      name: X-API-Signature
+      description: Hex HMAC-SHA256 signature of method, path, body hash, and timestamp
+  parameters:
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      schema:
+        type: string
+        format: uuid
+      description: Reuse to safely retry requests.
+  headers:
+    XRateLimitLimit:
+      schema:
+        type: integer
+      description: Rate limit ceiling for the current window.
+    XRateLimitRemaining:
+      schema:
+        type: integer
+      description: Remaining requests in the window.
+    XRateLimitReset:
+      schema:
+        type: integer
+      description: Unix timestamp when the rate limit resets.
+  responses:
+    Error400:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Error401:
+      description: Authentication or signature failure
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Error404:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Error409:
+      description: Conflict or duplicate request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Error422:
+      description: Unprocessable avatar (policy violation)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Error429:
+      description: Rate limit exceeded
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+          description: Seconds until next request allowed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    EmailRegisterRequest:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+        aliasHint:
+          type: string
+          description: Optional alias hint to include in email copy
+    EmailRegisterResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [pending]
+        expiresIn:
+          type: integer
+          description: Seconds until verification code expires
+    EmailVerifyRequest:
+      type: object
+      required:
+        - email
+        - code
+      properties:
+        email:
+          type: string
+          format: email
+        code:
+          type: string
+          minLength: 6
+          maxLength: 6
+    EmailVerifyResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [verified]
+        verifiedAt:
+          type: string
+          format: date-time
+        emailHash:
+          type: string
+          pattern: '^0x[a-fA-F0-9]+$'
+    BindEmailRequest:
+      type: object
+      required:
+        - aliasId
+        - email
+        - consent
+      properties:
+        aliasId:
+          type: string
+          pattern: '^0x[a-fA-F0-9]+$'
+        email:
+          type: string
+          format: email
+        consent:
+          type: boolean
+    BindEmailResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [linked]
+        aliasId:
+          type: string
+        emailHash:
+          type: string
+        publicLookup:
+          type: boolean
+    ResolveResponse:
+      type: object
+      properties:
+        alias:
+          type: string
+        aliasId:
+          type: string
+        primary:
+          type: string
+        addresses:
+          type: array
+          items:
+            type: string
+        avatarUrl:
+          type: string
+          format: uri
+        createdAt:
+          type: string
+          format: date-time
+    ReverseResponse:
+      type: object
+      properties:
+        alias:
+          type: string
+        aliasId:
+          type: string
+    AvatarUploadResponse:
+      type: object
+      properties:
+        avatarRef:
+          type: string
+          description: Canonical avatar reference URL or blob ref
+        contentType:
+          type: string
+        size:
+          type: integer
+        etag:
+          type: string
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details:
+              type: object
+              additionalProperties: true
+          required:
+            - code
+            - message

--- a/docs/pay-by-username.md
+++ b/docs/pay-by-username.md
@@ -1,0 +1,132 @@
+# Pay-by-Username & Email Flows
+
+This guide outlines the wallet and service flows that enable human-friendly payments on NHBChain. The identity module resolves
+aliases to settlement addresses, while claimables bridge first-time recipients via escrowed holds.
+
+## Quick Reference
+
+* Known alias → resolve + transfer.
+* Unknown alias/email → create claimable → recipient registers alias → claim.
+* QR codes encode the alias and transfer metadata using the `znhb://` URI scheme.
+
+## 1. Direct Pay to Known Alias
+
+1. **Input**: Sender enters `@frankrocks` in wallet UI.
+2. **Resolve**: Wallet calls `identity_resolve("frankrocks")`.
+3. **Safety Review**: Wallet surfaces alias, avatar, creation date, and a fingerprint of the primary address (first/last 6 chars).
+4. **Confirm & Transfer**: Wallet constructs a token transfer to the returned `primary` address.
+5. **Observe Events**: Clients may subscribe to `identity.alias.primarySet` to detect address changes.
+
+```mermaid
+sequenceDiagram
+  participant Sender
+  participant Wallet
+  participant Node
+  Sender->>Wallet: Enter @frankrocks + amount
+  Wallet->>Node: identity_resolve("frankrocks")
+  Node-->>Wallet: {primary, addresses, avatarRef}
+  Wallet->>Sender: Show confirmation card
+  Sender->>Wallet: Confirm
+  Wallet->>Node: token transfer -> primary
+  Node-->>Wallet: tx receipt
+```
+
+### UX Checklist
+
+* Display alias avatar (or fallback identicon) from `avatarRef`.
+* Highlight creation date: "Member since May 2024".
+* Render linked address fingerprint: `nhb1...r0cks`.
+* Warn if alias version changed recently (possible re-assignment) by querying `identity_get`.
+
+## 2. Pay by Email (Recipient not yet registered)
+
+When the sender only knows an email address, claimables allow funds to be held until the recipient verifies and creates an alias.
+
+### Sender Flow
+
+1. Wallet hashes email: `emailHash = HMAC(salt, emailLowerNFKC)` (same as gateway). Salt is wallet-specific but consistent per
+   ecosystem to enable detection of duplicates.
+2. Sender signs a request payload for `identity_createClaimable` including token, amount, expiry.
+3. Wallet submits the JSON-RPC call. The node places funds into the identity escrow vault and returns `claimId`.
+4. Wallet optionally notifies recipient via gateway or email.
+
+### Recipient Flow
+
+1. Recipient receives email invite with `claimId` and instructions.
+2. Recipient verifies email through the [Identity Gateway](./identity-gateway.md#post-identityemailverify).
+3. Recipient registers an alias via `identity_registerAlias`.
+4. Recipient signs `identity_claim(claimId, recipientSig)`.
+5. Funds settle to the alias primary address; events emitted include `identity.claimable.claimed`.
+
+```mermaid
+sequenceDiagram
+  participant Sender
+  participant Wallet
+  participant Gateway
+  participant Node
+  Sender->>Wallet: Provide recipient email + amount
+  Wallet->>Gateway: POST /identity/email/register
+  Gateway-->>Wallet: pending (code sent)
+  Sender->>Wallet: Approve hold
+  Wallet->>Node: identity_createClaimable(emailHash,...)
+  Node-->>Wallet: {claimId}
+  Recipient->>Gateway: POST /identity/email/verify
+  Recipient->>Node: identity_registerAlias
+  Recipient->>Node: identity_claim(claimId)
+  Node-->>Recipient: transfer executed
+```
+
+### Claimable Expiry & Recovery
+
+* `expiry` recommended minimum: 7 days. Wallets should display countdown.
+* If expiry lapses before claim, funds auto-refund to payer; node emits `identity.claimable.expired`.
+* Payer may cancel early via governance call (future release) but current flow relies on expiry.
+
+## 3. Pay by QR Code
+
+Wallets can embed alias payments into QR codes using the NHBChain intent scheme.
+
+```
+znhb://pay?to=@frankrocks&amount=25.75&token=NHB&memo=Lunch
+```
+
+* `to`: alias or aliasId. Wallets must normalize before calling `identity_resolve`.
+* `amount`: decimal string (respect token precision).
+* `token`: denom string.
+* Additional fields: `expiry`, `callback`, `ref` (merchant reference).
+
+### Merchant Experience
+
+1. Merchant prints QR linking to their alias (ensure alias is verified and avatar set).
+2. Customer scans; wallet resolves alias and shows avatar + verification badge.
+3. Customer confirms; transfer executed as in section 1.
+
+## 4. UX Safety Controls
+
+* **Human confirmation**: Always show alias + avatar + creation date before payment.
+* **Fingerprint**: Render a short checksum of the primary address (e.g., BLAKE3 6 chars) to catch last-minute swaps.
+* **Version watch**: If `identity_get` shows `updatedAt` within the last minute, display warning banner.
+* **Claimable context**: When paying by email, indicate "Funds held until frank@example.com claims by Jun 18".
+* **Escrow link**: Provide "View escrow" CTA linking to [Escrow module docs](./escrow.md) for transparency.
+
+## 5. Developer Checklist
+
+* Integrate both JSON-RPC and Gateway APIs.
+* Cache successful `identity_resolve` responses for 60 seconds to reduce load; invalidate on `identity.alias.*` events.
+* For pay-by-email, store `claimId`, `token`, `amount`, and `expiry` locally for status tracking.
+* Support cancellation/resend flows by creating a new claimable and marking previous as expired when funds return.
+
+## Appendix: Sample Timeline
+
+| Step | Sender | Recipient |
+| --- | --- | --- |
+| T0 | Create claimable | Receive invite |
+| T+5m | — | Verify email |
+| T+10m | — | Register alias |
+| T+11m | — | Claim funds |
+| T+12m | Auto-refund if not claimed | — |
+
+---
+
+For CLI-driven flows, refer to [identity-cli.md](./identity-cli.md). For security considerations, see
+[identity-security-compliance.md](./identity-security-compliance.md).


### PR DESCRIPTION
## Summary
- document the identity alias subsystem including concepts, flows, RPC methods, gateway REST interface, CLI usage, and compliance posture
- provide runnable HTTP examples and OpenAPI 3.1 schema for the gateway endpoints
- update the docs index with an identity quickstart and cross-links

## Testing
- npx --yes @redocly/cli@latest lint docs/openapi/identity.yaml

------
https://chatgpt.com/codex/tasks/task_e_68d352065ed0832d9b9c9fbe93dc98a3