### PR TITLE
feat: add swap voucher RPC minting path

### DIFF
--- a/core/events/swap.go
+++ b/core/events/swap.go
@@ -1,0 +1,47 @@
+package events
+
+import (
+	"math/big"
+	"strings"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+const (
+	// TypeSwapMinted is emitted whenever a swap voucher mints ZNHB on-chain.
+	TypeSwapMinted = "swap.minted"
+)
+
+type SwapMinted struct {
+	OrderID    string
+	Recipient  [20]byte
+	Amount     *big.Int
+	Fiat       string
+	FiatAmount string
+	Rate       string
+}
+
+func (SwapMinted) EventType() string { return TypeSwapMinted }
+
+func (e SwapMinted) Event() *types.Event {
+	amount := big.NewInt(0)
+	if e.Amount != nil {
+		amount = new(big.Int).Set(e.Amount)
+	}
+	recipient := ""
+	if e.Recipient != ([20]byte{}) {
+		recipient = crypto.NewAddress(crypto.NHBPrefix, e.Recipient[:]).String()
+	}
+	return &types.Event{
+		Type: TypeSwapMinted,
+		Attributes: map[string]string{
+			"orderId":    strings.TrimSpace(e.OrderID),
+			"recipient":  recipient,
+			"amount":     amount.String(),
+			"fiat":       strings.TrimSpace(e.Fiat),
+			"fiatAmount": strings.TrimSpace(e.FiatAmount),
+			"rate":       strings.TrimSpace(e.Rate),
+		},
+	}
+}

--- a/core/swap.go
+++ b/core/swap.go
@@ -1,0 +1,22 @@
+package core
+
+import "errors"
+
+var (
+        // ErrSwapInvalidDomain indicates the voucher domain does not match the expected identifier.
+        ErrSwapInvalidDomain = errors.New("swap: invalid domain")
+        // ErrSwapInvalidChainID indicates the voucher targets a different chain.
+        ErrSwapInvalidChainID = errors.New("swap: invalid chain id")
+        // ErrSwapExpired indicates the voucher expiry timestamp has elapsed.
+        ErrSwapExpired = errors.New("swap: voucher expired")
+        // ErrSwapInvalidToken indicates the voucher requested an unsupported token.
+        ErrSwapInvalidToken = errors.New("swap: invalid token")
+        // ErrSwapInvalidSignature indicates the signature is malformed or cannot be recovered.
+        ErrSwapInvalidSignature = errors.New("swap: invalid signature")
+        // ErrSwapInvalidSigner indicates the recovered signer does not match the configured mint authority.
+        ErrSwapInvalidSigner = errors.New("swap: invalid signer")
+        // ErrSwapNonceUsed indicates the order identifier has already been processed.
+        ErrSwapNonceUsed = errors.New("swap: order already processed")
+        // ErrSwapMintPaused indicates the token mint has been paused by governance.
+        ErrSwapMintPaused = errors.New("swap: mint paused")
+)

--- a/docs/swap.md
+++ b/docs/swap.md
@@ -1,0 +1,52 @@
+# Swap Voucher RPC Summary
+
+## Voucher Schema
+
+The node accepts version 1 swap vouchers with the domain string `NHB_SWAP_VOUCHER_V1`. Each voucher serialises to JSON with the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `domain` | string | Must equal `NHB_SWAP_VOUCHER_V1`. Protects against cross-protocol reuse. |
+| `chainId` | integer | Chain identifier derived from the NHB genesis hash. |
+| `token` | string | Supported token symbol. The initial deployment only permits `ZNHB`. |
+| `recipient` | string | NHB bech32 address that receives the minted ZNHB. |
+| `amount` | string | Positive decimal string representing the amount of ZNHB (wei precision). |
+| `fiat` | string | Fiat currency code supplied by the gateway (e.g. `USD`). |
+| `fiatAmount` | string | Fiat amount paid by the customer. |
+| `rate` | string | Fiat→token conversion rate embedded in the voucher. |
+| `orderId` | string | Gateway order identifier used as the replay-protection nonce. |
+| `nonce` | string | Hex-encoded random salt (case-insensitive) included in the signed payload. |
+| `expiry` | integer | Unix timestamp after which the voucher is rejected. |
+
+The keccak256 hash is computed over the deterministic template
+
+```
+NHB_SWAP_VOUCHER_V1|chain=<chainId>|token=<token>|to=<recipient_hex>|amount=<amount>|fiat=<fiat>|fiatAmt=<fiatAmount>|rate=<rate>|order=<orderId>|nonce=<nonce>|exp=<expiry>
+```
+
+where `recipient_hex` is the 20-byte NHB address in lowercase hex and `nonce` is lowercase hex without the `0x` prefix.
+
+## RPC Endpoint
+
+`swap_submitVoucher` accepts a single parameter object:
+
+```json
+{
+  "voucher": { /* VoucherV1 payload */ },
+  "sig": "0x<secp256k1 signature>"
+}
+```
+
+On success the response contains `{ "txHash": "0x...", "minted": true }`. Failures return standard JSON-RPC errors:
+
+- invalid domain, chain, token, expiry or signature → `codeInvalidParams`
+- unauthorized signer → `codeUnauthorized`
+- duplicate `orderId` replay → `codeDuplicateTx`
+
+## Security Notes
+
+- The node compares `domain` with `NHB_SWAP_VOUCHER_V1` and verifies `chainId` against the running chain.
+- Vouchers expire when `now > expiry`; clients should refresh vouchers frequently (default gateway TTL: 15 minutes).
+- Only `ZNHB` minting is enabled for MVP and the recovered signer must match the configured `ZNHB` mint authority.
+- Replays are prevented by persisting `orderId` inside the state trie; duplicate submissions receive `codeDuplicateTx`.
+- Successful mints append a `swap.minted` event with `{orderId, recipient, amount, fiat, fiatAmount, rate}` for downstream indexing and compliance monitoring.

--- a/native/swap/voucher.go
+++ b/native/swap/voucher.go
@@ -1,0 +1,161 @@
+package swap
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+
+	repoCrypto "nhbchain/crypto"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// VoucherDomainV1 defines the voucher domain string for the first swap voucher version.
+const VoucherDomainV1 = "NHB_SWAP_VOUCHER_V1"
+
+// VoucherV1 captures the structured payload authorised by the fiat gateway.
+type VoucherV1 struct {
+	Domain     string
+	ChainID    uint64
+	Token      string
+	Recipient  [20]byte
+	Amount     *big.Int
+	Fiat       string
+	FiatAmount string
+	Rate       string
+	OrderID    string
+	Nonce      []byte
+	Expiry     int64
+}
+
+type voucherJSON struct {
+	Domain     string `json:"domain"`
+	ChainID    uint64 `json:"chainId"`
+	Token      string `json:"token"`
+	Recipient  string `json:"recipient"`
+	Amount     string `json:"amount"`
+	Fiat       string `json:"fiat"`
+	FiatAmount string `json:"fiatAmount"`
+	Rate       string `json:"rate"`
+	OrderID    string `json:"orderId"`
+	Nonce      string `json:"nonce"`
+	Expiry     int64  `json:"expiry"`
+}
+
+// MarshalJSON encodes the voucher into the JSON representation consumed by RPC clients.
+func (v VoucherV1) MarshalJSON() ([]byte, error) {
+	amountStr := "0"
+	if v.Amount != nil {
+		amountStr = strings.TrimSpace(v.Amount.String())
+	}
+	nonceHex := hex.EncodeToString(v.Nonce)
+	recipient := ""
+	if v.Recipient != ([20]byte{}) {
+		recipient = repoCrypto.NewAddress(repoCrypto.NHBPrefix, v.Recipient[:]).String()
+	}
+	payload := voucherJSON{
+		Domain:     strings.TrimSpace(v.Domain),
+		ChainID:    v.ChainID,
+		Token:      strings.TrimSpace(v.Token),
+		Recipient:  recipient,
+		Amount:     amountStr,
+		Fiat:       strings.TrimSpace(v.Fiat),
+		FiatAmount: strings.TrimSpace(v.FiatAmount),
+		Rate:       strings.TrimSpace(v.Rate),
+		OrderID:    strings.TrimSpace(v.OrderID),
+		Nonce:      strings.ToLower(nonceHex),
+		Expiry:     v.Expiry,
+	}
+	return json.Marshal(payload)
+}
+
+// UnmarshalJSON decodes the on-wire representation into the canonical struct.
+func (v *VoucherV1) UnmarshalJSON(data []byte) error {
+	if v == nil {
+		return fmt.Errorf("voucher: nil receiver")
+	}
+	var payload voucherJSON
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return err
+	}
+	domain := strings.TrimSpace(payload.Domain)
+	if domain == "" {
+		return fmt.Errorf("voucher: domain required")
+	}
+	token := strings.ToUpper(strings.TrimSpace(payload.Token))
+	if token == "" {
+		return fmt.Errorf("voucher: token required")
+	}
+	recipientStr := strings.TrimSpace(payload.Recipient)
+	if recipientStr == "" {
+		return fmt.Errorf("voucher: recipient required")
+	}
+	recipientAddr, err := repoCrypto.DecodeAddress(recipientStr)
+	if err != nil {
+		return fmt.Errorf("voucher: recipient: %w", err)
+	}
+	var recipient [20]byte
+	copy(recipient[:], recipientAddr.Bytes())
+	amountStr := strings.TrimSpace(payload.Amount)
+	if amountStr == "" {
+		return fmt.Errorf("voucher: amount required")
+	}
+	amount, ok := new(big.Int).SetString(amountStr, 10)
+	if !ok {
+		return fmt.Errorf("voucher: invalid amount %q", payload.Amount)
+	}
+	if amount.Sign() <= 0 {
+		return fmt.Errorf("voucher: amount must be positive")
+	}
+	orderID := strings.TrimSpace(payload.OrderID)
+	if orderID == "" {
+		return fmt.Errorf("voucher: orderId required")
+	}
+	nonceStr := strings.TrimSpace(payload.Nonce)
+	if nonceStr == "" {
+		return fmt.Errorf("voucher: nonce required")
+	}
+	normalizedNonce := strings.TrimPrefix(strings.ToLower(nonceStr), "0x")
+	nonce, err := hex.DecodeString(normalizedNonce)
+	if err != nil {
+		return fmt.Errorf("voucher: nonce: %w", err)
+	}
+	*v = VoucherV1{
+		Domain:     domain,
+		ChainID:    payload.ChainID,
+		Token:      token,
+		Recipient:  recipient,
+		Amount:     amount,
+		Fiat:       strings.TrimSpace(payload.Fiat),
+		FiatAmount: strings.TrimSpace(payload.FiatAmount),
+		Rate:       strings.TrimSpace(payload.Rate),
+		OrderID:    orderID,
+		Nonce:      nonce,
+		Expiry:     payload.Expiry,
+	}
+	return nil
+}
+
+// Hash reconstructs the canonical message digest signed by the mint authority.
+func (v VoucherV1) Hash() []byte {
+	amountStr := "0"
+	if v.Amount != nil {
+		amountStr = v.Amount.String()
+	}
+	payload := fmt.Sprintf("%s|chain=%d|token=%s|to=%s|amount=%s|fiat=%s|fiatAmt=%s|rate=%s|order=%s|nonce=%s|exp=%d",
+		strings.TrimSpace(v.Domain),
+		v.ChainID,
+		strings.TrimSpace(v.Token),
+		hex.EncodeToString(v.Recipient[:]),
+		amountStr,
+		strings.TrimSpace(v.Fiat),
+		strings.TrimSpace(v.FiatAmount),
+		strings.TrimSpace(v.Rate),
+		strings.TrimSpace(v.OrderID),
+		strings.ToLower(hex.EncodeToString(v.Nonce)),
+		v.Expiry,
+	)
+	return ethcrypto.Keccak256([]byte(payload))
+}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -239,6 +239,8 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handleGetRewardPayout(w, r, req)
 	case "mint_with_sig":
 		s.handleMintWithSig(w, r, req)
+	case "swap_submitVoucher":
+		s.handleSwapSubmitVoucher(w, r, req)
 	case "stake_delegate":
 		s.handleStakeDelegate(w, r, req)
 	case "stake_undelegate":

--- a/rpc/swap_handlers.go
+++ b/rpc/swap_handlers.go
@@ -1,0 +1,68 @@
+package rpc
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"nhbchain/core"
+	swap "nhbchain/native/swap"
+)
+
+func (s *Server) handleSwapSubmitVoucher(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected payload with voucher and sig", nil)
+		return
+	}
+	var payload struct {
+		Voucher json.RawMessage `json:"voucher"`
+		Sig     string          `json:"sig"`
+	}
+	if err := json.Unmarshal(req.Params[0], &payload); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid payload", err.Error())
+		return
+	}
+	if len(bytes.TrimSpace(payload.Voucher)) == 0 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "voucher required", nil)
+		return
+	}
+	var voucher swap.VoucherV1
+	if err := json.Unmarshal(payload.Voucher, &voucher); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid voucher", err.Error())
+		return
+	}
+	sigHex := strings.TrimSpace(payload.Sig)
+	if sigHex == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "signature required", nil)
+		return
+	}
+	sigHex = strings.TrimPrefix(sigHex, "0x")
+	signature, err := hex.DecodeString(sigHex)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid signature", err.Error())
+		return
+	}
+	txHash, minted, err := s.node.SwapSubmitVoucher(&voucher, signature)
+	if err != nil {
+		switch {
+		case errors.Is(err, core.ErrSwapInvalidSigner):
+			writeError(w, http.StatusUnauthorized, req.ID, codeUnauthorized, err.Error(), nil)
+		case errors.Is(err, core.ErrSwapNonceUsed):
+			writeError(w, http.StatusConflict, req.ID, codeDuplicateTx, err.Error(), voucher.OrderID)
+		case errors.Is(err, core.ErrSwapInvalidDomain),
+			errors.Is(err, core.ErrSwapInvalidChainID),
+			errors.Is(err, core.ErrSwapExpired),
+			errors.Is(err, core.ErrSwapInvalidToken),
+			errors.Is(err, core.ErrSwapInvalidSignature),
+			errors.Is(err, core.ErrSwapMintPaused):
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		default:
+			writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "swap voucher failed", err.Error())
+		}
+		return
+	}
+	writeResult(w, req.ID, map[string]interface{}{"txHash": txHash, "minted": minted})
+}

--- a/rpc/swap_handlers_test.go
+++ b/rpc/swap_handlers_test.go
@@ -1,0 +1,294 @@
+package rpc
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"nhbchain/core"
+	"nhbchain/core/events"
+	nhbstate "nhbchain/core/state"
+	"nhbchain/crypto"
+	swap "nhbchain/native/swap"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+func configureSwapToken(t *testing.T, node *core.Node, minterAddr [20]byte) {
+	t.Helper()
+	if err := node.WithState(func(m *nhbstate.Manager) error {
+		meta, err := m.Token("ZNHB")
+		if err != nil {
+			return err
+		}
+		if meta == nil {
+			if err := m.RegisterToken("ZNHB", "Zero NHB", 18); err != nil {
+				return err
+			}
+		}
+		if err := m.SetTokenMintAuthority("ZNHB", minterAddr[:]); err != nil {
+			return err
+		}
+		return m.SetTokenMintPaused("ZNHB", false)
+	}); err != nil {
+		t.Fatalf("configure swap token: %v", err)
+	}
+}
+
+func buildSwapVoucher(t *testing.T, chainID uint64, recipient [20]byte) swap.VoucherV1 {
+	t.Helper()
+	return swap.VoucherV1{
+		Domain:     swap.VoucherDomainV1,
+		ChainID:    chainID,
+		Token:      "ZNHB",
+		Recipient:  recipient,
+		Amount:     big.NewInt(1_000_000_000_000_000_000),
+		Fiat:       "USD",
+		FiatAmount: "100.00",
+		Rate:       "0.10",
+		OrderID:    "ORDER-123",
+		Nonce:      []byte("nonce-1"),
+		Expiry:     time.Now().Add(time.Hour).Unix(),
+	}
+}
+
+func signSwapVoucher(t *testing.T, key *crypto.PrivateKey, voucher swap.VoucherV1) []byte {
+	t.Helper()
+	hash := voucher.Hash()
+	sig, err := ethcrypto.Sign(hash, key.PrivateKey)
+	if err != nil {
+		t.Fatalf("sign voucher: %v", err)
+	}
+	return sig
+}
+
+func TestSwapSubmitVoucherInvalidDomain(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient)
+	voucher.Domain = "BAD_DOMAIN"
+	sig := signSwapVoucher(t, minterKey, voucher)
+
+	payload := map[string]interface{}{
+		"voucher": voucher,
+		"sig":     "0x" + hex.EncodeToString(sig),
+	}
+	req := &RPCRequest{ID: 1, Params: []json.RawMessage{marshalParam(t, payload)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorder, env.newRequest(), req)
+	_, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr == nil {
+		t.Fatalf("expected error")
+	}
+	if rpcErr.Code != codeInvalidParams {
+		t.Fatalf("expected invalid params code, got %d", rpcErr.Code)
+	}
+}
+
+func TestSwapSubmitVoucherInvalidChain(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID()+1, recipient)
+	sig := signSwapVoucher(t, minterKey, voucher)
+
+	payload := map[string]interface{}{
+		"voucher": voucher,
+		"sig":     "0x" + hex.EncodeToString(sig),
+	}
+	req := &RPCRequest{ID: 2, Params: []json.RawMessage{marshalParam(t, payload)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorder, env.newRequest(), req)
+	_, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr == nil {
+		t.Fatalf("expected error")
+	}
+	if rpcErr.Code != codeInvalidParams {
+		t.Fatalf("expected invalid params code, got %d", rpcErr.Code)
+	}
+}
+
+func TestSwapSubmitVoucherExpired(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient)
+	voucher.Expiry = time.Now().Add(-time.Minute).Unix()
+	sig := signSwapVoucher(t, minterKey, voucher)
+
+	payload := map[string]interface{}{
+		"voucher": voucher,
+		"sig":     "0x" + hex.EncodeToString(sig),
+	}
+	req := &RPCRequest{ID: 3, Params: []json.RawMessage{marshalParam(t, payload)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorder, env.newRequest(), req)
+	_, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr == nil {
+		t.Fatalf("expected error")
+	}
+	if rpcErr.Code != codeInvalidParams {
+		t.Fatalf("expected invalid params code, got %d", rpcErr.Code)
+	}
+}
+
+func TestSwapSubmitVoucherInvalidToken(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient)
+	voucher.Token = "NHB"
+	sig := signSwapVoucher(t, minterKey, voucher)
+
+	payload := map[string]interface{}{
+		"voucher": voucher,
+		"sig":     "0x" + hex.EncodeToString(sig),
+	}
+	req := &RPCRequest{ID: 4, Params: []json.RawMessage{marshalParam(t, payload)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorder, env.newRequest(), req)
+	_, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr == nil {
+		t.Fatalf("expected error")
+	}
+	if rpcErr.Code != codeInvalidParams {
+		t.Fatalf("expected invalid params code, got %d", rpcErr.Code)
+	}
+}
+
+func TestSwapSubmitVoucherInvalidSigner(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	rogueKey, _ := crypto.GeneratePrivateKey()
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient)
+	sig := signSwapVoucher(t, rogueKey, voucher)
+
+	payload := map[string]interface{}{
+		"voucher": voucher,
+		"sig":     "0x" + hex.EncodeToString(sig),
+	}
+	req := &RPCRequest{ID: 5, Params: []json.RawMessage{marshalParam(t, payload)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorder, env.newRequest(), req)
+	_, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr == nil {
+		t.Fatalf("expected error")
+	}
+	if rpcErr.Code != codeUnauthorized {
+		t.Fatalf("expected unauthorized code, got %d", rpcErr.Code)
+	}
+}
+
+func TestSwapSubmitVoucherSuccessAndReplay(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	chainID := env.node.Chain().ChainID()
+	voucher := buildSwapVoucher(t, chainID, recipient)
+	sig := signSwapVoucher(t, minterKey, voucher)
+	payload := map[string]interface{}{
+		"voucher": voucher,
+		"sig":     "0x" + hex.EncodeToString(sig),
+	}
+	req := &RPCRequest{ID: 6, Params: []json.RawMessage{marshalParam(t, payload)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorder, env.newRequest(), req)
+	result, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr != nil {
+		t.Fatalf("unexpected error: %+v", rpcErr)
+	}
+	var response struct {
+		TxHash string `json:"txHash"`
+		Minted bool   `json:"minted"`
+	}
+	if err := json.Unmarshal(result, &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.Minted {
+		t.Fatalf("expected minted true")
+	}
+	if response.TxHash == "" {
+		t.Fatalf("expected tx hash")
+	}
+
+	account, err := env.node.GetAccount(recipient[:])
+	if err != nil {
+		t.Fatalf("get account: %v", err)
+	}
+	if account.BalanceZNHB.Cmp(voucher.Amount) != 0 {
+		t.Fatalf("unexpected balance: got %s want %s", account.BalanceZNHB.String(), voucher.Amount.String())
+	}
+
+	evts := env.node.Events()
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event got %d", len(evts))
+	}
+	evt := evts[0]
+	if evt.Type != events.TypeSwapMinted {
+		t.Fatalf("unexpected event type %s", evt.Type)
+	}
+	if evt.Attributes["orderId"] != voucher.OrderID {
+		t.Fatalf("unexpected orderId %s", evt.Attributes["orderId"])
+	}
+	if evt.Attributes["amount"] != voucher.Amount.String() {
+		t.Fatalf("unexpected amount %s", evt.Attributes["amount"])
+	}
+
+	// Replay should be rejected
+	replayRec := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(replayRec, env.newRequest(), req)
+	_, replayErr := decodeRPCResponse(t, replayRec)
+	if replayErr == nil {
+		t.Fatalf("expected replay error")
+	}
+	if replayErr.Code != codeDuplicateTx {
+		t.Fatalf("expected duplicate code, got %d", replayErr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- implement voucher parsing in native swap package and on-chain replay protection
- add swap_submitVoucher RPC handler that mints ZNHB after verifying minter signature
- emit swap.minted events, expose helper node methods, and document flows for all stakeholders

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d3e5222dcc832da32850be2b4a8bfc