### PR TITLE
feat: add swap gateway service

### DIFF
--- a/docs/swap/README.md
+++ b/docs/swap/README.md
@@ -1,0 +1,235 @@
+# Swap Gateway Technical Documentation
+
+## 1. Overview
+
+The Swap Gateway bridges fiat payments (e.g., USD) to on-chain ZNHB mints. It exposes a REST API that quotes conversion rates, creates payment orders, verifies payment webhooks, and submits signed mint vouchers to the NHB chain via JSON-RPC. This document covers architecture, message formats, operational flows, and guidance tailored to frontend engineers, auditors, regulators, investors, and consumers.
+
+## 2. Components
+
+| Component | Responsibility |
+| --- | --- |
+| Swap Gateway service | Hosts REST API, calculates quotes, manages order state, signs vouchers, and calls `swap_submitVoucher` on the node. |
+| Price source | Determines fiat → ZNHB rate. Development uses a fixed price (`fixed:<rate>`); production may integrate CoinGecko or oracles. |
+| Order store | In-memory map (pluggable for SQLite/Postgres) keyed by `reference`/`orderId` for idempotency. Tracks status transitions. |
+| Node RPC | Receives vouchers and signatures. Executes minting via on-chain module introduced in SWAP-2. |
+| NowPayments (or equivalent fiat processor) | Sends payment webhook with HMAC-authenticated payload once the fiat invoice is paid. |
+
+## 3. Environment Configuration
+
+| Variable | Description |
+| --- | --- |
+| `SWAP_PORT` | HTTP listen port (default `8090`). |
+| `SWAP_NODE_RPC_URL` | JSON-RPC endpoint for submitting vouchers. |
+| `SWAP_CHAIN_ID` | NHB chain ID for voucher hashing. |
+| `SWAP_PAYMENT_HMAC_SECRET` | Shared secret for verifying webhook HMAC. Empty disables verification (dev only). |
+| `SWAP_PRICE_SOURCE` | Price backend spec (e.g., `fixed:0.10`). |
+| `MINTER_ZNHB_ADDRESS` | Bech32 NHB address of the signer. Must match recovered signature. |
+| `MINTER_ZNHB_PRIVKEY` | Hex-encoded secp256k1 private key used to sign vouchers (KMS/HSM recommended in prod). |
+
+## 4. REST API Endpoints
+
+### 4.1 `POST /swap/quote`
+
+**Request**
+```json
+{
+  "fiat": "USD",
+  "amountFiat": "100.00"
+}
+```
+
+**Response**
+```json
+{
+  "fiat": "USD",
+  "amountFiat": "100.00",
+  "rate": "0.10",
+  "znHB": "1000000000000000000000"
+}
+```
+
+The gateway parses decimal inputs, enforces USD for the fixed source, and converts the fiat amount to wei (`amountFiat / rate * 1e18`). Non-integral conversions trigger an error.
+
+### 4.2 `POST /swap/order`
+
+Creates or retrieves an order keyed by `reference` for idempotency.
+
+**Request**
+```json
+{
+  "fiat": "USD",
+  "amountFiat": "100.00",
+  "recipient": "nhb1...",
+  "reference": "SWP_123"
+}
+```
+
+**Response**
+```json
+{
+  "orderId": "SWP_123",
+  "payUrl": "https://pay.dev/checkout/SWP_123",
+  "expected": "100.00",
+  "recipient": "nhb1...",
+  "fiat": "USD",
+  "amountWei": "1000000000000000000000",
+  "rate": "0.10"
+}
+```
+
+Orders start with status `PENDING`. In production, `payUrl` should point to the fiat processor checkout session.
+
+### 4.3 `POST /webhooks/payment`
+
+Processes payment notifications after HMAC verification.
+
+**Headers**
+```
+X-HMAC: <hex(hmac_sha256(body, SWAP_PAYMENT_HMAC_SECRET))>
+```
+
+**Body**
+```json
+{
+  "orderId": "SWP_123",
+  "fiat": "USD",
+  "amountFiat": "100.00",
+  "paid": true,
+  "txRef": "NOWP-001"
+}
+```
+
+Workflow:
+1. HMAC validation (required for non-empty secret).
+2. Order lookup and state validation (`PENDING` or `PAID`).
+3. Voucher assembly (random nonce, `expiry = now + 15 min`).
+4. secp256k1 signature using minter key. Recovered signer must equal `MINTER_ZNHB_ADDRESS`.
+5. JSON-RPC request `swap_submitVoucher` with payload `{"voucher": <VoucherV1>, "sig": "0x..."}`.
+6. Order status updates to `MINT_SUBMITTED` with minted wei recorded.
+
+**Response**
+```json
+{
+  "ok": true,
+  "submitted": true,
+  "minted": "1000000000000000000000"
+}
+```
+
+### 4.4 `GET /orders/{orderId}`
+
+Returns order snapshot (status, minted amount, pay URL, etc.). Possible statuses: `PENDING`, `PAID`, `MINT_SUBMITTED`, `MINTED` (reserved for future confirmation events).
+
+## 5. Voucher Specification
+
+```json
+{
+  "domain": "NHB_SWAP_VOUCHER_V1",
+  "chainId": 187001,
+  "token": "ZNHB",
+  "recipient": "nhb1...",
+  "amount": "1000000000000000000000",
+  "fiat": "USD",
+  "fiatAmount": "100.00",
+  "rate": "0.10",
+  "orderId": "SWP_123",
+  "nonce": "d6b2f3c4...",
+  "expiry": 1735689600
+}
+```
+
+Hashing uses the deterministic string template:
+```
+NHB_SWAP_VOUCHER_V1|chain=<chainId>|token=<token>|to=<recipient_hex>|amount=<amount>|fiat=<fiat>|fiatAmt=<fiatAmount>|rate=<rate>|order=<orderId>|nonce=<nonce>|exp=<expiry>
+```
+
+`recipient_hex` is the 20-byte NHB address decoded from bech32 and lowercased hex. The SHA3 Keccak-256 digest feeds secp256k1 signing. Gateways must reject signatures that do not recover to `MINTER_ZNHB_ADDRESS`.
+
+## 6. JSON-RPC Submission
+
+`swap_submitVoucher` request:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "swap_submitVoucher",
+  "params": [
+    {
+      "voucher": { ... },
+      "sig": "0x<65-byte-signature>"
+    }
+  ]
+}
+```
+
+Responses follow JSON-RPC 2.0 semantics. Any non-200 status or RPC error must be surfaced to webhook callers for retry logic. Future iterations may include idempotency tokens or asynchronous mint confirmations.
+
+## 7. Order Lifecycle
+
+1. **Quote** — Frontend fetches conversion to display expected ZNHB output.
+2. **Order creation** — Frontend submits recipient address and reference. Gateway stores pending order and returns `payUrl`.
+3. **Fiat payment** — Customer completes checkout on NowPayments (or chosen PSP).
+4. **Webhook** — PSP POSTs to `/webhooks/payment`. Gateway verifies HMAC, signs voucher, submits to node, updates status to `MINT_SUBMITTED`.
+5. **Mint finalization** — Node mints ZNHB and will emit events; future extensions can poll or subscribe to confirm and mark order `MINTED`.
+
+## 8. Frontend Implementation Guide
+
+### 8.1 UX Flow
+
+1. **Collect recipient** — Accept NHB bech32 address or username (optionally resolve via identity module).
+2. **Amount entry** — Let users input fiat amount in USD. Fetch `/swap/quote` to display minted ZNHB.
+3. **Order create** — POST `/swap/order` with a unique `reference` (UUID). Store `orderId` and `payUrl` from response.
+4. **Redirect to PSP** — Launch NowPayments checkout using `payUrl`. Provide instructions for wallet credit timeline.
+5. **Status polling** — Poll `/orders/{orderId}` to surface transitions (`PENDING` → `MINT_SUBMITTED`). Once minted, display minted wei (convert to ZNHB with 18 decimals).
+6. **Error handling** — On quote/order failures, show user-friendly message (e.g., unsupported fiat, invalid address). For webhook errors, provide support fallback as backend will log failure.
+
+### 8.2 Security Considerations for Frontend
+
+- Validate bech32 addresses client-side before calling the gateway.
+- Generate cryptographically random `reference` to avoid collisions.
+- Use HTTPS and include CSRF protections if embedding order creation in web apps.
+- Do not expose minter private key or node credentials to the browser; all signing occurs server-side.
+
+## 9. Operational & Security Notes
+
+- **HMAC secrets** should be rotated regularly. Failed verifications respond with HTTP 401.
+- **Key custody** — Production deployments should load `MINTER_ZNHB_PRIVKEY` from HSM/KMS. The reference implementation uses env vars for dev.
+- **Rate validation** — For live price feeds, enforce rate freshness and maximum slippage to protect consumers.
+- **Observability** — Enable structured logging for order events, webhook processing, and RPC interactions. Consider Prometheus metrics for monitoring latency and errors.
+- **Idempotency** — Duplicate webhooks must be safe. The store transition guard rejects already-processed orders.
+
+## 10. Compliance & Transparency (Auditors, Regulators, Investors, Consumers)
+
+- **Traceability** — Each voucher includes fiat amount, rate, and PSP reference (`orderId`, `txRef`). Logs should correlate voucher submissions with fiat receipts.
+- **Audit trails** — Persist order state transitions and voucher payloads in durable storage (extend `orderStore` to SQLite/Postgres). Attach PSP transaction IDs and blockchain tx hashes once available.
+- **Consumer disclosures** — Communicate conversion rate, fees, mint timing, and refund policies at checkout and in post-payment confirmations.
+- **Regulatory controls** — Integrate KYC/AML screening upstream of order creation if required. Enforce per-user limits and sanction screening before submitting vouchers.
+- **Risk management** — Implement PSP webhook retry validation (e.g., replay protection with nonce expiry) and monitor for mismatched amounts or fiat currencies.
+
+## 11. Extensibility
+
+- **Alternative price sources** — Implement additional `priceSource` strategies (CoinGecko, oracle) in `quote.go` while preserving interface contract.
+- **Persistent storage** — Swap in SQLite/Postgres by implementing an `orderStore` backed by database transactions.
+- **Asynchronous mint confirmation** — Subscribe to node events to transition `MINT_SUBMITTED` → `MINTED` and notify clients.
+- **Multiple tokens** — Parameterize `token` and `rate` logic to support other NHB assets.
+
+## 12. Testing & Local Development
+
+1. `go test ./services/swap-gateway/...` — runs unit tests (quote math, HMAC verification, voucher hashing & signing, webhook dry-run).
+2. `go run ./services/swap-gateway` — launches local server on `SWAP_PORT`.
+3. `curl` examples:
+   - `curl -X POST localhost:8090/swap/quote -d '{"fiat":"USD","amountFiat":"100.00"}' -H 'Content-Type: application/json'`
+   - `curl -X POST localhost:8090/swap/order ...`
+   - Simulate webhook by computing HMAC with `SWAP_PAYMENT_HMAC_SECRET` and POSTing to `/webhooks/payment`.
+
+## 13. Glossary
+
+- **ZNHB** — Stable asset minted on NHB chain.
+- **Voucher** — Off-chain signed instruction authorizing mint.
+- **PSP** — Payment Service Provider (e.g., NowPayments).
+- **Wei** — Smallest unit (1e-18 ZNHB).
+
+## 14. Change Log
+
+- **SWAP-1** — Introduced Swap Gateway with quoting, order creation, webhook signing, voucher submission, and documentation.
+

--- a/services/swap-gateway/client_node.go
+++ b/services/swap-gateway/client_node.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// VoucherSubmitter abstracts voucher submission for easier testing.
+type VoucherSubmitter interface {
+	SubmitVoucher(ctx context.Context, voucher VoucherV1, sigHex string) error
+}
+
+type NodeClient struct {
+	url        string
+	httpClient *http.Client
+}
+
+func NewNodeClient(url string) *NodeClient {
+	return &NodeClient{
+		url:        url,
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+type rpcRequest struct {
+	JSONRPC string        `json:"jsonrpc"`
+	ID      int           `json:"id"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *rpcError       `json:"error"`
+}
+
+func (c *NodeClient) SubmitVoucher(ctx context.Context, voucher VoucherV1, sigHex string) error {
+	payload := rpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "swap_submitVoucher",
+		Params: []interface{}{
+			map[string]interface{}{
+				"voucher": voucher,
+				"sig":     sigHex,
+			},
+		},
+	}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(buf))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("rpc request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var rpcResp rpcResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if rpcResp.Error != nil {
+		return fmt.Errorf("rpc error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+var _ VoucherSubmitter = (*NodeClient)(nil)

--- a/services/swap-gateway/main.go
+++ b/services/swap-gateway/main.go
@@ -1,0 +1,449 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type orderStatus string
+
+const (
+	orderStatusPending       orderStatus = "PENDING"
+	orderStatusPaid          orderStatus = "PAID"
+	orderStatusMintSubmitted orderStatus = "MINT_SUBMITTED"
+	orderStatusMinted        orderStatus = "MINTED"
+)
+
+type order struct {
+	OrderID    string      `json:"orderId"`
+	Reference  string      `json:"reference"`
+	Fiat       string      `json:"fiat"`
+	AmountFiat string      `json:"amountFiat"`
+	Recipient  string      `json:"recipient"`
+	Rate       string      `json:"rate"`
+	AmountWei  string      `json:"amountWei"`
+	PayURL     string      `json:"payUrl"`
+	Status     orderStatus `json:"status"`
+	MintedWei  string      `json:"minted"`
+	TxRef      string      `json:"txRef"`
+}
+
+type orderStore struct {
+	mu     sync.RWMutex
+	orders map[string]*order
+}
+
+func newOrderStore() *orderStore {
+	return &orderStore{orders: make(map[string]*order)}
+}
+
+func (s *orderStore) get(id string) (*order, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ord, ok := s.orders[id]
+	if !ok {
+		return nil, false
+	}
+	dup := *ord
+	return &dup, true
+}
+
+func (s *orderStore) createOrGet(ord *order) (*order, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, ok := s.orders[ord.Reference]
+	if ok {
+		if existing.AmountFiat != ord.AmountFiat || existing.Fiat != ord.Fiat || existing.Recipient != ord.Recipient {
+			return nil, false, fmt.Errorf("order reference %s already exists with different details", ord.Reference)
+		}
+		dup := *existing
+		return &dup, true, nil
+	}
+	s.orders[ord.Reference] = ord
+	dup := *ord
+	return &dup, false, nil
+}
+
+func (s *orderStore) update(id string, fn func(*order) error) (*order, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, ok := s.orders[id]
+	if !ok {
+		return nil, fmt.Errorf("order %s not found", id)
+	}
+	if err := fn(existing); err != nil {
+		return nil, err
+	}
+	dup := *existing
+	return &dup, nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("swap gateway failed: %v", err)
+	}
+}
+
+func run() error {
+	port := getEnv("SWAP_PORT", "8090")
+	nodeURL := getEnv("SWAP_NODE_RPC_URL", "http://127.0.0.1:8545")
+	chainIDStr := getEnv("SWAP_CHAIN_ID", "187001")
+	hmacSecret := os.Getenv("SWAP_PAYMENT_HMAC_SECRET")
+	priceSource := getEnv("SWAP_PRICE_SOURCE", "fixed:0.10")
+	minterAddr := getEnv("MINTER_ZNHB_ADDRESS", "")
+	minterPriv := getEnv("MINTER_ZNHB_PRIVKEY", "")
+
+	if minterAddr == "" || minterPriv == "" {
+		return errors.New("MINTER_ZNHB_ADDRESS and MINTER_ZNHB_PRIVKEY must be set")
+	}
+
+	chainID, err := strconv.ParseInt(chainIDStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid SWAP_CHAIN_ID: %w", err)
+	}
+
+	quoter, err := NewQuoter(priceSource)
+	if err != nil {
+		return fmt.Errorf("init quoter: %w", err)
+	}
+
+	store := newOrderStore()
+	client := NewNodeClient(nodeURL)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/swap/quote", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		handleQuote(w, r, quoter)
+	})
+	mux.HandleFunc("/swap/order", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		handleOrder(w, r, quoter, store)
+	})
+	mux.HandleFunc("/webhooks/payment", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		handlePaymentWebhook(w, r, store, quoter, client, chainID, minterAddr, minterPriv, hmacSecret)
+	})
+	mux.HandleFunc("/orders/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		orderID := strings.TrimPrefix(r.URL.Path, "/orders/")
+		if orderID == "" {
+			http.Error(w, "orderId required", http.StatusBadRequest)
+			return
+		}
+		handleGetOrder(w, r, store, orderID)
+	})
+
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: loggingMiddleware(mux),
+	}
+
+	log.Printf("swap gateway listening on %s", srv.Addr)
+	return srv.ListenAndServe()
+}
+
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
+	})
+}
+
+type quoteRequest struct {
+	Fiat       string `json:"fiat"`
+	AmountFiat string `json:"amountFiat"`
+}
+
+type quoteResponse struct {
+	Fiat       string `json:"fiat"`
+	AmountFiat string `json:"amountFiat"`
+	Rate       string `json:"rate"`
+	AmountWei  string `json:"znHB"`
+}
+
+func handleQuote(w http.ResponseWriter, r *http.Request, quoter *Quoter) {
+	var req quoteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if req.Fiat == "" || req.AmountFiat == "" {
+		http.Error(w, "fiat and amountFiat required", http.StatusBadRequest)
+		return
+	}
+	rate, amountWei, err := quoter.Quote(r.Context(), req.Fiat, req.AmountFiat)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, quoteResponse{Fiat: req.Fiat, AmountFiat: req.AmountFiat, Rate: rate, AmountWei: amountWei})
+}
+
+type orderRequest struct {
+	Fiat       string `json:"fiat"`
+	AmountFiat string `json:"amountFiat"`
+	Recipient  string `json:"recipient"`
+	Reference  string `json:"reference"`
+}
+
+type orderResponse struct {
+	OrderID   string `json:"orderId"`
+	PayURL    string `json:"payUrl"`
+	Expected  string `json:"expected"`
+	Recipient string `json:"recipient"`
+	Fiat      string `json:"fiat"`
+	AmountWei string `json:"amountWei"`
+	Rate      string `json:"rate"`
+}
+
+func handleOrder(w http.ResponseWriter, r *http.Request, quoter *Quoter, store *orderStore) {
+	var req orderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if req.Fiat == "" || req.AmountFiat == "" || req.Recipient == "" || req.Reference == "" {
+		http.Error(w, "fiat, amountFiat, recipient, reference required", http.StatusBadRequest)
+		return
+	}
+	if err := validateRecipient(req.Recipient); err != nil {
+		http.Error(w, fmt.Sprintf("invalid recipient: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	rate, amountWei, err := quoter.Quote(r.Context(), req.Fiat, req.AmountFiat)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ord := &order{
+		OrderID:    req.Reference,
+		Reference:  req.Reference,
+		Fiat:       req.Fiat,
+		AmountFiat: req.AmountFiat,
+		Recipient:  req.Recipient,
+		Rate:       rate,
+		AmountWei:  amountWei,
+		PayURL:     fmt.Sprintf("https://pay.dev/checkout/%s", req.Reference),
+		Status:     orderStatusPending,
+	}
+
+	stored, existed, err := store.createOrGet(ord)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if !existed {
+		log.Printf("created order %s for %s %s", stored.OrderID, stored.Fiat, stored.AmountFiat)
+	}
+
+	resp := orderResponse{
+		OrderID:   stored.OrderID,
+		PayURL:    stored.PayURL,
+		Expected:  stored.AmountFiat,
+		Recipient: stored.Recipient,
+		Fiat:      stored.Fiat,
+		AmountWei: stored.AmountWei,
+		Rate:      stored.Rate,
+	}
+	writeJSON(w, resp)
+}
+
+func validateRecipient(recipient string) error {
+	if recipient == "" {
+		return errors.New("recipient empty")
+	}
+	_, err := decodeRecipient(recipient)
+	return err
+}
+
+type paymentWebhook struct {
+	OrderID    string `json:"orderId"`
+	Fiat       string `json:"fiat"`
+	AmountFiat string `json:"amountFiat"`
+	Paid       bool   `json:"paid"`
+	TxRef      string `json:"txRef"`
+}
+
+type webhookResponse struct {
+	OK        bool   `json:"ok"`
+	Submitted bool   `json:"submitted"`
+	Minted    string `json:"minted"`
+}
+
+func handlePaymentWebhook(w http.ResponseWriter, r *http.Request, store *orderStore, quoter *Quoter, client VoucherSubmitter, chainID int64, minterAddr, minterPriv, hmacSecret string) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	if hmacSecret != "" {
+		sig := r.Header.Get("X-HMAC")
+		if !VerifyIPNHMAC(hmacSecret, body, sig) {
+			http.Error(w, "invalid HMAC", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	var payload paymentWebhook
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	if payload.OrderID == "" {
+		http.Error(w, "orderId required", http.StatusBadRequest)
+		return
+	}
+
+	if !payload.Paid {
+		http.Error(w, "payment not completed", http.StatusBadRequest)
+		return
+	}
+
+	ord, err := store.update(payload.OrderID, func(o *order) error {
+		if o.Status != orderStatusPending && o.Status != orderStatusPaid {
+			return fmt.Errorf("order %s already processed", o.OrderID)
+		}
+		if payload.Fiat != "" && !strings.EqualFold(payload.Fiat, o.Fiat) {
+			return fmt.Errorf("fiat mismatch: %s != %s", payload.Fiat, o.Fiat)
+		}
+		if payload.AmountFiat != "" && payload.AmountFiat != o.AmountFiat {
+			return fmt.Errorf("amount mismatch: %s != %s", payload.AmountFiat, o.AmountFiat)
+		}
+		o.Status = orderStatusPaid
+		o.TxRef = payload.TxRef
+		return nil
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	mintedWei := ord.AmountWei
+	rate := ord.Rate
+
+	nonce, err := randomHex(16)
+	if err != nil {
+		http.Error(w, "failed to create nonce", http.StatusInternalServerError)
+		return
+	}
+	expiry := time.Now().Add(15 * time.Minute).Unix()
+
+	voucher := VoucherV1{
+		Domain:     "NHB_SWAP_VOUCHER_V1",
+		ChainID:    chainID,
+		Token:      "ZNHB",
+		Recipient:  ord.Recipient,
+		Amount:     mintedWei,
+		Fiat:       ord.Fiat,
+		FiatAmount: ord.AmountFiat,
+		Rate:       rate,
+		OrderID:    ord.OrderID,
+		Nonce:      nonce,
+		Expiry:     expiry,
+	}
+
+	sigBytes, err := SignVoucher(voucher, minterPriv)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("sign voucher: %v", err), http.StatusInternalServerError)
+		return
+	}
+	signerAddr, err := RecoverVoucherSignerAddress(voucher, sigBytes)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("recover signer: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if !strings.EqualFold(signerAddr, minterAddr) {
+		http.Error(w, "signer mismatch", http.StatusInternalServerError)
+		return
+	}
+	sigHex := "0x" + hex.EncodeToString(sigBytes)
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	if err := client.SubmitVoucher(ctx, voucher, sigHex); err != nil {
+		http.Error(w, fmt.Sprintf("submit voucher: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	if _, err := store.update(ord.OrderID, func(o *order) error {
+		o.Status = orderStatusMintSubmitted
+		o.MintedWei = mintedWei
+		return nil
+	}); err != nil {
+		log.Printf("warn: failed to update order after submit: %v", err)
+	}
+
+	writeJSON(w, webhookResponse{OK: true, Submitted: true, Minted: mintedWei})
+}
+
+func handleGetOrder(w http.ResponseWriter, r *http.Request, store *orderStore, orderID string) {
+	ord, ok := store.get(orderID)
+	if !ok {
+		http.Error(w, "order not found", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, ord)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("write response error: %v", err)
+	}
+}
+
+func randomHex(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func getEnv(key, def string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return def
+}
+
+func decodeRecipient(recipient string) ([]byte, error) {
+	addr, err := decodeBech32Address(recipient)
+	if err != nil {
+		return nil, err
+	}
+	return addr, nil
+}
+
+// decodeBech32Address is defined in voucher.go to avoid duplication.

--- a/services/swap-gateway/nowpayments.go
+++ b/services/swap-gateway/nowpayments.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// VerifyIPNHMAC ensures the webhook payload integrity against the shared secret.
+func VerifyIPNHMAC(secret string, body []byte, provided string) bool {
+	if secret == "" {
+		return true
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expected := mac.Sum(nil)
+	cleaned := strings.TrimSpace(provided)
+	cleaned = strings.TrimPrefix(strings.ToLower(cleaned), "0x")
+	if len(cleaned) == 0 {
+		return false
+	}
+	got, err := hex.DecodeString(cleaned)
+	if err != nil {
+		return false
+	}
+	return hmac.Equal(expected, got)
+}

--- a/services/swap-gateway/nowpayments_test.go
+++ b/services/swap-gateway/nowpayments_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func TestVerifyIPNHMAC(t *testing.T) {
+	secret := "super-secret"
+	body := []byte(`{"orderId":"SWP_1"}`)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	sig := hex.EncodeToString(mac.Sum(nil))
+
+	if !VerifyIPNHMAC(secret, body, sig) {
+		t.Fatalf("expected verification to pass")
+	}
+
+	if VerifyIPNHMAC(secret, body, "deadbeef") {
+		t.Fatalf("expected verification to fail")
+	}
+}

--- a/services/swap-gateway/quote.go
+++ b/services/swap-gateway/quote.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+var weiMultiplier = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+
+// Quoter provides fiat to ZNHB quoting using a configured price source.
+type Quoter struct {
+	source priceSource
+}
+
+type priceSource interface {
+	Rate(ctx context.Context, fiat string) (*big.Rat, string, error)
+}
+
+type fixedPriceSource struct {
+	rate    *big.Rat
+	rateStr string
+}
+
+// NewQuoter constructs a quoter from the SWAP_PRICE_SOURCE env string.
+func NewQuoter(cfg string) (*Quoter, error) {
+	parts := strings.SplitN(cfg, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid price source %q", cfg)
+	}
+	switch strings.ToLower(strings.TrimSpace(parts[0])) {
+	case "fixed":
+		rateStr := strings.TrimSpace(parts[1])
+		rate, err := parseDecimal(rateStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid fixed price: %w", err)
+		}
+		if rate.Cmp(big.NewRat(0, 1)) <= 0 {
+			return nil, fmt.Errorf("rate must be positive")
+		}
+		return &Quoter{source: &fixedPriceSource{rate: rate, rateStr: rateStr}}, nil
+	default:
+		return nil, fmt.Errorf("unsupported price source %q", parts[0])
+	}
+}
+
+func (q *Quoter) Quote(ctx context.Context, fiat, amountFiat string) (string, string, error) {
+	if !strings.EqualFold(fiat, "USD") {
+		return "", "", fmt.Errorf("unsupported fiat %q", fiat)
+	}
+	amount, err := parseDecimal(amountFiat)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid amount: %w", err)
+	}
+	rate, rateStr, err := q.source.Rate(ctx, fiat)
+	if err != nil {
+		return "", "", err
+	}
+
+	minted := new(big.Rat).Quo(amount, rate)
+	wei := new(big.Rat).Mul(minted, new(big.Rat).SetInt(weiMultiplier))
+	weiStr, err := ratToIntegerString(wei)
+	if err != nil {
+		return "", "", fmt.Errorf("non integral mint amount: %w", err)
+	}
+	return rateStr, weiStr, nil
+}
+
+func (f *fixedPriceSource) Rate(ctx context.Context, fiat string) (*big.Rat, string, error) {
+	if !strings.EqualFold(fiat, "USD") {
+		return nil, "", fmt.Errorf("unsupported fiat %q", fiat)
+	}
+	return new(big.Rat).Set(f.rate), f.rateStr, nil
+}
+
+func parseDecimal(v string) (*big.Rat, error) {
+	r := new(big.Rat)
+	if _, ok := r.SetString(v); !ok {
+		return nil, fmt.Errorf("cannot parse %q", v)
+	}
+	return r, nil
+}
+
+func ratToIntegerString(r *big.Rat) (string, error) {
+	num := new(big.Int).Set(r.Num())
+	den := new(big.Int).Set(r.Denom())
+	quotient := new(big.Int).Quo(num, den)
+	remainder := new(big.Int).Mod(num, den)
+	if remainder.Sign() != 0 {
+		return "", fmt.Errorf("remainder %s/%s", remainder.String(), den.String())
+	}
+	return quotient.String(), nil
+}

--- a/services/swap-gateway/quote_test.go
+++ b/services/swap-gateway/quote_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestQuoteFixedPrice(t *testing.T) {
+	quoter, err := NewQuoter("fixed:0.10")
+	if err != nil {
+		t.Fatalf("NewQuoter: %v", err)
+	}
+	rate, minted, err := quoter.Quote(context.Background(), "USD", "100.00")
+	if err != nil {
+		t.Fatalf("Quote: %v", err)
+	}
+	if rate != "0.10" {
+		t.Fatalf("unexpected rate %s", rate)
+	}
+	expected := "1000000000000000000000"
+	if minted != expected {
+		t.Fatalf("expected %s minted, got %s", expected, minted)
+	}
+}

--- a/services/swap-gateway/voucher.go
+++ b/services/swap-gateway/voucher.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	repoCrypto "nhbchain/crypto"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// VoucherV1 mirrors the payload the gateway submits to the node.
+type VoucherV1 struct {
+	Domain     string `json:"domain"`
+	ChainID    int64  `json:"chainId"`
+	Token      string `json:"token"`
+	Recipient  string `json:"recipient"`
+	Amount     string `json:"amount"`
+	Fiat       string `json:"fiat"`
+	FiatAmount string `json:"fiatAmount"`
+	Rate       string `json:"rate"`
+	OrderID    string `json:"orderId"`
+	Nonce      string `json:"nonce"`
+	Expiry     int64  `json:"expiry"`
+}
+
+func (v VoucherV1) Hash() ([]byte, error) {
+	if v.Domain == "" {
+		return nil, fmt.Errorf("domain required")
+	}
+	if v.Recipient == "" {
+		return nil, fmt.Errorf("recipient required")
+	}
+	recipientBytes, err := decodeBech32Address(v.Recipient)
+	if err != nil {
+		return nil, fmt.Errorf("decode recipient: %w", err)
+	}
+	payload := fmt.Sprintf("%s|chain=%d|token=%s|to=%s|amount=%s|fiat=%s|fiatAmt=%s|rate=%s|order=%s|nonce=%s|exp=%d",
+		v.Domain,
+		v.ChainID,
+		v.Token,
+		hex.EncodeToString(recipientBytes),
+		v.Amount,
+		v.Fiat,
+		v.FiatAmount,
+		v.Rate,
+		v.OrderID,
+		strings.ToLower(v.Nonce),
+		v.Expiry,
+	)
+	hash := ethcrypto.Keccak256([]byte(payload))
+	return hash, nil
+}
+
+func SignVoucher(v VoucherV1, privKeyHex string) ([]byte, error) {
+	hash, err := v.Hash()
+	if err != nil {
+		return nil, err
+	}
+	pkHex := strings.TrimPrefix(privKeyHex, "0x")
+	if pkHex == "" {
+		return nil, fmt.Errorf("empty private key")
+	}
+	key, err := ethcrypto.HexToECDSA(pkHex)
+	if err != nil {
+		return nil, fmt.Errorf("load private key: %w", err)
+	}
+	sig, err := ethcrypto.Sign(hash, key)
+	if err != nil {
+		return nil, fmt.Errorf("sign voucher: %w", err)
+	}
+	return sig, nil
+}
+
+func RecoverVoucherSignerAddress(v VoucherV1, sig []byte) (string, error) {
+	hash, err := v.Hash()
+	if err != nil {
+		return "", err
+	}
+	pub, err := ethcrypto.SigToPub(hash, sig)
+	if err != nil {
+		return "", fmt.Errorf("recover pubkey: %w", err)
+	}
+	addrBytes := ethcrypto.PubkeyToAddress(*pub).Bytes()
+	return repoCrypto.NewAddress(repoCrypto.NHBPrefix, addrBytes).String(), nil
+}
+
+func decodeBech32Address(addr string) ([]byte, error) {
+	decoded, err := repoCrypto.DecodeAddress(addr)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, len(decoded.Bytes()))
+	copy(out, decoded.Bytes())
+	return out, nil
+}

--- a/services/swap-gateway/voucher_test.go
+++ b/services/swap-gateway/voucher_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	repoCrypto "nhbchain/crypto"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestVoucherHashDeterministic(t *testing.T) {
+	recipientBytes := bytes.Repeat([]byte{0x11}, 20)
+	recipient := repoCrypto.NewAddress(repoCrypto.NHBPrefix, recipientBytes).String()
+	voucher := VoucherV1{
+		Domain:     "NHB_SWAP_VOUCHER_V1",
+		ChainID:    187001,
+		Token:      "ZNHB",
+		Recipient:  recipient,
+		Amount:     "1000000000000000000",
+		Fiat:       "USD",
+		FiatAmount: "100.00",
+		Rate:       "0.10",
+		OrderID:    "SWP_1",
+		Nonce:      "abcd",
+		Expiry:     1700000000,
+	}
+
+	hash1, err := voucher.Hash()
+	if err != nil {
+		t.Fatalf("hash1: %v", err)
+	}
+	hash2, err := voucher.Hash()
+	if err != nil {
+		t.Fatalf("hash2: %v", err)
+	}
+
+	if !bytes.Equal(hash1, hash2) {
+		t.Fatalf("hashes differ")
+	}
+}
+
+func TestSignVoucherRecoverAddress(t *testing.T) {
+	key, err := ethcrypto.HexToECDSA("4f3edf983ac636a65a842ce7c78d9aa706d3b113b37e2b8c3c6d53295d85f81b")
+	if err != nil {
+		t.Fatalf("hex to ecdsa: %v", err)
+	}
+	minterAddr := repoCrypto.NewAddress(repoCrypto.NHBPrefix, ethcrypto.PubkeyToAddress(key.PublicKey).Bytes()).String()
+
+	recipientBytes := bytes.Repeat([]byte{0x22}, 20)
+	recipient := repoCrypto.NewAddress(repoCrypto.NHBPrefix, recipientBytes).String()
+
+	voucher := VoucherV1{
+		Domain:     "NHB_SWAP_VOUCHER_V1",
+		ChainID:    187001,
+		Token:      "ZNHB",
+		Recipient:  recipient,
+		Amount:     "1000000000000000000",
+		Fiat:       "USD",
+		FiatAmount: "100.00",
+		Rate:       "0.10",
+		OrderID:    "SWP_TEST",
+		Nonce:      "0011ee",
+		Expiry:     1800000000,
+	}
+
+	sig, err := SignVoucher(voucher, "0x1234")
+	if err == nil {
+		t.Fatalf("expected signing to fail with wrong key input")
+	}
+
+	sig, err = SignVoucher(voucher, "0x4f3edf983ac636a65a842ce7c78d9aa706d3b113b37e2b8c3c6d53295d85f81b")
+	if err != nil {
+		t.Fatalf("SignVoucher: %v", err)
+	}
+
+	recovered, err := RecoverVoucherSignerAddress(voucher, sig)
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if recovered != minterAddr {
+		t.Fatalf("expected %s recovered, got %s", minterAddr, recovered)
+	}
+}

--- a/services/swap-gateway/webhook_test.go
+++ b/services/swap-gateway/webhook_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	repoCrypto "nhbchain/crypto"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+type stubSubmitter struct {
+	called  bool
+	voucher VoucherV1
+	sig     string
+}
+
+func (s *stubSubmitter) SubmitVoucher(_ context.Context, voucher VoucherV1, sigHex string) error {
+	s.called = true
+	s.voucher = voucher
+	s.sig = sigHex
+	return nil
+}
+
+func TestHandlePaymentWebhook(t *testing.T) {
+	store := newOrderStore()
+
+	keyHex := "4f3edf983ac636a65a842ce7c78d9aa706d3b113b37e2b8c3c6d53295d85f81b"
+	key, err := ethcrypto.HexToECDSA(keyHex)
+	if err != nil {
+		t.Fatalf("hex to ecdsa: %v", err)
+	}
+	minterAddr := repoCrypto.NewAddress(repoCrypto.NHBPrefix, ethcrypto.PubkeyToAddress(key.PublicKey).Bytes()).String()
+
+	recipientBytes := bytes.Repeat([]byte{0x33}, 20)
+	recipient := repoCrypto.NewAddress(repoCrypto.NHBPrefix, recipientBytes).String()
+
+	ord := &order{
+		OrderID:    "SWP_1",
+		Reference:  "SWP_1",
+		Fiat:       "USD",
+		AmountFiat: "100.00",
+		Recipient:  recipient,
+		Rate:       "0.10",
+		AmountWei:  "1000000000000000000000",
+		Status:     orderStatusPending,
+	}
+	if _, _, err := store.createOrGet(ord); err != nil {
+		t.Fatalf("store order: %v", err)
+	}
+
+	payload := paymentWebhook{
+		OrderID:    "SWP_1",
+		Fiat:       "USD",
+		AmountFiat: "100.00",
+		Paid:       true,
+		TxRef:      "np_test",
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	secret := "hook-secret"
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	sig := hex.EncodeToString(mac.Sum(nil))
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/payment", bytes.NewReader(body))
+	req.Header.Set("X-HMAC", sig)
+
+	recorder := httptest.NewRecorder()
+	submitter := &stubSubmitter{}
+
+	handlePaymentWebhook(recorder, req, store, nil, submitter, 187001, minterAddr, "0x"+keyHex, secret)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unexpected status %d", recorder.Code)
+	}
+	if !submitter.called {
+		t.Fatalf("expected submitter to be called")
+	}
+	if !strings.HasPrefix(submitter.sig, "0x") {
+		t.Fatalf("expected hex signature, got %s", submitter.sig)
+	}
+
+	updated, ok := store.get("SWP_1")
+	if !ok {
+		t.Fatalf("order missing after webhook")
+	}
+	if updated.Status != orderStatusMintSubmitted {
+		t.Fatalf("expected status %s, got %s", orderStatusMintSubmitted, updated.Status)
+	}
+	if updated.MintedWei != ord.AmountWei {
+		t.Fatalf("expected minted %s, got %s", ord.AmountWei, updated.MintedWei)
+	}
+}


### PR DESCRIPTION
## Summary
- add a swap gateway HTTP service that handles quoting, order creation, payment webhooks, and voucher submission to the node
- implement price quoting, voucher hashing/signing, HMAC validation, and a JSON-RPC client alongside targeted unit tests
- document the swap flow, frontend integration guidance, and audit considerations under `docs/swap`

## Testing
- `go test ./services/swap-gateway/...`


------
https://chatgpt.com/codex/tasks/task_e_68d3e1ab76b8832d9a017daced179415