### PR TITLE
Add payments gateway service with NowPayments integration

### DIFF
--- a/services/payments-gateway/config.go
+++ b/services/payments-gateway/config.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Config captures runtime configuration for the payments gateway service.
+type Config struct {
+	ListenAddress        string
+	DatabasePath         string
+	NodeURL              string
+	NodeAuthToken        string
+	QuoteTTL             time.Duration
+	QuoteCurrency        string
+	OracleTTL            time.Duration
+	OracleMaxDeviation   float64
+	OracleCircuitBreaker float64
+	NowPaymentsAPIKey    string
+	NowPaymentsIPNSecret string
+	NowPaymentsBaseURL   string
+	MinterKMSEnv         string
+}
+
+const (
+	envListen          = "PAY_GATEWAY_LISTEN"
+	envDBPath          = "PAY_GATEWAY_DB"
+	envNodeURL         = "PAY_GATEWAY_NODE_URL"
+	envNodeToken       = "PAY_GATEWAY_NODE_TOKEN"
+	envQuoteTTL        = "PAY_GATEWAY_QUOTE_TTL"
+	envOracleTTL       = "PAY_GATEWAY_ORACLE_TTL"
+	envOracleDeviation = "PAY_GATEWAY_ORACLE_DEVIATION"
+	envOracleBreaker   = "PAY_GATEWAY_ORACLE_BREAKER"
+	envNowAPIKey       = "PAY_GATEWAY_NOW_API_KEY"
+	envNowIPNSecret    = "PAY_GATEWAY_NOW_IPN_SECRET"
+	envNowBaseURL      = "PAY_GATEWAY_NOW_BASE"
+	envKMSEnv          = "PAY_GATEWAY_MINTER_KMS_ENV"
+)
+
+// LoadConfigFromEnv resolves configuration from environment variables with sane defaults.
+func LoadConfigFromEnv() (*Config, error) {
+	cfg := &Config{
+		ListenAddress:        getenvDefault(envListen, ":8080"),
+		DatabasePath:         getenvDefault(envDBPath, "payments-gateway.db"),
+		NodeURL:              os.Getenv(envNodeURL),
+		NodeAuthToken:        os.Getenv(envNodeToken),
+		QuoteTTL:             parseDurationDefault(envQuoteTTL, 5*time.Minute),
+		QuoteCurrency:        "USD",
+		OracleTTL:            parseDurationDefault(envOracleTTL, time.Minute),
+		OracleMaxDeviation:   parsePercentDefault(envOracleDeviation, 0.05),
+		OracleCircuitBreaker: parsePercentDefault(envOracleBreaker, 0.20),
+		NowPaymentsAPIKey:    os.Getenv(envNowAPIKey),
+		NowPaymentsIPNSecret: os.Getenv(envNowIPNSecret),
+		NowPaymentsBaseURL:   getenvDefault(envNowBaseURL, "https://api.nowpayments.io/v1"),
+		MinterKMSEnv:         os.Getenv(envKMSEnv),
+	}
+
+	if cfg.NodeURL == "" {
+		return nil, fmt.Errorf("%s is required", envNodeURL)
+	}
+	if cfg.NowPaymentsAPIKey == "" {
+		return nil, fmt.Errorf("%s is required", envNowAPIKey)
+	}
+	if cfg.NowPaymentsIPNSecret == "" {
+		return nil, fmt.Errorf("%s is required", envNowIPNSecret)
+	}
+	if cfg.MinterKMSEnv == "" {
+		return nil, fmt.Errorf("%s is required", envKMSEnv)
+	}
+
+	return cfg, nil
+}
+
+func getenvDefault(key, def string) string {
+	if val := strings.TrimSpace(os.Getenv(key)); val != "" {
+		return val
+	}
+	return def
+}
+
+func parseDurationDefault(key string, def time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return def
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return def
+	}
+	return d
+}
+
+func parsePercentDefault(key string, def float64) float64 {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return def
+	}
+	f, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return def
+	}
+	if f < 0 {
+		f = 0
+	}
+	return f
+}

--- a/services/payments-gateway/kms.go
+++ b/services/payments-gateway/kms.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	nhbcrypto "nhbchain/crypto"
+)
+
+// Signer defines the interface expected for signing mint vouchers.
+type Signer interface {
+	Address() string
+	Sign(ctx context.Context, payload []byte) ([]byte, error)
+}
+
+// EnvKMSSigner implements the Signer interface by sourcing key material from an environment variable.
+type EnvKMSSigner struct {
+	key *nhbcrypto.PrivateKey
+}
+
+// NewEnvKMSSigner creates a signer using the provided environment variable. The material must be a hex-encoded secp256k1 key.
+func NewEnvKMSSigner(varName string) (*EnvKMSSigner, error) {
+	material := strings.TrimSpace(os.Getenv(varName))
+	if material == "" {
+		return nil, fmt.Errorf("environment variable %s not set", varName)
+	}
+	material = strings.TrimPrefix(material, "0x")
+	decoded, err := hex.DecodeString(material)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode private key material: %w", err)
+	}
+	key, err := nhbcrypto.PrivateKeyFromBytes(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key material: %w", err)
+	}
+	return &EnvKMSSigner{key: key}, nil
+}
+
+// Address returns the NHB-formatted address of the signer.
+func (s *EnvKMSSigner) Address() string {
+	if s == nil || s.key == nil {
+		return ""
+	}
+	return s.key.PubKey().Address().String()
+}
+
+// Sign produces a secp256k1 signature over the payload using the configured key.
+func (s *EnvKMSSigner) Sign(ctx context.Context, payload []byte) ([]byte, error) {
+	if s == nil || s.key == nil {
+		return nil, fmt.Errorf("kms signer not configured")
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	hash := ethcrypto.Keccak256(payload)
+	sig, err := ethcrypto.Sign(hash, s.key.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	return sig, nil
+}

--- a/services/payments-gateway/main.go
+++ b/services/payments-gateway/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+const shutdownTimeout = 10 * time.Second
+
+func main() {
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+	store, err := NewSQLiteStore(cfg.DatabasePath)
+	if err != nil {
+		log.Fatalf("open sqlite store: %v", err)
+	}
+	defer store.Close()
+
+	oracle := NewOracle(cfg.OracleTTL, cfg.OracleMaxDeviation, cfg.OracleCircuitBreaker)
+	signer, err := NewEnvKMSSigner(cfg.MinterKMSEnv)
+	if err != nil {
+		log.Fatalf("configure kms signer: %v", err)
+	}
+	nowClient := NewHTTPNowPaymentsClient(cfg.NowPaymentsBaseURL, cfg.NowPaymentsAPIKey)
+	nodeClient := NewRPCNodeClient(cfg.NodeURL, cfg.NodeAuthToken)
+
+	server := NewServer(store, oracle, nowClient, nodeClient, signer, cfg.QuoteTTL, cfg.QuoteCurrency, cfg.NowPaymentsIPNSecret)
+	srv := &http.Server{Addr: cfg.ListenAddress, Handler: server}
+
+	go func() {
+		log.Printf("payments gateway listening on %s", cfg.ListenAddress)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen: %v", err)
+		}
+	}()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+
+	log.Printf("shutting down payments gateway")
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Printf("graceful shutdown failed: %v", err)
+	}
+}

--- a/services/payments-gateway/node_client.go
+++ b/services/payments-gateway/node_client.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// NodeClient exposes the minimal RPC surface required by the payments gateway.
+type NodeClient interface {
+	MintWithSig(ctx context.Context, voucher MintVoucher) (string, error)
+}
+
+// MintVoucher mirrors the payload expected by the node RPC method mint_with_sig.
+type MintVoucher struct {
+	Recipient string `json:"recipient"`
+	Token     string `json:"token"`
+	Amount    string `json:"amount"`
+	Nonce     string `json:"nonce"`
+	Signature string `json:"signature"`
+}
+
+// RPCNodeClient is a lightweight JSON-RPC client.
+type RPCNodeClient struct {
+	baseURL   string
+	authToken string
+	http      *http.Client
+	nextID    atomic.Int64
+}
+
+// NewRPCNodeClient constructs a new RPC client.
+func NewRPCNodeClient(baseURL, authToken string) *RPCNodeClient {
+	return &RPCNodeClient{
+		baseURL:   baseURL,
+		authToken: authToken,
+		http: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (c *RPCNodeClient) MintWithSig(ctx context.Context, voucher MintVoucher) (string, error) {
+	params := []interface{}{map[string]interface{}{
+		"recipient": voucher.Recipient,
+		"token":     voucher.Token,
+		"amount":    voucher.Amount,
+		"nonce":     voucher.Nonce,
+		"signature": voucher.Signature,
+	}}
+	var result struct {
+		TxHash string `json:"txHash"`
+	}
+	if err := c.call(ctx, "mint_with_sig", params, &result); err != nil {
+		return "", err
+	}
+	return result.TxHash, nil
+}
+
+func (c *RPCNodeClient) call(ctx context.Context, method string, params interface{}, out interface{}) error {
+	id := c.nextID.Add(1)
+	bodyStruct := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	}
+	buf, err := json.Marshal(bodyStruct)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL, bytes.NewReader(buf))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if strings.TrimSpace(c.authToken) != "" {
+		req.Header.Set("Authorization", "Bearer "+c.authToken)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("node rpc %s failed: status=%d", method, resp.StatusCode)
+	}
+	var rpcResp struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  json.RawMessage `json:"result"`
+		Error   *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return err
+	}
+	if rpcResp.Error != nil {
+		return fmt.Errorf("node rpc error: %s", rpcResp.Error.Message)
+	}
+	if out == nil {
+		return nil
+	}
+	if len(rpcResp.Result) == 0 {
+		return fmt.Errorf("node rpc returned empty result")
+	}
+	return json.Unmarshal(rpcResp.Result, out)
+}

--- a/services/payments-gateway/nowpayments.go
+++ b/services/payments-gateway/nowpayments.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// NowPaymentsClient defines the subset of the NOWPayments API the service requires.
+type NowPaymentsClient interface {
+	CreateInvoice(ctx context.Context, req *NowPaymentsInvoiceRequest) (*NowPaymentsInvoice, error)
+	GetInvoice(ctx context.Context, id string) (*NowPaymentsInvoice, error)
+}
+
+// HTTPNowPaymentsClient implements NowPaymentsClient against the official HTTP API.
+type HTTPNowPaymentsClient struct {
+	apiKey  string
+	baseURL string
+	http    *http.Client
+}
+
+// NowPaymentsInvoiceRequest represents an invoice creation request.
+type NowPaymentsInvoiceRequest struct {
+	PriceAmount   string `json:"price_amount"`
+	PriceCurrency string `json:"price_currency"`
+	PayCurrency   string `json:"pay_currency"`
+	OrderID       string `json:"order_id"`
+	OrderDesc     string `json:"order_description,omitempty"`
+	FixedRate     bool   `json:"is_fixed_rate"`
+	SuccessURL    string `json:"success_url,omitempty"`
+	CancelURL     string `json:"cancel_url,omitempty"`
+}
+
+// NowPaymentsInvoice captures the relevant invoice attributes used by the service.
+type NowPaymentsInvoice struct {
+	ID            string `json:"id"`
+	InvoiceID     string `json:"invoice_id"`
+	OrderID       string `json:"order_id"`
+	PriceAmount   string `json:"price_amount"`
+	PayCurrency   string `json:"pay_currency"`
+	PriceCurrency string `json:"price_currency"`
+	PaymentStatus string `json:"payment_status"`
+	InvoiceURL    string `json:"invoice_url"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
+	Status        string `json:"status"`
+}
+
+// Paid returns whether the invoice is considered settled.
+func (i *NowPaymentsInvoice) Paid() bool {
+	status := strings.ToLower(strings.TrimSpace(i.PaymentStatus))
+	if status == "" {
+		status = strings.ToLower(strings.TrimSpace(i.Status))
+	}
+	switch status {
+	case "finished", "confirmed", "completed", "paid":
+		return true
+	}
+	return false
+}
+
+// NewHTTPNowPaymentsClient constructs an HTTP client with sane defaults.
+func NewHTTPNowPaymentsClient(baseURL, apiKey string) *HTTPNowPaymentsClient {
+	return &HTTPNowPaymentsClient{
+		apiKey:  apiKey,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		http:    &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (c *HTTPNowPaymentsClient) CreateInvoice(ctx context.Context, req *NowPaymentsInvoiceRequest) (*NowPaymentsInvoice, error) {
+	return c.doRequest(ctx, http.MethodPost, "/invoice", req)
+}
+
+func (c *HTTPNowPaymentsClient) GetInvoice(ctx context.Context, id string) (*NowPaymentsInvoice, error) {
+	return c.doRequest(ctx, http.MethodGet, fmt.Sprintf("/invoice/%s", id), nil)
+}
+
+func (c *HTTPNowPaymentsClient) doRequest(ctx context.Context, method, path string, payload interface{}) (*NowPaymentsInvoice, error) {
+	if c == nil {
+		return nil, fmt.Errorf("nowpayments client not configured")
+	}
+	var body *bytes.Reader
+	if payload != nil {
+		buf, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		body = bytes.NewReader(buf)
+	} else {
+		body = bytes.NewReader(nil)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", c.apiKey)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("nowpayments %s failed: status=%d", path, resp.StatusCode)
+	}
+	var invoice NowPaymentsInvoice
+	if err := json.NewDecoder(resp.Body).Decode(&invoice); err != nil {
+		return nil, err
+	}
+	return &invoice, nil
+}

--- a/services/payments-gateway/oracle.go
+++ b/services/payments-gateway/oracle.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"errors"
+	"sort"
+	"sync"
+	"time"
+)
+
+// PriceSample captures a single oracle price observation.
+type PriceSample struct {
+	Value     float64
+	Timestamp time.Time
+}
+
+// Oracle maintains a set of price feeds per token and exposes resilient median pricing.
+type Oracle struct {
+	mu           sync.RWMutex
+	ttl          time.Duration
+	maxDeviation float64
+	breaker      float64
+	feeds        map[string]map[string]PriceSample
+	lastAccepted map[string]float64
+}
+
+// ErrPriceUnavailable indicates the oracle cannot provide a price.
+var ErrPriceUnavailable = errors.New("price unavailable")
+
+// NewOracle creates a new median oracle.
+func NewOracle(ttl time.Duration, maxDeviation, breaker float64) *Oracle {
+	return &Oracle{
+		ttl:          ttl,
+		maxDeviation: maxDeviation,
+		breaker:      breaker,
+		feeds:        make(map[string]map[string]PriceSample),
+		lastAccepted: make(map[string]float64),
+	}
+}
+
+// Update records a new price observation for a feed.
+func (o *Oracle) Update(token, feed string, value float64, observed time.Time) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if _, ok := o.feeds[token]; !ok {
+		o.feeds[token] = make(map[string]PriceSample)
+	}
+	if observed.IsZero() {
+		observed = time.Now().UTC()
+	}
+	o.feeds[token][feed] = PriceSample{Value: value, Timestamp: observed}
+}
+
+// Price computes the median price for the specified token. Values outside of the deviation cap are discarded.
+func (o *Oracle) Price(token string, now time.Time) (float64, error) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	feeds, ok := o.feeds[token]
+	if !ok || len(feeds) == 0 {
+		return 0, ErrPriceUnavailable
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	var values []float64
+	for _, sample := range feeds {
+		if now.Sub(sample.Timestamp) > o.ttl {
+			continue
+		}
+		values = append(values, sample.Value)
+	}
+	if len(values) == 0 {
+		return 0, ErrPriceUnavailable
+	}
+	sort.Float64s(values)
+	median := values[len(values)/2]
+	if len(values)%2 == 0 {
+		median = (values[len(values)/2-1] + values[len(values)/2]) / 2
+	}
+	if median <= 0 {
+		return 0, ErrPriceUnavailable
+	}
+	if o.maxDeviation > 0 {
+		filtered := make([]float64, 0, len(values))
+		for _, v := range values {
+			diff := absFloat((v - median) / median)
+			if diff <= o.maxDeviation {
+				filtered = append(filtered, v)
+			}
+		}
+		if len(filtered) == 0 {
+			return 0, ErrPriceUnavailable
+		}
+		sort.Float64s(filtered)
+		median = filtered[len(filtered)/2]
+		if len(filtered)%2 == 0 {
+			median = (filtered[len(filtered)/2-1] + filtered[len(filtered)/2]) / 2
+		}
+	}
+	if prev, ok := o.lastAccepted[token]; ok && o.breaker > 0 {
+		diff := absFloat((median - prev) / prev)
+		if diff > o.breaker {
+			return 0, ErrPriceUnavailable
+		}
+	}
+	o.lastAccepted[token] = median
+	return median, nil
+}
+
+func absFloat(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/services/payments-gateway/server.go
+++ b/services/payments-gateway/server.go
@@ -1,0 +1,545 @@
+package main
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	maxRequestBody        = 1 << 20
+	headerIdempotencyKey  = "Idempotency-Key"
+	headerNowPaymentsSig  = "X-Nowpayments-Signature"
+	headerNowPaymentsSig2 = "x-nowpayments-sig"
+)
+
+// Server exposes HTTP endpoints for fiat-to-token flows.
+type Server struct {
+	store         *SQLiteStore
+	oracle        *Oracle
+	nowPayments   NowPaymentsClient
+	node          NodeClient
+	signer        Signer
+	quoteTTL      time.Duration
+	quoteCurrency string
+	hmacSecret    []byte
+	nowFn         func() time.Time
+}
+
+// QuoteRequest is the payload accepted by POST /quotes.
+type QuoteRequest struct {
+	Fiat       string `json:"fiat"`
+	Token      string `json:"token"`
+	AmountFiat string `json:"amountFiat"`
+}
+
+// QuoteResponse is returned to the caller when requesting a quote.
+type QuoteResponse struct {
+	QuoteID     string `json:"quoteId"`
+	Fiat        string `json:"fiat"`
+	Token       string `json:"token"`
+	AmountFiat  string `json:"amountFiat"`
+	AmountToken string `json:"amountToken"`
+	Expiry      string `json:"expiry"`
+}
+
+// InvoiceCreateRequest is accepted by POST /invoices.
+type InvoiceCreateRequest struct {
+	QuoteID   string `json:"quoteId"`
+	Recipient string `json:"recipient"`
+}
+
+// NowPaymentsWebhookPayload models the minimal webhook structure.
+type NowPaymentsWebhookPayload struct {
+	InvoiceID     string `json:"invoice_id"`
+	PaymentStatus string `json:"payment_status"`
+	Status        string `json:"status"`
+}
+
+// NewServer constructs a payments gateway server.
+func NewServer(store *SQLiteStore, oracle *Oracle, nowClient NowPaymentsClient, node NodeClient, signer Signer, quoteTTL time.Duration, quoteCurrency string, hmacSecret string) *Server {
+	if store == nil {
+		panic("store required")
+	}
+	if oracle == nil {
+		panic("oracle required")
+	}
+	if nowClient == nil {
+		panic("nowpayments client required")
+	}
+	if node == nil {
+		panic("node client required")
+	}
+	if signer == nil {
+		panic("kms signer required")
+	}
+	secret := []byte(strings.TrimSpace(hmacSecret))
+	if len(secret) == 0 {
+		panic("hmac secret required")
+	}
+	if quoteTTL <= 0 {
+		quoteTTL = 5 * time.Minute
+	}
+	if strings.TrimSpace(quoteCurrency) == "" {
+		quoteCurrency = "USD"
+	}
+	return &Server{
+		store:         store,
+		oracle:        oracle,
+		nowPayments:   nowClient,
+		node:          node,
+		signer:        signer,
+		quoteTTL:      quoteTTL,
+		quoteCurrency: quoteCurrency,
+		hmacSecret:    secret,
+		nowFn:         time.Now,
+	}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/quotes":
+		s.handleQuote(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/invoices":
+		s.handleInvoiceCreate(w, r)
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/invoices/"):
+		s.handleInvoiceGet(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/webhooks/nowpayments":
+		s.handleNowPaymentsWebhook(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handleQuote(w http.ResponseWriter, r *http.Request) {
+	body, err := s.readBody(w, r)
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, err, body, nil)
+		return
+	}
+	var req QuoteRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		s.writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid JSON payload: %w", err), body, nil)
+		return
+	}
+	if err := validateQuoteRequest(req, s.quoteCurrency); err != nil {
+		s.writeError(w, r, http.StatusBadRequest, err, body, nil)
+		return
+	}
+	now := s.nowFn().UTC()
+	price, err := s.oracle.Price(req.Token, now)
+	if err != nil {
+		s.writeError(w, r, http.StatusServiceUnavailable, err, body, nil)
+		return
+	}
+	amountToken, err := convertQuote(price, req.AmountFiat)
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, err, body, nil)
+		return
+	}
+	quoteID := uuid.NewString()
+	expiry := now.Add(s.quoteTTL)
+	record := QuoteRecord{
+		ID:           quoteID,
+		FiatCurrency: s.quoteCurrency,
+		Token:        req.Token,
+		AmountFiat:   req.AmountFiat,
+		AmountToken:  amountToken,
+		Expiry:       expiry,
+		CreatedAt:    now,
+	}
+	if err := s.store.InsertQuote(r.Context(), record); err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, err, body, nil)
+		return
+	}
+	resp := QuoteResponse{
+		QuoteID:     quoteID,
+		Fiat:        record.FiatCurrency,
+		Token:       record.Token,
+		AmountFiat:  record.AmountFiat,
+		AmountToken: record.AmountToken,
+		Expiry:      expiry.Format(time.RFC3339),
+	}
+	s.writeJSON(w, r, http.StatusOK, resp, body)
+}
+
+func validateQuoteRequest(req QuoteRequest, expectedFiat string) error {
+	if strings.TrimSpace(req.Fiat) == "" {
+		return errors.New("fiat currency required")
+	}
+	if expectedFiat != "" && !strings.EqualFold(strings.TrimSpace(req.Fiat), expectedFiat) {
+		return fmt.Errorf("unsupported fiat currency: %s", req.Fiat)
+	}
+	if strings.TrimSpace(req.Token) == "" {
+		return errors.New("token required")
+	}
+	if strings.TrimSpace(req.AmountFiat) == "" {
+		return errors.New("amountFiat required")
+	}
+	if _, ok := new(big.Rat).SetString(req.AmountFiat); !ok {
+		return fmt.Errorf("invalid amountFiat: %s", req.AmountFiat)
+	}
+	return nil
+}
+
+func convertQuote(price float64, amountFiat string) (string, error) {
+	if price <= 0 {
+		return "", fmt.Errorf("invalid oracle price")
+	}
+	fiat, ok := new(big.Rat).SetString(amountFiat)
+	if !ok {
+		return "", fmt.Errorf("invalid amountFiat: %s", amountFiat)
+	}
+	priceRat := new(big.Rat).SetFloat64(price)
+	if priceRat.Sign() <= 0 {
+		return "", fmt.Errorf("invalid price")
+	}
+	tokens := new(big.Rat).Quo(fiat, priceRat)
+	if tokens.Sign() <= 0 {
+		return "", fmt.Errorf("calculated token amount is non-positive")
+	}
+	return formatRat(tokens, 8), nil
+}
+
+func formatRat(r *big.Rat, precision int) string {
+	f := new(big.Float).SetRat(r)
+	f = f.SetPrec(uint(precision * 4))
+	text := f.Text('f', precision)
+	text = strings.TrimRight(text, "0")
+	text = strings.TrimRight(text, ".")
+	if text == "" {
+		text = "0"
+	}
+	return text
+}
+
+func (s *Server) handleInvoiceCreate(w http.ResponseWriter, r *http.Request) {
+	body, err := s.readBody(w, r)
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, err, body, nil)
+		return
+	}
+	key := strings.TrimSpace(r.Header.Get(headerIdempotencyKey))
+	if key == "" {
+		s.writeError(w, r, http.StatusBadRequest, errors.New("missing Idempotency-Key header"), body, nil)
+		return
+	}
+	requestHash := hashRequest(r.Method, canonicalRequestPath(r), body)
+	if cached, err := s.store.LookupIdempotency(r.Context(), key, requestHash); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, ErrIdempotencyConflict) {
+			status = http.StatusConflict
+		}
+		s.writeError(w, r, status, err, body, nil)
+		return
+	} else if cached != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(cached.Status)
+		_, _ = w.Write(cached.Body)
+		s.audit(r.Context(), r, body, cached.Body, cached.Status)
+		return
+	}
+	var req InvoiceCreateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		s.writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid JSON payload: %w", err), body, nil)
+		return
+	}
+	if err := validateInvoiceCreate(req); err != nil {
+		s.writeError(w, r, http.StatusBadRequest, err, body, nil)
+		return
+	}
+	quote, err := s.store.GetQuote(r.Context(), req.QuoteID)
+	if err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, err, body, nil)
+		return
+	}
+	if quote == nil {
+		s.writeError(w, r, http.StatusBadRequest, fmt.Errorf("quote %s not found", req.QuoteID), body, nil)
+		return
+	}
+	now := s.nowFn().UTC()
+	if now.After(quote.Expiry) {
+		s.writeError(w, r, http.StatusBadRequest, errors.New("quote expired"), body, nil)
+		return
+	}
+	invoiceID := uuid.NewString()
+	npReq := &NowPaymentsInvoiceRequest{
+		PriceAmount:   quote.AmountFiat,
+		PriceCurrency: quote.FiatCurrency,
+		PayCurrency:   quote.Token,
+		OrderID:       invoiceID,
+		OrderDesc:     fmt.Sprintf("Mint %s %s", quote.AmountToken, quote.Token),
+		FixedRate:     true,
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	invoice, err := s.nowPayments.CreateInvoice(ctx, npReq)
+	if err != nil {
+		s.writeError(w, r, http.StatusBadGateway, err, body, nil)
+		return
+	}
+	nowID := firstNonEmpty(invoice.InvoiceID, invoice.ID)
+	record := InvoiceRecord{
+		ID:        invoiceID,
+		QuoteID:   quote.ID,
+		Recipient: req.Recipient,
+		Status:    "pending",
+		NowID:     nowID,
+		NowURL:    invoice.InvoiceURL,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.store.InsertInvoice(r.Context(), record); err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, err, body, nil)
+		return
+	}
+	resp := map[string]string{
+		"invoiceId":      record.ID,
+		"nowpaymentsUrl": record.NowURL,
+	}
+	respBody, _ := json.Marshal(resp)
+	if err := s.store.SaveIdempotency(r.Context(), key, requestHash, http.StatusOK, respBody); err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, err, body, nil)
+		return
+	}
+	s.writeJSONBytes(w, r, http.StatusOK, respBody, body)
+}
+
+func validateInvoiceCreate(req InvoiceCreateRequest) error {
+	if strings.TrimSpace(req.QuoteID) == "" {
+		return errors.New("quoteId required")
+	}
+	if strings.TrimSpace(req.Recipient) == "" {
+		return errors.New("recipient required")
+	}
+	return nil
+}
+
+func (s *Server) handleInvoiceGet(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/invoices/")
+	if id == "" {
+		s.writeError(w, r, http.StatusBadRequest, errors.New("invoice id required"), nil, nil)
+		return
+	}
+	invoice, err := s.store.GetInvoice(r.Context(), id)
+	if err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, err, nil, nil)
+		return
+	}
+	if invoice == nil {
+		s.writeError(w, r, http.StatusNotFound, errors.New("invoice not found"), nil, nil)
+		return
+	}
+	quote, err := s.store.GetQuote(r.Context(), invoice.QuoteID)
+	if err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, err, nil, nil)
+		return
+	}
+	resp, err := MarshalInvoice(invoice, quote)
+	if err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, err, nil, nil)
+		return
+	}
+	s.writeJSONBytes(w, r, http.StatusOK, resp, nil)
+}
+
+func (s *Server) handleNowPaymentsWebhook(w http.ResponseWriter, r *http.Request) {
+	body, err := s.readBody(w, r)
+	if err != nil {
+		s.writeError(w, r, http.StatusBadRequest, err, body, nil)
+		return
+	}
+	sig := strings.TrimSpace(r.Header.Get(headerNowPaymentsSig))
+	if sig == "" {
+		sig = strings.TrimSpace(r.Header.Get(headerNowPaymentsSig2))
+	}
+	if !s.verifyHMAC(body, sig) {
+		s.writeError(w, r, http.StatusUnauthorized, errors.New("invalid webhook signature"), body, nil)
+		return
+	}
+	var payload NowPaymentsWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		s.writeError(w, r, http.StatusBadRequest, fmt.Errorf("invalid webhook payload: %w", err), body, nil)
+		return
+	}
+	nowID := strings.TrimSpace(firstNonEmpty(payload.InvoiceID))
+	if nowID == "" {
+		s.writeJSON(w, r, http.StatusOK, map[string]string{"status": "ignored"}, body)
+		return
+	}
+	invoice, err := s.store.GetInvoiceByNowID(r.Context(), nowID)
+	if err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, err, body, nil)
+		return
+	}
+	if invoice == nil {
+		s.writeJSON(w, r, http.StatusOK, map[string]string{"status": "unknown"}, body)
+		return
+	}
+	if strings.EqualFold(invoice.Status, "minted") {
+		s.writeJSON(w, r, http.StatusOK, map[string]string{"status": "already minted"}, body)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	latest, err := s.nowPayments.GetInvoice(ctx, nowID)
+	if err != nil {
+		s.writeError(w, r, http.StatusBadGateway, err, body, nil)
+		return
+	}
+	if !latest.Paid() {
+		_ = s.store.UpdateInvoiceStatus(r.Context(), invoice.ID, "processing", nil)
+		s.writeJSON(w, r, http.StatusOK, map[string]string{"status": "pending"}, body)
+		return
+	}
+	quote, err := s.store.GetQuote(r.Context(), invoice.QuoteID)
+	if err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, err, body, nil)
+		return
+	}
+	if quote == nil {
+		s.writeError(w, r, http.StatusInternalServerError, fmt.Errorf("quote %s missing", invoice.QuoteID), body, nil)
+		return
+	}
+	txHash, err := s.mintWithVoucher(ctx, invoice, quote)
+	if err != nil {
+		_ = s.store.UpdateInvoiceStatus(r.Context(), invoice.ID, "error", nil)
+		s.writeError(w, r, http.StatusBadGateway, err, body, nil)
+		return
+	}
+	_ = s.store.UpdateInvoiceStatus(r.Context(), invoice.ID, "minted", &txHash)
+	s.writeJSON(w, r, http.StatusOK, map[string]string{"status": "minted", "txHash": txHash}, body)
+}
+
+func (s *Server) mintWithVoucher(ctx context.Context, invoice *InvoiceRecord, quote *QuoteRecord) (string, error) {
+	payload := strings.Join([]string{invoice.Recipient, quote.Token, quote.AmountToken, invoice.ID}, "|")
+	sig, err := s.signer.Sign(ctx, []byte(payload))
+	if err != nil {
+		return "", err
+	}
+	voucher := MintVoucher{
+		Recipient: invoice.Recipient,
+		Token:     quote.Token,
+		Amount:    quote.AmountToken,
+		Nonce:     invoice.ID,
+		Signature: hex.EncodeToString(sig),
+	}
+	return s.node.MintWithSig(ctx, voucher)
+}
+
+func (s *Server) verifyHMAC(body []byte, signature string) bool {
+	if strings.TrimSpace(signature) == "" {
+		return false
+	}
+	mac := hmac.New(sha512.New, s.hmacSecret)
+	mac.Write(body)
+	expected := mac.Sum(nil)
+	decoded, err := hex.DecodeString(strings.TrimSpace(signature))
+	if err != nil {
+		return false
+	}
+	if len(decoded) != len(expected) {
+		return false
+	}
+	if hmac.Equal(decoded, expected) {
+		return true
+	}
+	return false
+}
+
+func (s *Server) readBody(w http.ResponseWriter, r *http.Request) ([]byte, error) {
+	reader := http.MaxBytesReader(w, r.Body, maxRequestBody)
+	defer func() {
+		_ = r.Body.Close()
+	}()
+	return io.ReadAll(reader)
+}
+
+func (s *Server) writeJSON(w http.ResponseWriter, r *http.Request, status int, payload interface{}, reqBody []byte) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		s.writeError(w, r, http.StatusInternalServerError, err, reqBody, nil)
+		return
+	}
+	s.writeJSONBytes(w, r, status, body, reqBody)
+}
+
+func (s *Server) writeJSONBytes(w http.ResponseWriter, r *http.Request, status int, body []byte, reqBody []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+	s.audit(r.Context(), r, reqBody, body, status)
+}
+
+func (s *Server) writeError(w http.ResponseWriter, r *http.Request, status int, err error, reqBody []byte, extra map[string]interface{}) {
+	if status <= 0 {
+		status = http.StatusInternalServerError
+	}
+	payload := map[string]interface{}{"error": err.Error()}
+	if extra != nil {
+		for k, v := range extra {
+			payload[k] = v
+		}
+	}
+	body, _ := json.Marshal(payload)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+	s.audit(r.Context(), r, reqBody, body, status)
+}
+
+func (s *Server) audit(ctx context.Context, r *http.Request, requestBody, responseBody []byte, status int) {
+	if s.store == nil {
+		return
+	}
+	entry := AuditEntry{
+		Method:         r.Method,
+		Path:           canonicalRequestPath(r),
+		RequestBody:    requestBody,
+		ResponseStatus: status,
+		ResponseBody:   responseBody,
+		Timestamp:      s.nowFn().UTC(),
+	}
+	_ = s.store.InsertAudit(ctx, entry)
+}
+
+func canonicalRequestPath(r *http.Request) string {
+	path := r.URL.Path
+	if path == "" {
+		path = "/"
+	}
+	if r.URL.RawQuery != "" {
+		parts := strings.Split(r.URL.RawQuery, "&")
+		sort.Strings(parts)
+		path += "?" + strings.Join(parts, "&")
+	}
+	return path
+}
+
+func hashRequest(method, path string, body []byte) string {
+	payload := strings.Join([]string{strings.ToUpper(method), path, string(body)}, "\n")
+	sum := sha256.Sum256([]byte(payload))
+	return fmt.Sprintf("%x", sum[:])
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/services/payments-gateway/server_test.go
+++ b/services/payments-gateway/server_test.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	store, err := NewSQLiteStore("file:test-payments?mode=memory&cache=shared")
+	if err != nil {
+		t.Fatalf("new sqlite store: %v", err)
+	}
+	return store
+}
+
+type stubNowPayments struct {
+	createFn    func(ctx context.Context, req *NowPaymentsInvoiceRequest) (*NowPaymentsInvoice, error)
+	getFn       func(ctx context.Context, id string) (*NowPaymentsInvoice, error)
+	createCalls int
+}
+
+func (s *stubNowPayments) CreateInvoice(ctx context.Context, req *NowPaymentsInvoiceRequest) (*NowPaymentsInvoice, error) {
+	s.createCalls++
+	if s.createFn == nil {
+		return &NowPaymentsInvoice{}, nil
+	}
+	return s.createFn(ctx, req)
+}
+
+func (s *stubNowPayments) GetInvoice(ctx context.Context, id string) (*NowPaymentsInvoice, error) {
+	if s.getFn == nil {
+		return &NowPaymentsInvoice{InvoiceID: id}, nil
+	}
+	return s.getFn(ctx, id)
+}
+
+type stubNode struct {
+	lastVoucher MintVoucher
+	txHash      string
+	callCount   int
+	err         error
+}
+
+func (n *stubNode) MintWithSig(ctx context.Context, voucher MintVoucher) (string, error) {
+	n.callCount++
+	n.lastVoucher = voucher
+	if n.err != nil {
+		return "", n.err
+	}
+	if n.txHash == "" {
+		n.txHash = "0xdeadbeef"
+	}
+	return n.txHash, nil
+}
+
+type stubSigner struct {
+	payloads [][]byte
+	sig      []byte
+	err      error
+}
+
+func (s *stubSigner) Address() string { return "nhb1test" }
+
+func (s *stubSigner) Sign(ctx context.Context, payload []byte) ([]byte, error) {
+	s.payloads = append(s.payloads, payload)
+	if s.err != nil {
+		return nil, s.err
+	}
+	if len(s.sig) == 0 {
+		return bytes.Repeat([]byte{0x01}, 65), nil
+	}
+	return s.sig, nil
+}
+
+func newTestServer(t *testing.T, store *SQLiteStore, np *stubNowPayments, node *stubNode, signer *stubSigner) *Server {
+	oracle := NewOracle(time.Minute, 0.10, 0.50)
+	srv := NewServer(store, oracle, np, node, signer, time.Minute, "USD", "secret")
+	fixed := time.Date(2024, 12, 1, 10, 0, 0, 0, time.UTC)
+	srv.nowFn = func() time.Time { return fixed }
+	return srv
+}
+
+func TestQuoteCalculation(t *testing.T) {
+	store := newTestStore(t)
+	t.Cleanup(func() { store.Close() })
+	np := &stubNowPayments{}
+	node := &stubNode{}
+	signer := &stubSigner{}
+	srv := newTestServer(t, store, np, node, signer)
+	srv.oracle.Update("NHB", "feed-a", 5.0, srv.nowFn())
+
+	reqBody := []byte(`{"fiat":"USD","token":"NHB","amountFiat":"125.00"}`)
+	req := httptest.NewRequest(http.MethodPost, "/quotes", bytes.NewReader(reqBody))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp QuoteResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.AmountToken != "25" {
+		t.Fatalf("expected 25 tokens, got %s", resp.AmountToken)
+	}
+	if resp.Expiry != srv.nowFn().Add(time.Minute).Format(time.RFC3339) {
+		t.Fatalf("unexpected expiry: %s", resp.Expiry)
+	}
+	if resp.Fiat != "USD" || resp.Token != "NHB" {
+		t.Fatalf("unexpected currencies in response: %+v", resp)
+	}
+}
+
+func TestInvoiceIdempotency(t *testing.T) {
+	store := newTestStore(t)
+	t.Cleanup(func() { store.Close() })
+	var storedQuote QuoteResponse
+	np := &stubNowPayments{
+		createFn: func(ctx context.Context, req *NowPaymentsInvoiceRequest) (*NowPaymentsInvoice, error) {
+			return &NowPaymentsInvoice{InvoiceID: "np-1", InvoiceURL: "https://nowpay/invoice/np-1"}, nil
+		},
+		getFn: func(ctx context.Context, id string) (*NowPaymentsInvoice, error) {
+			return &NowPaymentsInvoice{InvoiceID: id, PaymentStatus: "finished"}, nil
+		},
+	}
+	node := &stubNode{}
+	signer := &stubSigner{}
+	srv := newTestServer(t, store, np, node, signer)
+	srv.oracle.Update("NHB", "feed-a", 5.0, srv.nowFn())
+
+	quoteReq := httptest.NewRequest(http.MethodPost, "/quotes", bytes.NewReader([]byte(`{"fiat":"USD","token":"NHB","amountFiat":"50"}`)))
+	quoteResp := httptest.NewRecorder()
+	srv.ServeHTTP(quoteResp, quoteReq)
+	if quoteResp.Code != http.StatusOK {
+		t.Fatalf("quote creation failed: %s", quoteResp.Body.String())
+	}
+	if err := json.Unmarshal(quoteResp.Body.Bytes(), &storedQuote); err != nil {
+		t.Fatalf("decode quote response: %v", err)
+	}
+
+	invoicePayload := []byte(`{"quoteId":"` + storedQuote.QuoteID + `","recipient":"nhb1alice"}`)
+	req := httptest.NewRequest(http.MethodPost, "/invoices", bytes.NewReader(invoicePayload))
+	req.Header.Set(headerIdempotencyKey, "abc123")
+	res := httptest.NewRecorder()
+	srv.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("invoice create failed: %s", res.Body.String())
+	}
+	first := res.Body.Bytes()
+
+	// replay with same key
+	req2 := httptest.NewRequest(http.MethodPost, "/invoices", bytes.NewReader(invoicePayload))
+	req2.Header.Set(headerIdempotencyKey, "abc123")
+	res2 := httptest.NewRecorder()
+	srv.ServeHTTP(res2, req2)
+	if res2.Code != http.StatusOK {
+		t.Fatalf("second invoice create failed: %s", res2.Body.String())
+	}
+	if !bytes.Equal(first, res2.Body.Bytes()) {
+		t.Fatalf("responses differ for idempotent request")
+	}
+	if np.createCalls != 1 {
+		t.Fatalf("expected single invoice creation, got %d", np.createCalls)
+	}
+}
+
+func TestWebhookReconciliationAndMint(t *testing.T) {
+	store := newTestStore(t)
+	t.Cleanup(func() { store.Close() })
+	np := &stubNowPayments{}
+	node := &stubNode{}
+	signer := &stubSigner{}
+	srv := newTestServer(t, store, np, node, signer)
+	srv.oracle.Update("NHB", "feed-a", 5.0, srv.nowFn())
+
+	// create quote
+	quoteReq := httptest.NewRequest(http.MethodPost, "/quotes", bytes.NewReader([]byte(`{"fiat":"USD","token":"NHB","amountFiat":"20"}`)))
+	quoteRes := httptest.NewRecorder()
+	srv.ServeHTTP(quoteRes, quoteReq)
+	if quoteRes.Code != http.StatusOK {
+		t.Fatalf("quote failed: %s", quoteRes.Body.String())
+	}
+	var quote QuoteResponse
+	if err := json.Unmarshal(quoteRes.Body.Bytes(), &quote); err != nil {
+		t.Fatalf("decode quote: %v", err)
+	}
+
+	npID := "np-xyz"
+	np.createFn = func(ctx context.Context, req *NowPaymentsInvoiceRequest) (*NowPaymentsInvoice, error) {
+		return &NowPaymentsInvoice{InvoiceID: npID, InvoiceURL: "https://nowpay/invoice/" + npID}, nil
+	}
+	np.getFn = func(ctx context.Context, id string) (*NowPaymentsInvoice, error) {
+		return &NowPaymentsInvoice{InvoiceID: id, PaymentStatus: "finished"}, nil
+	}
+
+	invoicePayload := []byte(`{"quoteId":"` + quote.QuoteID + `","recipient":"nhb1bob"}`)
+	invReq := httptest.NewRequest(http.MethodPost, "/invoices", bytes.NewReader(invoicePayload))
+	invReq.Header.Set(headerIdempotencyKey, "idem-1")
+	invRes := httptest.NewRecorder()
+	srv.ServeHTTP(invRes, invReq)
+	if invRes.Code != http.StatusOK {
+		t.Fatalf("invoice create failed: %s", invRes.Body.String())
+	}
+	var invResp map[string]string
+	if err := json.Unmarshal(invRes.Body.Bytes(), &invResp); err != nil {
+		t.Fatalf("decode invoice resp: %v", err)
+	}
+	invoiceID := invResp["invoiceId"]
+	if invoiceID == "" {
+		t.Fatalf("missing invoice id in response")
+	}
+
+	webhook := NowPaymentsWebhookPayload{InvoiceID: npID, PaymentStatus: "finished"}
+	body, _ := json.Marshal(webhook)
+	sig := computeTestHMAC("secret", body)
+
+	whReq := httptest.NewRequest(http.MethodPost, "/webhooks/nowpayments", bytes.NewReader(body))
+	whReq.Header.Set(headerNowPaymentsSig, sig)
+	whRes := httptest.NewRecorder()
+	srv.ServeHTTP(whRes, whReq)
+	if whRes.Code != http.StatusOK {
+		t.Fatalf("webhook failed: %s", whRes.Body.String())
+	}
+	if node.callCount != 1 {
+		t.Fatalf("expected node mint call")
+	}
+	if node.lastVoucher.Recipient != "nhb1bob" || node.lastVoucher.Token != "NHB" {
+		t.Fatalf("unexpected voucher: %+v", node.lastVoucher)
+	}
+	if node.lastVoucher.Nonce != invoiceID {
+		t.Fatalf("nonce mismatch: %s", node.lastVoucher.Nonce)
+	}
+	inv, err := store.GetInvoice(context.Background(), invoiceID)
+	if err != nil {
+		t.Fatalf("fetch invoice: %v", err)
+	}
+	if inv.Status != "minted" {
+		t.Fatalf("expected invoice minted, got %s", inv.Status)
+	}
+	if !inv.TxHash.Valid {
+		t.Fatalf("expected tx hash to be recorded")
+	}
+}
+
+func computeTestHMAC(secret string, body []byte) string {
+	mac := hmac.New(sha512.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestWebhookSignatureFailure(t *testing.T) {
+	store := newTestStore(t)
+	t.Cleanup(func() { store.Close() })
+	np := &stubNowPayments{}
+	node := &stubNode{}
+	signer := &stubSigner{}
+	srv := newTestServer(t, store, np, node, signer)
+	webhook := NowPaymentsWebhookPayload{InvoiceID: "np-1"}
+	body, _ := json.Marshal(webhook)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/nowpayments", bytes.NewReader(body))
+	req.Header.Set(headerNowPaymentsSig, "bad-signature")
+	res := httptest.NewRecorder()
+	srv.ServeHTTP(res, req)
+	if res.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.Code)
+	}
+}

--- a/services/payments-gateway/storage.go
+++ b/services/payments-gateway/storage.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// ErrIdempotencyConflict indicates a key is reused with a different payload.
+var ErrIdempotencyConflict = errors.New("idempotency key conflict")
+
+// SQLiteStore persists quotes, invoices, and audit logs.
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+func NewSQLiteStore(path string) (*SQLiteStore, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, err
+	}
+	store := &SQLiteStore{db: db}
+	if err := store.init(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *SQLiteStore) init() error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS idempotency_keys (
+            key TEXT PRIMARY KEY,
+            request_hash TEXT NOT NULL,
+            response_status INTEGER NOT NULL,
+            response_body BLOB NOT NULL,
+            created_at TIMESTAMP NOT NULL
+        );`,
+		`CREATE TABLE IF NOT EXISTS audit_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            occurred_at TIMESTAMP NOT NULL,
+            method TEXT NOT NULL,
+            path TEXT NOT NULL,
+            request_body BLOB,
+            response_status INTEGER,
+            response_body BLOB
+        );`,
+		`CREATE TABLE IF NOT EXISTS quotes (
+            id TEXT PRIMARY KEY,
+            fiat_currency TEXT NOT NULL,
+            token TEXT NOT NULL,
+            amount_fiat TEXT NOT NULL,
+            amount_token TEXT NOT NULL,
+            expiry TIMESTAMP NOT NULL,
+            created_at TIMESTAMP NOT NULL
+        );`,
+		`CREATE TABLE IF NOT EXISTS invoices (
+            id TEXT PRIMARY KEY,
+            quote_id TEXT NOT NULL,
+            recipient TEXT NOT NULL,
+            status TEXT NOT NULL,
+            nowpayments_id TEXT,
+            nowpayments_url TEXT,
+            tx_hash TEXT,
+            created_at TIMESTAMP NOT NULL,
+            updated_at TIMESTAMP NOT NULL,
+            UNIQUE(quote_id)
+        );`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *SQLiteStore) Close() error { return s.db.Close() }
+
+// StoredResponse captures an idempotent response.
+type StoredResponse struct {
+	Status int
+	Body   []byte
+}
+
+func (s *SQLiteStore) LookupIdempotency(ctx context.Context, key, hash string) (*StoredResponse, error) {
+	const query = `SELECT response_status, response_body, request_hash FROM idempotency_keys WHERE key = ?`
+	row := s.db.QueryRowContext(ctx, query, key)
+	var status int
+	var body []byte
+	var storedHash string
+	err := row.Scan(&status, &body, &storedHash)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if storedHash != hash {
+		return nil, ErrIdempotencyConflict
+	}
+	return &StoredResponse{Status: status, Body: body}, nil
+}
+
+func (s *SQLiteStore) SaveIdempotency(ctx context.Context, key, hash string, status int, body []byte) error {
+	const stmt = `INSERT OR REPLACE INTO idempotency_keys(key, request_hash, response_status, response_body, created_at) VALUES (?, ?, ?, ?, ?)`
+	_, err := s.db.ExecContext(ctx, stmt, key, hash, status, body, time.Now().UTC())
+	return err
+}
+
+// AuditEntry captures request/response pairs.
+type AuditEntry struct {
+	Method         string
+	Path           string
+	RequestBody    []byte
+	ResponseStatus int
+	ResponseBody   []byte
+	Timestamp      time.Time
+}
+
+func (s *SQLiteStore) InsertAudit(ctx context.Context, entry AuditEntry) error {
+	const stmt = `INSERT INTO audit_log(occurred_at, method, path, request_body, response_status, response_body) VALUES (?, ?, ?, ?, ?, ?)`
+	_, err := s.db.ExecContext(ctx, stmt, entry.Timestamp, entry.Method, entry.Path, entry.RequestBody, entry.ResponseStatus, entry.ResponseBody)
+	return err
+}
+
+// QuoteRecord describes a quote persisted in SQLite.
+type QuoteRecord struct {
+	ID           string
+	FiatCurrency string
+	Token        string
+	AmountFiat   string
+	AmountToken  string
+	Expiry       time.Time
+	CreatedAt    time.Time
+}
+
+func (s *SQLiteStore) InsertQuote(ctx context.Context, q QuoteRecord) error {
+	const stmt = `INSERT INTO quotes(id, fiat_currency, token, amount_fiat, amount_token, expiry, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
+	_, err := s.db.ExecContext(ctx, stmt, q.ID, q.FiatCurrency, q.Token, q.AmountFiat, q.AmountToken, q.Expiry, q.CreatedAt)
+	return err
+}
+
+func (s *SQLiteStore) GetQuote(ctx context.Context, id string) (*QuoteRecord, error) {
+	const query = `SELECT id, fiat_currency, token, amount_fiat, amount_token, expiry, created_at FROM quotes WHERE id = ?`
+	row := s.db.QueryRowContext(ctx, query, id)
+	var rec QuoteRecord
+	if err := row.Scan(&rec.ID, &rec.FiatCurrency, &rec.Token, &rec.AmountFiat, &rec.AmountToken, &rec.Expiry, &rec.CreatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &rec, nil
+}
+
+// InvoiceRecord captures stored invoice metadata.
+type InvoiceRecord struct {
+	ID        string
+	QuoteID   string
+	Recipient string
+	Status    string
+	NowID     string
+	NowURL    string
+	TxHash    sql.NullString
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (s *SQLiteStore) InsertInvoice(ctx context.Context, inv InvoiceRecord) error {
+	const stmt = `INSERT INTO invoices(id, quote_id, recipient, status, nowpayments_id, nowpayments_url, tx_hash, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err := s.db.ExecContext(ctx, stmt, inv.ID, inv.QuoteID, inv.Recipient, inv.Status, inv.NowID, inv.NowURL, inv.TxHash, inv.CreatedAt, inv.UpdatedAt)
+	return err
+}
+
+func (s *SQLiteStore) GetInvoice(ctx context.Context, id string) (*InvoiceRecord, error) {
+	const query = `SELECT id, quote_id, recipient, status, nowpayments_id, nowpayments_url, tx_hash, created_at, updated_at FROM invoices WHERE id = ?`
+	row := s.db.QueryRowContext(ctx, query, id)
+	return scanInvoice(row)
+}
+
+func (s *SQLiteStore) GetInvoiceByNowID(ctx context.Context, nowID string) (*InvoiceRecord, error) {
+	const query = `SELECT id, quote_id, recipient, status, nowpayments_id, nowpayments_url, tx_hash, created_at, updated_at FROM invoices WHERE nowpayments_id = ?`
+	row := s.db.QueryRowContext(ctx, query, nowID)
+	return scanInvoice(row)
+}
+
+func scanInvoice(row *sql.Row) (*InvoiceRecord, error) {
+	var rec InvoiceRecord
+	err := row.Scan(&rec.ID, &rec.QuoteID, &rec.Recipient, &rec.Status, &rec.NowID, &rec.NowURL, &rec.TxHash, &rec.CreatedAt, &rec.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &rec, nil
+}
+
+func (s *SQLiteStore) UpdateInvoiceStatus(ctx context.Context, id, status string, txHash *string) error {
+	const stmt = `UPDATE invoices SET status = ?, tx_hash = ?, updated_at = ? WHERE id = ?`
+	var hash interface{}
+	if txHash != nil {
+		hash = *txHash
+	} else {
+		hash = nil
+	}
+	_, err := s.db.ExecContext(ctx, stmt, status, hash, time.Now().UTC(), id)
+	return err
+}
+
+// MarshalInvoice converts an InvoiceRecord into a JSON-friendly payload.
+func MarshalInvoice(inv *InvoiceRecord, quote *QuoteRecord) ([]byte, error) {
+	if inv == nil {
+		return json.Marshal(map[string]string{"error": "invoice not found"})
+	}
+	payload := map[string]interface{}{
+		"invoiceId": inv.ID,
+		"quoteId":   inv.QuoteID,
+		"recipient": inv.Recipient,
+		"status":    inv.Status,
+		"nowpayments": map[string]string{
+			"id":  inv.NowID,
+			"url": inv.NowURL,
+		},
+		"updatedAt": inv.UpdatedAt.UTC().Format(time.RFC3339),
+		"createdAt": inv.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if quote != nil {
+		payload["amountFiat"] = quote.AmountFiat
+		payload["amountToken"] = quote.AmountToken
+	}
+	if inv.TxHash.Valid {
+		payload["txHash"] = inv.TxHash.String
+	}
+	return json.Marshal(payload)
+}


### PR DESCRIPTION
## Summary
- implement a payments gateway HTTP service that mints invoices by quoting prices, issuing NOWPayments invoices, verifying webhooks, and invoking the node RPC
- add supporting oracle, SQLite persistence with idempotency and audit logging, NOWPayments and node RPC clients, plus an environment-backed KMS signer for mint vouchers
- cover quote math, webhook verification and reconciliation, and invoice idempotency with dedicated tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d357426e34832dafa368d6edf96e24