### PR TITLE
Add mint_with_sig RPC with voucher validation

### DIFF
--- a/core/events/mint.go
+++ b/core/events/mint.go
@@ -1,0 +1,44 @@
+package events
+
+import (
+	"math/big"
+	"strings"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+const (
+	// TypeMintSettled is emitted whenever an invoice-backed mint completes.
+	TypeMintSettled = "mint.settled"
+)
+
+type MintSettled struct {
+	InvoiceID string
+	Recipient [20]byte
+	Token     string
+	Amount    *big.Int
+	TxHash    string
+}
+
+func (MintSettled) EventType() string { return TypeMintSettled }
+
+func (e MintSettled) Event() *types.Event {
+	if e.Amount == nil {
+		e.Amount = big.NewInt(0)
+	}
+	txHash := strings.TrimSpace(e.TxHash)
+	if txHash != "" && !strings.HasPrefix(txHash, "0x") {
+		txHash = "0x" + txHash
+	}
+	return &types.Event{
+		Type: TypeMintSettled,
+		Attributes: map[string]string{
+			"invoiceId": e.InvoiceID,
+			"recipient": crypto.NewAddress(crypto.NHBPrefix, e.Recipient[:]).String(),
+			"token":     e.Token,
+			"amount":    e.Amount.String(),
+			"txHash":    txHash,
+		},
+	}
+}

--- a/core/mint.go
+++ b/core/mint.go
@@ -1,0 +1,114 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// MintChainID defines the chain identifier expected inside mint vouchers.
+const MintChainID uint64 = 187001
+
+var (
+	// ErrMintInvalidSigner indicates the recovered signer does not hold the required role.
+	ErrMintInvalidSigner = errors.New("mint: invalid signer")
+	// ErrMintInvoiceUsed indicates the provided invoice identifier has already been processed.
+	ErrMintInvoiceUsed = errors.New("mint: invoice already settled")
+	// ErrMintExpired indicates the voucher expiry timestamp has elapsed.
+	ErrMintExpired = errors.New("mint: voucher expired")
+	// ErrMintInvalidChainID indicates the voucher targets a different chain identifier.
+	ErrMintInvalidChainID = errors.New("mint: invalid chain id")
+)
+
+// MintVoucher represents the canonical payload that is signed off-chain by a mint authority.
+type MintVoucher struct {
+	InvoiceID string `json:"invoiceId"`
+	Recipient string `json:"recipient"`
+	Token     string `json:"token"`
+	Amount    string `json:"amount"`
+	ChainID   uint64 `json:"chainId"`
+	Expiry    int64  `json:"expiry"`
+}
+
+// CanonicalJSON returns the canonical JSON encoding used for signing vouchers.
+func (v MintVoucher) CanonicalJSON() ([]byte, error) {
+	normalizedAmount, err := v.AmountBig()
+	if err != nil {
+		return nil, err
+	}
+	canonical := struct {
+		InvoiceID string `json:"invoiceId"`
+		Recipient string `json:"recipient"`
+		Token     string `json:"token"`
+		Amount    string `json:"amount"`
+		ChainID   uint64 `json:"chainId"`
+		Expiry    int64  `json:"expiry"`
+	}{
+		InvoiceID: strings.TrimSpace(v.InvoiceID),
+		Recipient: strings.TrimSpace(v.Recipient),
+		Token:     strings.ToUpper(strings.TrimSpace(v.Token)),
+		Amount:    normalizedAmount.String(),
+		ChainID:   v.ChainID,
+		Expiry:    v.Expiry,
+	}
+	if canonical.InvoiceID == "" {
+		return nil, fmt.Errorf("invoiceId required")
+	}
+	if canonical.Recipient == "" {
+		return nil, fmt.Errorf("recipient required")
+	}
+	if canonical.Token == "" {
+		return nil, fmt.Errorf("token required")
+	}
+	if canonical.ChainID == 0 {
+		return nil, fmt.Errorf("chainId required")
+	}
+	if canonical.Expiry == 0 {
+		return nil, fmt.Errorf("expiry required")
+	}
+	return json.Marshal(canonical)
+}
+
+// Digest computes the keccak256 hash over the canonical JSON representation.
+func (v MintVoucher) Digest() ([]byte, error) {
+	canonical, err := v.CanonicalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return ethcrypto.Keccak256(canonical), nil
+}
+
+// AmountBig parses the Amount field and returns it as a big integer.
+func (v MintVoucher) AmountBig() (*big.Int, error) {
+	trimmed := strings.TrimSpace(v.Amount)
+	if trimmed == "" {
+		return nil, fmt.Errorf("amount required")
+	}
+	value, ok := new(big.Int).SetString(trimmed, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid amount: %s", v.Amount)
+	}
+	if value.Sign() <= 0 {
+		return nil, fmt.Errorf("amount must be positive")
+	}
+	return value, nil
+}
+
+// NormalizedToken returns the uppercase token symbol included in the voucher.
+func (v MintVoucher) NormalizedToken() string {
+	return strings.ToUpper(strings.TrimSpace(v.Token))
+}
+
+// TrimmedInvoiceID returns the trimmed invoice identifier.
+func (v MintVoucher) TrimmedInvoiceID() string {
+	return strings.TrimSpace(v.InvoiceID)
+}
+
+// TrimmedRecipient returns the trimmed recipient reference.
+func (v MintVoucher) TrimmedRecipient() string {
+	return strings.TrimSpace(v.Recipient)
+}

--- a/core/mint_test.go
+++ b/core/mint_test.go
@@ -1,0 +1,170 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	nhbstate "nhbchain/core/state"
+	"nhbchain/crypto"
+	"nhbchain/storage"
+)
+
+func newTestNode(t *testing.T) *Node {
+	t.Helper()
+	db := storage.NewMemDB()
+	t.Cleanup(func() { db.Close() })
+	validatorKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key: %v", err)
+	}
+	node, err := NewNode(db, validatorKey, "", true)
+	if err != nil {
+		t.Fatalf("new node: %v", err)
+	}
+	return node
+}
+
+func assignRole(t *testing.T, node *Node, role string, addr [20]byte) {
+	t.Helper()
+	node.stateMu.Lock()
+	defer node.stateMu.Unlock()
+	manager := nhbstate.NewManager(node.state.Trie)
+	if err := manager.SetRole(role, addr[:]); err != nil {
+		t.Fatalf("set role %s: %v", role, err)
+	}
+}
+
+func signVoucher(t *testing.T, key *crypto.PrivateKey, voucher MintVoucher) []byte {
+	t.Helper()
+	payload, err := voucher.CanonicalJSON()
+	if err != nil {
+		t.Fatalf("canonical json: %v", err)
+	}
+	sig, err := ethcrypto.Sign(ethcrypto.Keccak256(payload), key.PrivateKey)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return sig
+}
+
+func TestMintWithSignatureInvalidSigner(t *testing.T) {
+	node := newTestNode(t)
+
+	minterKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("minter key: %v", err)
+	}
+	assignRole(t, node, "MINTER_NHB", toAddress(minterKey))
+
+	rogueKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("rogue key: %v", err)
+	}
+	recipientKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("recipient key: %v", err)
+	}
+
+	voucher := MintVoucher{
+		InvoiceID: "inv-1",
+		Recipient: recipientKey.PubKey().Address().String(),
+		Token:     "NHB",
+		Amount:    "100",
+		ChainID:   MintChainID,
+		Expiry:    time.Now().Add(time.Hour).Unix(),
+	}
+	sig := signVoucher(t, rogueKey, voucher)
+	if _, err := node.MintWithSignature(&voucher, sig); err == nil || err != ErrMintInvalidSigner {
+		t.Fatalf("expected ErrMintInvalidSigner, got %v", err)
+	}
+}
+
+func TestMintWithSignatureReplayInvoice(t *testing.T) {
+	node := newTestNode(t)
+	minterKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("minter key: %v", err)
+	}
+	assignRole(t, node, "MINTER_NHB", toAddress(minterKey))
+	recipientKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("recipient key: %v", err)
+	}
+	voucher := MintVoucher{
+		InvoiceID: "inv-2",
+		Recipient: recipientKey.PubKey().Address().String(),
+		Token:     "NHB",
+		Amount:    "50",
+		ChainID:   MintChainID,
+		Expiry:    time.Now().Add(time.Hour).Unix(),
+	}
+	sig := signVoucher(t, minterKey, voucher)
+	txHash, err := node.MintWithSignature(&voucher, sig)
+	if err != nil {
+		t.Fatalf("mint failed: %v", err)
+	}
+	if txHash == "" {
+		t.Fatalf("expected tx hash")
+	}
+	if _, err := node.MintWithSignature(&voucher, sig); err == nil || err != ErrMintInvoiceUsed {
+		t.Fatalf("expected ErrMintInvoiceUsed, got %v", err)
+	}
+}
+
+func TestMintWithSignatureExpired(t *testing.T) {
+	node := newTestNode(t)
+	minterKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("minter key: %v", err)
+	}
+	assignRole(t, node, "MINTER_NHB", toAddress(minterKey))
+	recipientKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("recipient key: %v", err)
+	}
+	voucher := MintVoucher{
+		InvoiceID: "inv-exp",
+		Recipient: recipientKey.PubKey().Address().String(),
+		Token:     "NHB",
+		Amount:    "10",
+		ChainID:   MintChainID,
+		Expiry:    time.Now().Add(-time.Minute).Unix(),
+	}
+	sig := signVoucher(t, minterKey, voucher)
+	if _, err := node.MintWithSignature(&voucher, sig); err == nil || err != ErrMintExpired {
+		t.Fatalf("expected ErrMintExpired, got %v", err)
+	}
+}
+
+func TestMintWithSignatureWrongChain(t *testing.T) {
+	node := newTestNode(t)
+	minterKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("minter key: %v", err)
+	}
+	assignRole(t, node, "MINTER_NHB", toAddress(minterKey))
+	recipientKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("recipient key: %v", err)
+	}
+	voucher := MintVoucher{
+		InvoiceID: "inv-chain",
+		Recipient: recipientKey.PubKey().Address().String(),
+		Token:     "NHB",
+		Amount:    "5",
+		ChainID:   999999,
+		Expiry:    time.Now().Add(time.Hour).Unix(),
+	}
+	sig := signVoucher(t, minterKey, voucher)
+	if _, err := node.MintWithSignature(&voucher, sig); err == nil || err != ErrMintInvalidChainID {
+		t.Fatalf("expected ErrMintInvalidChainID, got %v", err)
+	}
+}
+
+func toAddress(key *crypto.PrivateKey) [20]byte {
+	var out [20]byte
+	copy(out[:], key.PubKey().Address().Bytes())
+	return out
+}

--- a/core/state/manager.go
+++ b/core/state/manager.go
@@ -60,6 +60,7 @@ var (
 	tradeEscrowIndexPrefix     = []byte("trade/index/escrow/")
 	identityAliasPrefix        = []byte("identity/alias/")
 	identityReversePrefix      = []byte("identity/reverse/")
+	mintInvoicePrefix          = []byte("mint/invoice/")
 )
 
 func LoyaltyGlobalStorageKey() []byte {
@@ -181,6 +182,15 @@ func roleKey(role string) []byte {
 
 func kvKey(key []byte) []byte {
 	return ethcrypto.Keccak256(key)
+}
+
+// MintInvoiceKey derives the storage key used to track processed invoice identifiers.
+func MintInvoiceKey(invoiceID string) []byte {
+	trimmed := strings.TrimSpace(invoiceID)
+	buf := make([]byte, len(mintInvoicePrefix)+len(trimmed))
+	copy(buf, mintInvoicePrefix)
+	copy(buf[len(mintInvoicePrefix):], trimmed)
+	return buf
 }
 
 func escrowStorageKey(id [32]byte) []byte {

--- a/docs/mint-settlement.md
+++ b/docs/mint-settlement.md
@@ -1,0 +1,118 @@
+# Mint Settlement RPC (`mint_with_sig`)
+
+## Overview
+The `mint_with_sig` JSON-RPC method finalises invoice-backed mints for both **NHB** and **ZNHB** tokens. The payments gateway
+obtains a signed voucher from an authorised minter (e.g. the NowPayments workflow) and submits it to the node. The node
+verifies the signature, enforces replay protection via the on-chain invoice ledger, and credits the recipient's balance while
+emitting an auditable `mint.settled` event.
+
+This flow keeps mint authority centralised to wallets with the `MINTER_NHB` or `MINTER_ZNHB` roles and provides a deterministic
+bridge between fiat settlements and on-chain supply adjustments.
+
+## Voucher schema
+| Field       | Type   | Description |
+|-------------|--------|-------------|
+| `invoiceId` | string | Unique identifier for the fiat invoice. Replays are rejected once persisted. |
+| `recipient` | string | NHB bech32 address or username. Usernames resolve through the identity module; otherwise the value must be an address. |
+| `token`     | string | Token symbol (`NHB` or `ZNHB`). Determines the required minter role. |
+| `amount`    | string | Base unit amount (integer). Must be strictly positive. |
+| `chainId`   | number | Must equal `187001` (`core.MintChainID`). Prevents cross-network replay. |
+| `expiry`    | number | UNIX timestamp (seconds). Must be greater than the node's current time when processed. |
+
+All string values are trimmed before processing and token symbols are normalised to upper-case.
+
+## Canonical signing payload
+* Canonical JSON is generated from the voucher with the fields above in the order shown.
+* The JSON bytes are hashed with `keccak256` and signed using secp256k1 (`ethcrypto.Sign`).
+* The signature is provided to the RPC method as a hex string (optionally prefixed with `0x`).
+* The node recovers the signer with `SigToPub` and verifies the corresponding address holds the required role:
+  * `NHB` -> `MINTER_NHB`
+  * `ZNHB` -> `MINTER_ZNHB`
+
+The payments gateway embeds this canonicalisation in `core.MintVoucher.CanonicalJSON`, ensuring every client signs the same
+payload auditors will verify.
+
+## Replay protection and persistence
+* Every successful mint records the `invoiceId` inside the state trie via `state.MintInvoiceKey`.
+* Subsequent submissions with the same invoice are rejected with `ErrMintInvoiceUsed` and a `codeDuplicateTx` RPC error.
+* Replays or attempts with expired vouchers (`ErrMintExpired`) and wrong chain IDs (`ErrMintInvalidChainID`) are surfaced as
+  `codeInvalidParams` errors.
+
+## Event emission
+A successful mint appends a `mint.settled` event:
+
+```
+{
+  "type": "mint.settled",
+  "attributes": {
+    "invoiceId": "inv-123",
+    "recipient": "nhb1...",
+    "token": "NHB",
+    "amount": "2500000000000000000",
+    "txHash": "0xabc123..."
+  }
+}
+```
+
+The `txHash` is derived from the canonical voucher payload and signature, providing downstream systems with a deterministic
+identifier for reconciliation.
+
+## Settlement flow with NowPayments
+1. A fiat invoice is created through NowPayments and stored in the payments gateway database.
+2. Once the webhook reports a finished payment, the gateway constructs a `core.MintVoucher` with:
+   * `invoiceId` set to the internal invoice record.
+   * `chainId` fixed to `187001` and `expiry` set to `now + 10 minutes` (configurable via `mintVoucherTTL`).
+   * Token amount sourced from the locked quote.
+3. The gateway signs the canonical JSON using the configured KMS key (holding the appropriate minter role).
+4. The RPC client submits `mint_with_sig(voucherJSON, signatureHex)` to the node.
+5. The node verifies state constraints, credits the recipient (address or resolved username), records the invoice usage and
+   emits `mint.settled`.
+6. The gateway records the returned `txHash` against the invoice, marking it as `minted` for downstream reporting.
+
+This alignment provides auditors and partners with a full trail from fiat settlement through to on-chain emission.
+
+## Audience notes
+### Auditors & Risk Teams
+* Replay-protected invoice ledger enables deterministic reconciliation.
+* Event payloads include recipient bech32 addresses and amounts for ledger matching.
+* Only addresses with explicit `MINTER_*` roles can authorise mints; role assignments live in the state trie.
+
+### Investors & Treasury
+* Chain ID guard rails prevent cross-network leakage of supply adjustments.
+* Expiring vouchers limit exposure to stale authorisations.
+* `mint.settled` events act as real-time notifications for treasury dashboards.
+
+### Customers & Support
+* Usernames are seamlessly resolved when the identity module is enabled; otherwise requests must provide a bech32 address.
+* Duplicate or expired vouchers return descriptive errors that can be surfaced to support tooling.
+
+### Developers & Integrators
+* Use `core.MintVoucher` helpers to build and sign vouchers to avoid subtle normalisation mismatches.
+* RPC request example:
+
+```
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "mint_with_sig",
+  "params": [
+    {
+      "invoiceId": "inv-123",
+      "recipient": "nhb1alice...",
+      "token": "NHB",
+      "amount": "2500000000000000000",
+      "chainId": 187001,
+      "expiry": 1733070300
+    },
+    "0x...signature..."
+  ]
+}
+```
+
+* Response:
+
+```
+{"jsonrpc":"2.0","id":7,"result":{"txHash":"0xdeadbeef..."}}
+```
+
+* On failure the node returns an `error` object with the mappings described above.

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -173,6 +173,8 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handleGetLatestBlocks(w, r, req)
 	case "nhb_getLatestTransactions":
 		s.handleGetLatestTransactions(w, r, req)
+	case "mint_with_sig":
+		s.handleMintWithSig(w, r, req)
 	case "loyalty_createBusiness":
 		s.handleLoyaltyCreateBusiness(w, r, req)
 	case "loyalty_setPaymaster":

--- a/rpc/mint_handlers.go
+++ b/rpc/mint_handlers.go
@@ -1,0 +1,80 @@
+package rpc
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"nhbchain/core"
+)
+
+func (s *Server) handleMintWithSig(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 2 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected voucher and signature", nil)
+		return
+	}
+
+	rawVoucher := bytes.TrimSpace(req.Params[0])
+	var voucherBytes []byte
+	if len(rawVoucher) == 0 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "voucher payload required", nil)
+		return
+	}
+	if rawVoucher[0] == '"' {
+		var voucherStr string
+		if err := json.Unmarshal(rawVoucher, &voucherStr); err != nil {
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid voucher payload", err.Error())
+			return
+		}
+		voucherBytes = []byte(strings.TrimSpace(voucherStr))
+	} else {
+		voucherBytes = rawVoucher
+	}
+	voucherBytes = bytes.TrimSpace(voucherBytes)
+	if len(voucherBytes) == 0 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "voucher payload required", nil)
+		return
+	}
+
+	var voucher core.MintVoucher
+	if err := json.Unmarshal(voucherBytes, &voucher); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid voucher payload", err.Error())
+		return
+	}
+
+	var sigHex string
+	if err := json.Unmarshal(req.Params[1], &sigHex); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid signature", err.Error())
+		return
+	}
+	sig := strings.TrimPrefix(strings.TrimSpace(sigHex), "0x")
+	if sig == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "signature required", nil)
+		return
+	}
+	signature, err := hex.DecodeString(sig)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid signature", err.Error())
+		return
+	}
+
+	txHash, err := s.node.MintWithSignature(&voucher, signature)
+	if err != nil {
+		switch {
+		case errors.Is(err, core.ErrMintInvalidSigner):
+			writeError(w, http.StatusUnauthorized, req.ID, codeUnauthorized, err.Error(), nil)
+		case errors.Is(err, core.ErrMintInvoiceUsed):
+			writeError(w, http.StatusConflict, req.ID, codeDuplicateTx, err.Error(), voucher.InvoiceID)
+		case errors.Is(err, core.ErrMintExpired), errors.Is(err, core.ErrMintInvalidChainID):
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		default:
+			writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "mint failed", err.Error())
+		}
+		return
+	}
+
+	writeResult(w, req.ID, map[string]string{"txHash": txHash})
+}

--- a/services/payments-gateway/node_client.go
+++ b/services/payments-gateway/node_client.go
@@ -9,20 +9,13 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"nhbchain/core"
 )
 
 // NodeClient exposes the minimal RPC surface required by the payments gateway.
 type NodeClient interface {
-	MintWithSig(ctx context.Context, voucher MintVoucher) (string, error)
-}
-
-// MintVoucher mirrors the payload expected by the node RPC method mint_with_sig.
-type MintVoucher struct {
-	Recipient string `json:"recipient"`
-	Token     string `json:"token"`
-	Amount    string `json:"amount"`
-	Nonce     string `json:"nonce"`
-	Signature string `json:"signature"`
+	MintWithSig(ctx context.Context, voucher core.MintVoucher, signature string) (string, error)
 }
 
 // RPCNodeClient is a lightweight JSON-RPC client.
@@ -44,14 +37,8 @@ func NewRPCNodeClient(baseURL, authToken string) *RPCNodeClient {
 	}
 }
 
-func (c *RPCNodeClient) MintWithSig(ctx context.Context, voucher MintVoucher) (string, error) {
-	params := []interface{}{map[string]interface{}{
-		"recipient": voucher.Recipient,
-		"token":     voucher.Token,
-		"amount":    voucher.Amount,
-		"nonce":     voucher.Nonce,
-		"signature": voucher.Signature,
-	}}
+func (c *RPCNodeClient) MintWithSig(ctx context.Context, voucher core.MintVoucher, signature string) (string, error) {
+	params := []interface{}{voucher, signature}
 	var result struct {
 		TxHash string `json:"txHash"`
 	}


### PR DESCRIPTION
## Summary
- add a canonical mint voucher structure with helpers and errors, plus a new mint.settled event
- implement node-side mint_with_sig processing with signature checks, role gating, invoice replay protection, and state updates
- expose the mint_with_sig RPC handler, update the payments gateway client/server to emit the new voucher payload, and document the end-to-end flow

## Testing
- go test ./...

------
https://chatgpt.com/codex/tasks/task_e_68d35b70d2bc832d9e429b10539c7e00