### PR TITLE
Implement epoch snapshots and rotation

### DIFF
--- a/core/epoch/config.go
+++ b/core/epoch/config.go
@@ -1,0 +1,55 @@
+package epoch
+
+import "fmt"
+
+// Config describes how epochs and validator rotation are managed.
+type Config struct {
+	// Length is the number of blocks that make up a single epoch. The value
+	// must be greater than zero.
+	Length uint64
+
+	// StakeWeight is the multiplier applied to validator stake when
+	// computing the composite weight W_i.
+	StakeWeight uint64
+
+	// EngagementWeight is the multiplier applied to validator engagement
+	// score when computing the composite weight W_i.
+	EngagementWeight uint64
+
+	// RotationEnabled toggles validator set rotation at epoch boundaries.
+	RotationEnabled bool
+
+	// MaxValidators specifies how many validators should remain active after
+	// rotation when RotationEnabled is true. A zero value means "no limit".
+	MaxValidators uint64
+
+	// SnapshotHistory controls how many historical epoch snapshots are
+	// retained in state. A zero value means that all snapshots are retained.
+	SnapshotHistory uint64
+}
+
+// DefaultConfig returns a conservative default configuration.
+func DefaultConfig() Config {
+	return Config{
+		Length:           100,
+		StakeWeight:      100,
+		EngagementWeight: 1,
+		RotationEnabled:  false,
+		MaxValidators:    0,
+		SnapshotHistory:  64,
+	}
+}
+
+// Validate ensures the configuration is self-consistent.
+func (c Config) Validate() error {
+	if c.Length == 0 {
+		return fmt.Errorf("epoch length must be greater than zero")
+	}
+	if c.StakeWeight == 0 && c.EngagementWeight == 0 {
+		return fmt.Errorf("at least one weight component must be non-zero")
+	}
+	if c.RotationEnabled && c.MaxValidators == 0 {
+		return fmt.Errorf("max validators must be greater than zero when rotation is enabled")
+	}
+	return nil
+}

--- a/core/epoch/types.go
+++ b/core/epoch/types.go
@@ -1,0 +1,90 @@
+package epoch
+
+import (
+	"encoding/hex"
+	"math/big"
+	"sort"
+)
+
+// Weight captures the composite weight calculation inputs and result for a
+// single validator.
+type Weight struct {
+	Address    []byte
+	Stake      *big.Int
+	Engagement uint64
+	Composite  *big.Int
+}
+
+// Snapshot stores the per-epoch weight calculations and the resulting validator
+// selection.
+type Snapshot struct {
+	Epoch       uint64
+	Height      uint64
+	FinalizedAt int64
+	TotalWeight *big.Int
+	Weights     []Weight
+	Selected    [][]byte
+}
+
+// Summary provides a lightweight view over an epoch for external consumers.
+type Summary struct {
+	Epoch            uint64
+	Height           uint64
+	FinalizedAt      int64
+	TotalWeight      *big.Int
+	ActiveValidators [][]byte
+	EligibleCount    int
+}
+
+// Summary converts a snapshot into its summary representation.
+func (s Snapshot) Summary() Summary {
+	selected := make([][]byte, len(s.Selected))
+	for i := range s.Selected {
+		selected[i] = append([]byte(nil), s.Selected[i]...)
+	}
+	return Summary{
+		Epoch:            s.Epoch,
+		Height:           s.Height,
+		FinalizedAt:      s.FinalizedAt,
+		TotalWeight:      new(big.Int).Set(s.TotalWeight),
+		ActiveValidators: selected,
+		EligibleCount:    len(s.Weights),
+	}
+}
+
+// ComputeCompositeWeight derives the composite weight for a validator.
+func ComputeCompositeWeight(cfg Config, stake *big.Int, engagement uint64) *big.Int {
+	weight := new(big.Int)
+	if stake != nil && cfg.StakeWeight > 0 {
+		component := new(big.Int).Set(stake)
+		component.Mul(component, new(big.Int).SetUint64(cfg.StakeWeight))
+		weight.Add(weight, component)
+	}
+	if cfg.EngagementWeight > 0 && engagement > 0 {
+		component := new(big.Int).SetUint64(engagement)
+		component.Mul(component, new(big.Int).SetUint64(cfg.EngagementWeight))
+		weight.Add(weight, component)
+	}
+	return weight
+}
+
+// SortWeights sorts weights by descending composite weight with a deterministic
+// tie-breaker on address bytes.
+func SortWeights(weights []Weight) {
+	sort.Slice(weights, func(i, j int) bool {
+		if weights[i].Composite == nil && weights[j].Composite == nil {
+			return hex.EncodeToString(weights[i].Address) < hex.EncodeToString(weights[j].Address)
+		}
+		if weights[i].Composite == nil {
+			return false
+		}
+		if weights[j].Composite == nil {
+			return true
+		}
+		cmp := weights[i].Composite.Cmp(weights[j].Composite)
+		if cmp == 0 {
+			return hex.EncodeToString(weights[i].Address) < hex.EncodeToString(weights[j].Address)
+		}
+		return cmp > 0
+	})
+}

--- a/core/epoch_state_test.go
+++ b/core/epoch_state_test.go
@@ -1,0 +1,229 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	"nhbchain/storage"
+	statetrie "nhbchain/storage/trie"
+)
+
+func newTestStateProcessor(t *testing.T) *StateProcessor {
+	t.Helper()
+	db := storage.NewMemDB()
+	t.Cleanup(db.Close)
+	trie, err := statetrie.NewTrie(db, nil)
+	if err != nil {
+		t.Fatalf("new trie: %v", err)
+	}
+	sp, err := NewStateProcessor(trie)
+	if err != nil {
+		t.Fatalf("state processor: %v", err)
+	}
+	cfg := sp.EpochConfig()
+	cfg.Length = 1
+	cfg.StakeWeight = 1
+	cfg.EngagementWeight = 1
+	cfg.SnapshotHistory = 16
+	if err := sp.SetEpochConfig(cfg); err != nil {
+		t.Fatalf("set epoch config: %v", err)
+	}
+	return sp
+}
+
+func seedValidator(t *testing.T, sp *StateProcessor, stake int64, engagement uint64) []byte {
+	t.Helper()
+	key, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	addr := key.PubKey().Address().Bytes()
+	account := &types.Account{
+		BalanceNHB:      big.NewInt(0),
+		BalanceZNHB:     big.NewInt(0),
+		Stake:           big.NewInt(stake),
+		EngagementScore: engagement,
+	}
+	if err := sp.setAccount(addr, account); err != nil {
+		t.Fatalf("set account: %v", err)
+	}
+	return addr
+}
+
+func TestEpochSnapshotDeterminism(t *testing.T) {
+	sp := newTestStateProcessor(t)
+
+	a := seedValidator(t, sp, 2000, 10)
+	b := seedValidator(t, sp, 3000, 5)
+	c := seedValidator(t, sp, 2500, 12)
+
+	if err := sp.ProcessBlockLifecycle(1, time.Now().Unix()); err != nil {
+		t.Fatalf("process block: %v", err)
+	}
+
+	snapshot, ok := sp.LatestEpochSnapshot()
+	if !ok {
+		t.Fatalf("expected epoch snapshot")
+	}
+	if len(snapshot.Weights) != 3 {
+		t.Fatalf("expected 3 weight entries, got %d", len(snapshot.Weights))
+	}
+
+	// Composite weights should be sorted in descending order.
+	if snapshot.Weights[0].Composite.Cmp(snapshot.Weights[1].Composite) < 0 ||
+		snapshot.Weights[1].Composite.Cmp(snapshot.Weights[2].Composite) < 0 {
+		t.Fatalf("weights not sorted descending: %v", snapshot.Weights)
+	}
+
+	// Ensure repeated retrieval is deterministic.
+	byEpoch, ok := sp.EpochSnapshot(snapshot.Epoch)
+	if !ok {
+		t.Fatalf("missing snapshot by epoch")
+	}
+	for i := range snapshot.Weights {
+		if snapshot.Weights[i].Composite.Cmp(byEpoch.Weights[i].Composite) != 0 {
+			t.Fatalf("composite mismatch at index %d", i)
+		}
+	}
+
+	if len(sp.EpochHistory()) != 1 {
+		t.Fatalf("expected 1 snapshot in history, got %d", len(sp.EpochHistory()))
+	}
+
+	if snapshot.Weights[0].Composite.Cmp(snapshot.Weights[1].Composite) == 0 &&
+		bytesEqual(snapshot.Weights[0].Address, snapshot.Weights[1].Address) {
+		t.Fatalf("tie-breaking failed to produce deterministic order")
+	}
+
+	// Ensure addresses tracked.
+	expected := [][]byte{b, c, a}
+	for i, addr := range expected {
+		if !bytesEqual(snapshot.Weights[i].Address, addr) {
+			t.Fatalf("unexpected ordering at %d", i)
+		}
+	}
+}
+
+func TestEpochTieBreaks(t *testing.T) {
+	sp := newTestStateProcessor(t)
+
+	cfg := sp.EpochConfig()
+	cfg.Length = 1
+	cfg.StakeWeight = 1
+	cfg.EngagementWeight = 0
+	if err := sp.SetEpochConfig(cfg); err != nil {
+		t.Fatalf("set epoch config: %v", err)
+	}
+
+	a := seedValidator(t, sp, 2000, 0)
+	b := seedValidator(t, sp, 2000, 0)
+
+	if bytesCompare(a, b) > 0 {
+		a, b = b, a
+	}
+
+	if err := sp.ProcessBlockLifecycle(1, time.Now().Unix()); err != nil {
+		t.Fatalf("process block: %v", err)
+	}
+
+	snapshot, ok := sp.LatestEpochSnapshot()
+	if !ok {
+		t.Fatalf("expected snapshot")
+	}
+	if len(snapshot.Weights) != 2 {
+		t.Fatalf("expected 2 weights, got %d", len(snapshot.Weights))
+	}
+	if !bytesEqual(snapshot.Weights[0].Address, a) || !bytesEqual(snapshot.Weights[1].Address, b) {
+		t.Fatalf("tie-break ordering incorrect")
+	}
+}
+
+func TestEpochRotationRespectsMinimumStake(t *testing.T) {
+	sp := newTestStateProcessor(t)
+	cfg := sp.EpochConfig()
+	cfg.RotationEnabled = true
+	cfg.MaxValidators = 2
+	if err := sp.SetEpochConfig(cfg); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+
+	eligible1 := seedValidator(t, sp, 2000, 10)
+	eligible2 := seedValidator(t, sp, 3000, 5)
+	_ = seedValidator(t, sp, 500, 100) // below minimum stake
+
+	if err := sp.ProcessBlockLifecycle(1, time.Now().Unix()); err != nil {
+		t.Fatalf("process block: %v", err)
+	}
+
+	snapshot, ok := sp.LatestEpochSnapshot()
+	if !ok {
+		t.Fatalf("expected snapshot")
+	}
+	if len(snapshot.Selected) != 2 {
+		t.Fatalf("expected 2 selected validators, got %d", len(snapshot.Selected))
+	}
+
+	set := map[string]struct{}{}
+	for _, addr := range snapshot.Selected {
+		set[string(addr)] = struct{}{}
+	}
+	if _, ok := set[string(eligible1)]; !ok {
+		t.Fatalf("validator 1 missing from rotation")
+	}
+	if _, ok := set[string(eligible2)]; !ok {
+		t.Fatalf("validator 2 missing from rotation")
+	}
+	if _, ok := set[string(eligible1)]; !ok || len(sp.ValidatorSet) != 2 {
+		t.Fatalf("expected validator set to contain exactly selected validators")
+	}
+	if _, ok := sp.ValidatorSet[string(eligible1)]; !ok {
+		t.Fatalf("validator 1 not in active set")
+	}
+	if _, ok := sp.ValidatorSet[string(eligible2)]; !ok {
+		t.Fatalf("validator 2 not in active set")
+	}
+	for addr := range sp.ValidatorSet {
+		stake := sp.ValidatorSet[addr]
+		if stake.Cmp(big.NewInt(MINIMUM_STAKE)) < 0 {
+			t.Fatalf("validator with insufficient stake persisted: %s", addr)
+		}
+	}
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func bytesCompare(a, b []byte) int {
+	min := len(a)
+	if len(b) < min {
+		min = len(b)
+	}
+	for i := 0; i < min; i++ {
+		if a[i] < b[i] {
+			return -1
+		}
+		if a[i] > b[i] {
+			return 1
+		}
+	}
+	switch {
+	case len(a) < len(b):
+		return -1
+	case len(a) > len(b):
+		return 1
+	default:
+		return 0
+	}
+}

--- a/core/epochs.go
+++ b/core/epochs.go
@@ -1,0 +1,350 @@
+package core
+
+import (
+	"math/big"
+
+	"nhbchain/core/epoch"
+	"nhbchain/core/events"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type epochWeightRecord struct {
+	Address    []byte
+	Stake      *big.Int
+	Engagement uint64
+	Composite  *big.Int
+}
+
+type epochSnapshotRecord struct {
+	Epoch       uint64
+	Height      uint64
+	FinalizedAt uint64
+	TotalWeight *big.Int
+	Weights     []epochWeightRecord
+	Selected    [][]byte
+}
+
+func (sp *StateProcessor) loadEpochHistory() error {
+	data, err := sp.Trie.Get(epochHistoryKey)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		sp.epochHistory = make([]epoch.Snapshot, 0)
+		return nil
+	}
+	var records []epochSnapshotRecord
+	if err := rlp.DecodeBytes(data, &records); err != nil {
+		return err
+	}
+	history := make([]epoch.Snapshot, len(records))
+	for i := range records {
+		rec := records[i]
+		total := copyBigInt(rec.TotalWeight)
+		weights := make([]epoch.Weight, len(rec.Weights))
+		for j := range rec.Weights {
+			weights[j] = epoch.Weight{
+				Address:    append([]byte(nil), rec.Weights[j].Address...),
+				Stake:      copyBigInt(rec.Weights[j].Stake),
+				Engagement: rec.Weights[j].Engagement,
+				Composite:  copyBigInt(rec.Weights[j].Composite),
+			}
+		}
+		selected := make([][]byte, len(rec.Selected))
+		for j := range rec.Selected {
+			selected[j] = append([]byte(nil), rec.Selected[j]...)
+		}
+		history[i] = epoch.Snapshot{
+			Epoch:       rec.Epoch,
+			Height:      rec.Height,
+			FinalizedAt: int64(rec.FinalizedAt),
+			TotalWeight: total,
+			Weights:     weights,
+			Selected:    selected,
+		}
+	}
+	sp.epochHistory = history
+	return nil
+}
+
+func (sp *StateProcessor) persistEpochHistory() error {
+	records := make([]epochSnapshotRecord, len(sp.epochHistory))
+	for i := range sp.epochHistory {
+		snapshot := sp.epochHistory[i]
+		weights := make([]epochWeightRecord, len(snapshot.Weights))
+		for j := range snapshot.Weights {
+			weights[j] = epochWeightRecord{
+				Address:    append([]byte(nil), snapshot.Weights[j].Address...),
+				Stake:      copyBigInt(snapshot.Weights[j].Stake),
+				Engagement: snapshot.Weights[j].Engagement,
+				Composite:  copyBigInt(snapshot.Weights[j].Composite),
+			}
+		}
+		selected := make([][]byte, len(snapshot.Selected))
+		for j := range snapshot.Selected {
+			selected[j] = append([]byte(nil), snapshot.Selected[j]...)
+		}
+		records[i] = epochSnapshotRecord{
+			Epoch:       snapshot.Epoch,
+			Height:      snapshot.Height,
+			FinalizedAt: uint64(snapshot.FinalizedAt),
+			TotalWeight: copyBigInt(snapshot.TotalWeight),
+			Weights:     weights,
+			Selected:    selected,
+		}
+	}
+	encoded, err := rlp.EncodeToBytes(records)
+	if err != nil {
+		return err
+	}
+	return sp.Trie.Update(epochHistoryKey, encoded)
+}
+
+func (sp *StateProcessor) pruneEpochHistory() {
+	limit := sp.epochConfig.SnapshotHistory
+	if limit == 0 {
+		return
+	}
+	if len(sp.epochHistory) <= int(limit) {
+		return
+	}
+	trim := len(sp.epochHistory) - int(limit)
+	if trim <= 0 {
+		return
+	}
+	sp.epochHistory = append([]epoch.Snapshot(nil), sp.epochHistory[trim:]...)
+}
+
+func (sp *StateProcessor) ProcessBlockLifecycle(height uint64, timestamp int64) error {
+	if sp.epochConfig.Length == 0 {
+		return nil
+	}
+	if height == 0 {
+		return nil
+	}
+	if height%sp.epochConfig.Length != 0 {
+		return nil
+	}
+	return sp.finalizeEpoch(height, timestamp)
+}
+
+func (sp *StateProcessor) finalizeEpoch(height uint64, timestamp int64) error {
+	weights, totalWeight, err := sp.computeEpochWeights()
+	if err != nil {
+		return err
+	}
+	epochNumber := height / sp.epochConfig.Length
+	selected := sp.selectValidators(weights)
+	snapshot := epoch.Snapshot{
+		Epoch:       epochNumber,
+		Height:      height,
+		FinalizedAt: timestamp,
+		TotalWeight: totalWeight,
+		Weights:     weights,
+		Selected:    selected,
+	}
+	sp.epochHistory = append(sp.epochHistory, snapshot)
+	sp.pruneEpochHistory()
+	if err := sp.persistEpochHistory(); err != nil {
+		return err
+	}
+	sp.emitEpochEvents(snapshot)
+	return sp.applyValidatorSelection(snapshot)
+}
+
+func (sp *StateProcessor) computeEpochWeights() ([]epoch.Weight, *big.Int, error) {
+	if sp.EligibleValidators == nil {
+		return []epoch.Weight{}, big.NewInt(0), nil
+	}
+	weights := make([]epoch.Weight, 0, len(sp.EligibleValidators))
+	total := big.NewInt(0)
+	minStake := big.NewInt(MINIMUM_STAKE)
+	for addrKey := range sp.EligibleValidators {
+		addrBytes := []byte(addrKey)
+		account, err := sp.getAccount(addrBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		if account.Stake == nil || account.Stake.Cmp(minStake) < 0 {
+			continue
+		}
+		composite := epoch.ComputeCompositeWeight(sp.epochConfig, account.Stake, account.EngagementScore)
+		weight := epoch.Weight{
+			Address:    append([]byte(nil), addrBytes...),
+			Stake:      copyBigInt(account.Stake),
+			Engagement: account.EngagementScore,
+			Composite:  composite,
+		}
+		weights = append(weights, weight)
+		total.Add(total, composite)
+	}
+	epoch.SortWeights(weights)
+	return weights, total, nil
+}
+
+func (sp *StateProcessor) selectValidators(weights []epoch.Weight) [][]byte {
+	if !sp.epochConfig.RotationEnabled || sp.epochConfig.MaxValidators == 0 {
+		selected := make([][]byte, len(weights))
+		for i := range weights {
+			selected[i] = append([]byte(nil), weights[i].Address...)
+		}
+		return selected
+	}
+	count := int(sp.epochConfig.MaxValidators)
+	if count <= 0 {
+		return [][]byte{}
+	}
+	selected := make([][]byte, 0, count)
+	minStake := big.NewInt(MINIMUM_STAKE)
+	for _, w := range weights {
+		if w.Stake == nil || w.Stake.Cmp(minStake) < 0 {
+			continue
+		}
+		selected = append(selected, append([]byte(nil), w.Address...))
+		if len(selected) == count {
+			break
+		}
+	}
+	return selected
+}
+
+func (sp *StateProcessor) applyValidatorSelection(snapshot epoch.Snapshot) error {
+	if sp.epochConfig.RotationEnabled {
+		newSet := make(map[string]*big.Int, len(snapshot.Selected))
+		minStake := big.NewInt(MINIMUM_STAKE)
+		for _, addr := range snapshot.Selected {
+			account, err := sp.getAccount(addr)
+			if err != nil {
+				return err
+			}
+			if account.Stake == nil || account.Stake.Cmp(minStake) < 0 {
+				continue
+			}
+			newSet[string(addr)] = copyBigInt(account.Stake)
+		}
+		sp.ValidatorSet = newSet
+		if err := sp.persistValidatorSet(); err != nil {
+			return err
+		}
+		rotation := events.ValidatorsRotated{Epoch: snapshot.Epoch, Validators: snapshot.Selected}
+		if payload := rotation.Event(); payload != nil {
+			sp.AppendEvent(payload)
+		}
+		return nil
+	}
+
+	desired := make(map[string]*big.Int, len(sp.EligibleValidators))
+	for k, v := range sp.EligibleValidators {
+		desired[k] = copyBigInt(v)
+	}
+	if !validatorMapsEqual(sp.ValidatorSet, desired) {
+		sp.ValidatorSet = desired
+		if err := sp.persistValidatorSet(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (sp *StateProcessor) emitEpochEvents(snapshot epoch.Snapshot) {
+	finalised := events.EpochFinalized{
+		Epoch:         snapshot.Epoch,
+		Height:        snapshot.Height,
+		FinalizedAt:   snapshot.FinalizedAt,
+		TotalWeight:   snapshot.TotalWeight,
+		EligibleCount: len(snapshot.Weights),
+	}
+	if payload := finalised.Event(); payload != nil {
+		sp.AppendEvent(payload)
+	}
+}
+
+func validatorMapsEqual(a, b map[string]*big.Int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		other, ok := b[k]
+		if !ok {
+			return false
+		}
+		if v == nil && other == nil {
+			continue
+		}
+		if v == nil || other == nil {
+			return false
+		}
+		if v.Cmp(other) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (sp *StateProcessor) EpochHistory() []epoch.Snapshot {
+	history := make([]epoch.Snapshot, len(sp.epochHistory))
+	for i := range sp.epochHistory {
+		history[i] = cloneEpochSnapshot(sp.epochHistory[i])
+	}
+	return history
+}
+
+func (sp *StateProcessor) EpochSnapshot(epochNumber uint64) (*epoch.Snapshot, bool) {
+	for i := range sp.epochHistory {
+		if sp.epochHistory[i].Epoch == epochNumber {
+			snapshot := cloneEpochSnapshot(sp.epochHistory[i])
+			return &snapshot, true
+		}
+	}
+	return nil, false
+}
+
+func (sp *StateProcessor) LatestEpochSnapshot() (*epoch.Snapshot, bool) {
+	if len(sp.epochHistory) == 0 {
+		return nil, false
+	}
+	snapshot := cloneEpochSnapshot(sp.epochHistory[len(sp.epochHistory)-1])
+	return &snapshot, true
+}
+
+func (sp *StateProcessor) LatestEpochSummary() (*epoch.Summary, bool) {
+	latest, ok := sp.LatestEpochSnapshot()
+	if !ok {
+		return nil, false
+	}
+	summary := latest.Summary()
+	return &summary, true
+}
+
+func cloneEpochSnapshot(snapshot epoch.Snapshot) epoch.Snapshot {
+	total := copyBigInt(snapshot.TotalWeight)
+	weights := make([]epoch.Weight, len(snapshot.Weights))
+	for i := range snapshot.Weights {
+		weights[i] = epoch.Weight{
+			Address:    append([]byte(nil), snapshot.Weights[i].Address...),
+			Stake:      copyBigInt(snapshot.Weights[i].Stake),
+			Engagement: snapshot.Weights[i].Engagement,
+			Composite:  copyBigInt(snapshot.Weights[i].Composite),
+		}
+	}
+	selected := make([][]byte, len(snapshot.Selected))
+	for i := range snapshot.Selected {
+		selected[i] = append([]byte(nil), snapshot.Selected[i]...)
+	}
+	return epoch.Snapshot{
+		Epoch:       snapshot.Epoch,
+		Height:      snapshot.Height,
+		FinalizedAt: snapshot.FinalizedAt,
+		TotalWeight: total,
+		Weights:     weights,
+		Selected:    selected,
+	}
+}
+
+func copyBigInt(value *big.Int) *big.Int {
+	if value == nil {
+		return big.NewInt(0)
+	}
+	return new(big.Int).Set(value)
+}

--- a/core/events/epoch.go
+++ b/core/events/epoch.go
@@ -1,0 +1,66 @@
+package events
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"nhbchain/core/types"
+)
+
+const (
+	EventEpochFinalized    = "epoch.finalized"
+	EventValidatorsRotated = "validators.rotated"
+)
+
+// EpochFinalized signals that an epoch boundary has been reached and the
+// composite weights have been recorded.
+type EpochFinalized struct {
+	Epoch         uint64
+	Height        uint64
+	FinalizedAt   int64
+	TotalWeight   *big.Int
+	EligibleCount int
+}
+
+// EventType implements the Event interface.
+func (EpochFinalized) EventType() string { return EventEpochFinalized }
+
+// Event converts the struct into a types.Event payload.
+func (e EpochFinalized) Event() *types.Event {
+	total := big.NewInt(0)
+	if e.TotalWeight != nil {
+		total = new(big.Int).Set(e.TotalWeight)
+	}
+	attrs := map[string]string{
+		"epoch":               strconv.FormatUint(e.Epoch, 10),
+		"height":              strconv.FormatUint(e.Height, 10),
+		"finalized_at":        strconv.FormatInt(e.FinalizedAt, 10),
+		"eligible_validators": strconv.Itoa(e.EligibleCount),
+		"total_weight":        total.String(),
+	}
+	return &types.Event{Type: EventEpochFinalized, Attributes: attrs}
+}
+
+// ValidatorsRotated captures a validator set update driven by epoch rotation.
+type ValidatorsRotated struct {
+	Epoch      uint64
+	Validators [][]byte
+}
+
+// EventType implements the Event interface.
+func (ValidatorsRotated) EventType() string { return EventValidatorsRotated }
+
+// Event converts the rotation into a types.Event payload.
+func (e ValidatorsRotated) Event() *types.Event {
+	encoded := make([]string, len(e.Validators))
+	for i := range e.Validators {
+		encoded[i] = "0x" + hex.EncodeToString(e.Validators[i])
+	}
+	attrs := map[string]string{
+		"epoch":      strconv.FormatUint(e.Epoch, 10),
+		"validators": strings.Join(encoded, ","),
+	}
+	return &types.Event{Type: EventValidatorsRotated, Attributes: attrs}
+}

--- a/docs/epochs.md
+++ b/docs/epochs.md
@@ -1,0 +1,225 @@
+# Epochs and Validator Rotation
+
+This document explains the epoch snapshot system introduced in the NHB Chain
+state processor. It is intended to serve the due-diligence needs of multiple
+stakeholders, including auditors, investors, developers, end-users, and
+regulators.
+
+## Overview
+
+* Every `epoch` is a fixed number of blocks (configurable, default `100`).
+* At the end of each epoch the chain records a snapshot of the composite weight
+  `W_i` for every eligible validator.
+* Snapshots are retained on-chain (default: latest 64 epochs) to provide an
+  auditable history of validator performance and eligibility.
+* Optionally, the active validator set is **rotated** to the top `N` validators
+  each epoch. Rotation is disabled by default.
+* Two structured events are emitted at epoch boundaries:
+  * `epoch.finalized` summarises the epoch and the computed weight totals.
+  * `validators.rotated` captures the list of validators promoted to the active
+    set when rotation is enabled.
+
+## Composite Weight Calculation
+
+The composite weight combines stake and engagement metrics:
+
+```
+W_i = (stake_i * stake_weight) + (engagement_i * engagement_weight)
+```
+
+Where:
+
+* `stake_i` is the validator's staked balance (ZapNHB).
+* `engagement_i` is the exponentially-weighted engagement score already tracked
+  by the protocol.
+* `stake_weight` and `engagement_weight` are positive integers configured per
+  network (defaults: `100` and `1` respectively).
+
+Only accounts whose stake is **greater than or equal to** the protocol minimum
+(`1000` ZapNHB) are considered. Validators below the minimum are pruned from the
+eligibility pool and from the active validator set.
+
+### Determinism and Tie-Breaking
+
+* Weights are sorted deterministically: higher composite weight first, ties
+  broken by ascending lexicographic order of the validator address bytes.
+* Dedicated tests verify deterministic ordering, tie-break behaviour, and
+  enforcement of the minimum stake threshold.
+
+## Configuration Surface
+
+The epoch system exposes the following configuration parameters (available via
+`StateProcessor.SetEpochConfig` / `Node.SetEpochConfig`):
+
+| Field              | Description                                                                     | Default |
+|--------------------|---------------------------------------------------------------------------------|---------|
+| `Length`           | Number of blocks per epoch (must be `> 0`).                                      | 100     |
+| `StakeWeight`      | Multiplier applied to the stake component.                                      | 100     |
+| `EngagementWeight` | Multiplier applied to the engagement component.                                | 1       |
+| `RotationEnabled`  | When `true`, the validator set is rotated each epoch.                           | false   |
+| `MaxValidators`    | Maximum validators retained after rotation (must be `> 0` when rotation on).    | 0       |
+| `SnapshotHistory`  | Number of epoch snapshots retained in state (`0` keeps the full history).       | 64      |
+
+Changing the configuration prunes the in-memory snapshot cache according to the
+new history length.
+
+## Epoch Lifecycle
+
+1. Transactions are processed normally during a block.
+2. Before the block is committed, the state processor checks whether the block
+   height is a multiple of the configured epoch length.
+3. If so, it computes composite weights for all eligible validators and builds a
+   snapshot.
+4. The snapshot is stored in state, the `epoch.finalized` event is emitted, and
+   (if enabled) the validator set is rotated to the top `MaxValidators` entries.
+5. The rotation emits the `validators.rotated` event.
+
+Snapshots capture:
+
+* Epoch number and the block height that finalized the epoch.
+* Timestamp (from the block header) at finalization.
+* The total composite weight and individual entries per validator (address,
+  stake, engagement, composite weight).
+* The list of validators selected for the next epoch (always all weights when
+  rotation is disabled).
+
+## JSON-RPC Endpoints
+
+Two JSON-RPC endpoints expose the new functionality.
+
+### `nhb_getEpochSummary`
+
+Returns a lightweight view of an epoch.
+
+**Parameters** (optional):
+
+* `epoch` (number) — specific epoch number to query. If omitted the latest
+  available epoch is returned.
+
+**Result fields:**
+
+| Field                     | Type     | Description                                                     |
+|---------------------------|----------|-----------------------------------------------------------------|
+| `epoch`                   | `uint64` | Epoch number.                                                   |
+| `height`                  | `uint64` | Block height that finalized the epoch.                          |
+| `finalizedAt`             | `int64`  | Block timestamp (Unix seconds).                                 |
+| `totalWeight`             | `string` | Decimal-encoded composite weight sum.                           |
+| `activeValidators`        | `[]string` | Hex addresses (0x-prefixed) in the active set after rotation. |
+| `eligibleValidatorCount`  | `int`    | Number of validators considered when computing weights.         |
+
+**Example:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "nhb_getEpochSummary",
+  "params": [42],
+  "id": 1
+}
+```
+
+### `nhb_getEpochSnapshot`
+
+Returns the full recorded snapshot for an epoch, including per-validator
+weights.
+
+**Parameters** (optional):
+
+* `epoch` (number) — specific epoch number. If omitted, the latest snapshot is
+  returned.
+
+**Result fields:**
+
+| Field            | Type              | Description                                         |
+|------------------|-------------------|-----------------------------------------------------|
+| `epoch`          | `uint64`          | Epoch number.                                       |
+| `height`         | `uint64`          | Block height that finalized the epoch.              |
+| `finalizedAt`    | `int64`           | Block timestamp (Unix seconds).                     |
+| `totalWeight`    | `string`          | Decimal composite weight sum.                       |
+| `weights`        | `[]object`        | Detailed entries per validator (see below).         |
+| `selectedValidators` | `[]string`    | Hex addresses that remain in the active set.        |
+
+Each element of `weights` contains:
+
+| Field             | Type     | Description                                   |
+|-------------------|----------|-----------------------------------------------|
+| `address`         | `string` | Validator address (0x-prefixed hex).          |
+| `stake`           | `string` | Decimal stake used in the calculation.        |
+| `engagement`      | `uint64` | Engagement score input.                       |
+| `compositeWeight` | `string` | Decimal composite weight for the validator.   |
+
+## Events
+
+### `epoch.finalized`
+
+Attributes:
+
+| Key                   | Description                                         |
+|-----------------------|-----------------------------------------------------|
+| `epoch`               | Epoch number.                                       |
+| `height`              | Block height finalising the epoch.                  |
+| `finalized_at`        | Block timestamp (Unix seconds).                     |
+| `eligible_validators` | Validators considered when computing weights.       |
+| `total_weight`        | Decimal representation of the aggregated weight.    |
+
+### `validators.rotated`
+
+Attributes:
+
+| Key         | Description                                           |
+|-------------|-------------------------------------------------------|
+| `epoch`     | Epoch number triggering the rotation.                 |
+| `validators`| Comma-separated list of 0x-prefixed validator addrs.  |
+
+An empty `validators` attribute indicates that rotation was disabled for the
+epoch or that no validators satisfied the minimum stake requirement.
+
+## Audience Notes
+
+### Auditors
+
+* Snapshots are deterministic and reproducible from state, enabling independent
+  verification.
+* Historical retention ensures traceability of validator eligibility changes.
+* Minimum stake enforcement prevents zero-weight or dust accounts from entering
+  the validator pool.
+
+### Investors
+
+* Composite weights surface both capital commitment (stake) and operational
+  engagement, providing a richer signal of validator quality.
+* Optional rotation rewards top performers while preserving transparency into
+  the selection process.
+
+### Developers & Implementers
+
+* Use `Node.SetEpochConfig` / `StateProcessor.SetEpochConfig` to customise epoch
+  length, weighting, rotation, and snapshot retention.
+* Snapshots are stored in the state trie under `epoch-history`, enabling light
+  clients or indexers to fetch data directly from state if required.
+* JSON-RPC endpoints offer machine-readable access without full state decoding.
+
+### Users
+
+* `nhb_getEpochSummary` provides a simple way to inspect current validators and
+  their aggregate weight.
+* Rotations (if enabled) are announced via events, allowing wallet UIs to alert
+  delegators when the validator set changes.
+
+### Regulators
+
+* The system exposes clear, immutable records of validator eligibility and
+  selection, aiding oversight and compliance checks.
+* Deterministic tie-break rules eliminate discretionary behaviour in validator
+  promotions.
+
+## Testing Guarantees
+
+Automated tests cover:
+
+* Deterministic ordering of composite weights.
+* Address-based tie-breaking when weights are equal.
+* Strict enforcement of the minimum stake threshold during rotation.
+
+These tests are located in `core/epoch_state_test.go` and executed as part of
+`go test ./...`.


### PR DESCRIPTION
## Summary
- add epoch configuration, weight calculation helpers, and storage for eligible validators
- finalize epochs with deterministic snapshots, optional top-N rotation, and structured events
- expose epoch JSON-RPC endpoints, add regression tests, and document the workflow for stakeholders

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d3cd937538832dab41acbb30aa6ade