### PR TITLE
Implement POTSO reward claim mode with history, exports, and docs

### DIFF
--- a/cmd/nhb-cli/potso.go
+++ b/cmd/nhb-cli/potso.go
@@ -49,6 +49,8 @@ func runPotsoCommand(args []string, stdout, stderr io.Writer) int {
 		return runPotsoTop(args[1:], stdout, stderr)
 	case "stake":
 		return runPotsoStake(args[1:], stdout, stderr)
+	case "reward":
+		return runPotsoReward(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "Unknown potso subcommand: %s\n", args[0])
 		fmt.Fprintln(stderr, potsoUsage())
@@ -64,6 +66,7 @@ func potsoUsage() string {
 	fmt.Fprintln(buf, "  user-meters   Fetch the raw meters for a user")
 	fmt.Fprintln(buf, "  top           List top participants for a day")
 	fmt.Fprintln(buf, "  stake         Manage ZapNHB staking locks")
+	fmt.Fprintln(buf, "  reward        Manage reward claims, history, and exports")
 	return buf.String()
 }
 

--- a/cmd/nhb-cli/potso_rewards.go
+++ b/cmd/nhb-cli/potso_rewards.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+type potsoRewardClaimCLIParams struct {
+	Epoch     uint64 `json:"epoch"`
+	Address   string `json:"address"`
+	Signature string `json:"signature"`
+}
+
+type potsoRewardHistoryCLIParams struct {
+	Address string `json:"address"`
+	Cursor  string `json:"cursor,omitempty"`
+	Limit   int    `json:"limit,omitempty"`
+}
+
+type potsoRewardExportCLIParams struct {
+	Epoch uint64 `json:"epoch"`
+}
+
+type potsoRewardExportCLIResult struct {
+	Epoch     uint64 `json:"epoch"`
+	CSVBase64 string `json:"csvBase64"`
+	TotalPaid string `json:"totalPaid"`
+	Winners   int    `json:"winners"`
+}
+
+func runPotsoReward(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, potsoRewardUsage())
+		return 1
+	}
+	switch args[0] {
+	case "claim":
+		return runPotsoRewardClaim(args[1:], stdout, stderr)
+	case "history":
+		return runPotsoRewardHistory(args[1:], stdout, stderr)
+	case "export":
+		return runPotsoRewardExport(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "Unknown potso reward subcommand: %s\n", args[0])
+		fmt.Fprintln(stderr, potsoRewardUsage())
+		return 1
+	}
+}
+
+func potsoRewardUsage() string {
+	builder := &strings.Builder{}
+	fmt.Fprintln(builder, "Usage: nhb-cli potso reward <subcommand> [options]")
+	fmt.Fprintln(builder, "Subcommands:")
+	fmt.Fprintln(builder, "  claim    Claim a pending reward")
+	fmt.Fprintln(builder, "  history  View reward settlement history")
+	fmt.Fprintln(builder, "  export   Export an epoch payout ledger as CSV")
+	return builder.String()
+}
+
+func potsoRewardClaimDigest(epoch uint64, addr string) []byte {
+	normalized := strings.ToLower(strings.TrimSpace(addr))
+	payload := fmt.Sprintf("potso_reward_claim|%d|%s", epoch, normalized)
+	digest := sha256.Sum256([]byte(payload))
+	return digest[:]
+}
+
+func runPotsoRewardClaim(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("potso reward claim", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		epoch uint64
+		addr  string
+		key   string
+	)
+	fs.Uint64Var(&epoch, "epoch", 0, "reward epoch number")
+	fs.StringVar(&addr, "addr", "", "bech32 address to claim for")
+	fs.StringVar(&key, "key", "wallet.key", "path to signing key")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if addr == "" {
+		fmt.Fprintln(stderr, "Error: --addr is required")
+		return 1
+	}
+	if epoch == 0 {
+		fmt.Fprintln(stderr, "Error: --epoch is required")
+		return 1
+	}
+	privKey, err := loadPrivateKey(key)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error loading key: %v\n", err)
+		return 1
+	}
+	signer := privKey.PubKey().Address().String()
+	if !strings.EqualFold(strings.TrimSpace(signer), strings.TrimSpace(addr)) {
+		fmt.Fprintf(stderr, "Error: signing key belongs to %s but --addr was %s\n", signer, addr)
+		return 1
+	}
+	digest := potsoRewardClaimDigest(epoch, addr)
+	sig, err := ethcrypto.Sign(digest, privKey.PrivateKey)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error signing claim: %v\n", err)
+		return 1
+	}
+	params := potsoRewardClaimCLIParams{Epoch: epoch, Address: addr, Signature: "0x" + strings.ToLower(hex.EncodeToString(sig))}
+	result, err := callPotsoRPCWithAuth("potso_reward_claim", params, true)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error submitting claim: %v\n", err)
+		return 1
+	}
+	printJSONResult(result)
+	return 0
+}
+
+func runPotsoRewardHistory(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("potso reward history", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		addr   string
+		cursor string
+		limit  int
+	)
+	fs.StringVar(&addr, "addr", "", "bech32 address to query")
+	fs.StringVar(&cursor, "cursor", "", "optional pagination cursor")
+	fs.IntVar(&limit, "limit", 0, "optional page size")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if addr == "" {
+		fmt.Fprintln(stderr, "Error: --addr is required")
+		return 1
+	}
+	params := potsoRewardHistoryCLIParams{Address: addr}
+	if strings.TrimSpace(cursor) != "" {
+		params.Cursor = strings.TrimSpace(cursor)
+	}
+	if limit > 0 {
+		params.Limit = limit
+	}
+	result, err := callPotsoRPC("potso_rewards_history", params)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error fetching history: %v\n", err)
+		return 1
+	}
+	printJSONResult(result)
+	return 0
+}
+
+func runPotsoRewardExport(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("potso reward export", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var epoch uint64
+	fs.Uint64Var(&epoch, "epoch", 0, "reward epoch number")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if epoch == 0 {
+		fmt.Fprintln(stderr, "Error: --epoch is required")
+		return 1
+	}
+	params := potsoRewardExportCLIParams{Epoch: epoch}
+	raw, err := callPotsoRPC("potso_export_epoch", params)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error exporting epoch: %v\n", err)
+		return 1
+	}
+	var result potsoRewardExportCLIResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		fmt.Fprintf(stderr, "Error decoding export result: %v\n", err)
+		return 1
+	}
+	data, err := base64.StdEncoding.DecodeString(result.CSVBase64)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error decoding CSV payload: %v\n", err)
+		return 1
+	}
+	if _, err := stdout.Write(data); err != nil {
+		fmt.Fprintf(stderr, "Error writing CSV: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/config.toml
+++ b/config.toml
@@ -26,6 +26,7 @@ EmissionPerEpoch = "0"
 TreasuryAddress = "nhb1exampletreasury000000000000000000000"
 MaxWinnersPerEpoch = 5000
 CarryRemainder = true
+PayoutMode = "auto"
 
 [potso.weights]
 AlphaStakeBps = 7000

--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,7 @@ type PotsoRewardsConfig struct {
 	TreasuryAddress    string `toml:"TreasuryAddress"`
 	MaxWinnersPerEpoch uint64 `toml:"MaxWinnersPerEpoch"`
 	CarryRemainder     bool   `toml:"CarryRemainder"`
+	PayoutMode         string `toml:"PayoutMode"`
 }
 
 // PotsoWeightsConfig mirrors the `[potso.weights]` TOML section.
@@ -217,6 +218,13 @@ func (cfg *Config) PotsoRewardConfig() (potso.RewardConfig, error) {
 		result.TreasuryAddress = addr
 	}
 
+	trimmedMode := strings.TrimSpace(rewards.PayoutMode)
+	if trimmedMode == "" {
+		result.PayoutMode = potso.RewardPayoutModeAuto
+	} else {
+		result.PayoutMode = potso.RewardPayoutMode(trimmedMode).Normalise()
+	}
+
 	if err := result.Validate(); err != nil {
 		return result, err
 	}
@@ -316,6 +324,7 @@ func createDefault(path string) (*Config, error) {
 		MinPayoutWei:     "0",
 		EmissionPerEpoch: "0",
 		CarryRemainder:   true,
+		PayoutMode:       string(potso.RewardPayoutModeAuto),
 	}
 	cfg.ValidatorKeystorePath = keystorePath
 

--- a/core/potso_rewards_integration_test.go
+++ b/core/potso_rewards_integration_test.go
@@ -1,11 +1,17 @@
 package core
 
 import (
+	"bytes"
+	"encoding/csv"
 	"math/big"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"nhbchain/core/events"
 	nhbstate "nhbchain/core/state"
+	"nhbchain/crypto"
 	"nhbchain/native/potso"
 	"nhbchain/storage"
 	statetrie "nhbchain/storage/trie"
@@ -105,6 +111,34 @@ func TestProcessPotsoRewardEpoch(t *testing.T) {
 		t.Fatalf("payout sum mismatch: %s", paid)
 	}
 
+	claimA, ok, err := manager.PotsoRewardsGetClaim(0, participantA)
+	if err != nil || !ok || claimA == nil {
+		t.Fatalf("expected claim record for participant A")
+	}
+	if !claimA.Claimed {
+		t.Fatalf("expected participant A to be marked claimed")
+	}
+	if claimA.Mode != potso.RewardPayoutModeAuto {
+		t.Fatalf("unexpected claim mode for participant A: %s", claimA.Mode)
+	}
+	if claimA.Amount.Cmp(payoutA) != 0 {
+		t.Fatalf("claim amount mismatch: %s vs %s", claimA.Amount, payoutA)
+	}
+
+	historyA, err := manager.PotsoRewardsHistory(participantA)
+	if err != nil {
+		t.Fatalf("history A: %v", err)
+	}
+	if len(historyA) != 1 {
+		t.Fatalf("expected one history entry, got %d", len(historyA))
+	}
+	if historyA[0].Mode != potso.RewardPayoutModeAuto {
+		t.Fatalf("unexpected history mode: %s", historyA[0].Mode)
+	}
+	if historyA[0].Amount.Cmp(payoutA) != 0 {
+		t.Fatalf("history amount mismatch: %s vs %s", historyA[0].Amount, payoutA)
+	}
+
 	updatedTreasury, err := manager.GetAccount(treasury[:])
 	if err != nil {
 		t.Fatalf("reload treasury: %v", err)
@@ -154,5 +188,361 @@ func TestProcessPotsoRewardEpoch(t *testing.T) {
 	repeatPayoutA, ok, err := manager.PotsoRewardsGetPayout(0, participantA)
 	if err != nil || !ok || repeatPayoutA.Cmp(payoutA) != 0 {
 		t.Fatalf("payout mutated after repeat processing")
+	}
+}
+
+func TestPotsoRewardClaimFlow(t *testing.T) {
+	db := storage.NewMemDB()
+	t.Cleanup(db.Close)
+
+	validatorKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key: %v", err)
+	}
+	node, err := NewNode(db, validatorKey, "", true)
+	if err != nil {
+		t.Fatalf("new node: %v", err)
+	}
+
+	treasury := [20]byte{1}
+	cfg := potso.RewardConfig{
+		EpochLengthBlocks:  2,
+		AlphaStakeBps:      7000,
+		MinPayoutWei:       big.NewInt(0),
+		EmissionPerEpoch:   big.NewInt(900),
+		TreasuryAddress:    treasury,
+		MaxWinnersPerEpoch: 10,
+		CarryRemainder:     true,
+		PayoutMode:         potso.RewardPayoutModeClaim,
+	}
+	if err := node.SetPotsoRewardConfig(cfg); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+
+	manager := nhbstate.NewManager(node.state.Trie)
+	treasuryAcc, err := manager.GetAccount(treasury[:])
+	if err != nil {
+		t.Fatalf("treasury account: %v", err)
+	}
+	treasuryAcc.BalanceZNHB = big.NewInt(900)
+	if err := manager.PutAccount(treasury[:], treasuryAcc); err != nil {
+		t.Fatalf("store treasury: %v", err)
+	}
+
+	participantA := [20]byte{2}
+	participantB := [20]byte{3}
+	if err := manager.PotsoStakeSetBondedTotal(participantA, big.NewInt(600)); err != nil {
+		t.Fatalf("set stake A: %v", err)
+	}
+	if err := manager.PotsoStakeSetBondedTotal(participantB, big.NewInt(400)); err != nil {
+		t.Fatalf("set stake B: %v", err)
+	}
+
+	now := time.Now().UTC()
+	day := now.Format(potso.DayFormat)
+	if err := manager.PotsoPutMeter(participantA, &potso.Meter{Day: day, UptimeSeconds: 30 * 60}); err != nil {
+		t.Fatalf("put meter A: %v", err)
+	}
+	if err := manager.PotsoPutMeter(participantB, &potso.Meter{Day: day, UptimeSeconds: 10 * 60}); err != nil {
+		t.Fatalf("put meter B: %v", err)
+	}
+
+	if err := node.state.ProcessBlockLifecycle(1, now.Add(-time.Second).Unix()); err != nil {
+		t.Fatalf("process block 1: %v", err)
+	}
+	if err := node.state.ProcessBlockLifecycle(2, now.Unix()); err != nil {
+		t.Fatalf("process block 2: %v", err)
+	}
+
+	claimA, ok, err := manager.PotsoRewardsGetClaim(0, participantA)
+	if err != nil || !ok || claimA == nil {
+		t.Fatalf("expected claim entry for A")
+	}
+	if claimA.Claimed {
+		t.Fatalf("claim should not be marked claimed before settlement")
+	}
+	if claimA.Mode != potso.RewardPayoutModeClaim {
+		t.Fatalf("unexpected claim mode: %s", claimA.Mode)
+	}
+
+	historyA, err := manager.PotsoRewardsHistory(participantA)
+	if err != nil {
+		t.Fatalf("history retrieval: %v", err)
+	}
+	if len(historyA) != 0 {
+		t.Fatalf("expected empty history before claim")
+	}
+
+	eventsList := node.state.Events()
+	readyCount := 0
+	paidCount := 0
+	for _, evt := range eventsList {
+		switch evt.Type {
+		case events.TypePotsoRewardReady:
+			readyCount++
+		case events.TypePotsoRewardPaid:
+			paidCount++
+		}
+	}
+	if readyCount == 0 {
+		t.Fatalf("expected ready events in claim mode")
+	}
+	if paidCount != 0 {
+		t.Fatalf("expected no paid events before manual claim")
+	}
+
+	payoutA, _, err := manager.PotsoRewardsGetPayout(0, participantA)
+	if err != nil {
+		t.Fatalf("payout lookup: %v", err)
+	}
+	payoutB, _, err := manager.PotsoRewardsGetPayout(0, participantB)
+	if err != nil {
+		t.Fatalf("payout lookup B: %v", err)
+	}
+
+	paid, amount, err := node.PotsoRewardClaim(0, participantA)
+	if err != nil {
+		t.Fatalf("claim payout: %v", err)
+	}
+	if !paid {
+		t.Fatalf("expected payout to occur on first claim")
+	}
+	if amount.Cmp(payoutA) != 0 {
+		t.Fatalf("claimed amount mismatch: %s vs %s", amount, payoutA)
+	}
+
+	claimA, ok, err = manager.PotsoRewardsGetClaim(0, participantA)
+	if err != nil || !ok || claimA == nil || !claimA.Claimed {
+		t.Fatalf("claim should be marked claimed after payout")
+	}
+	if claimA.ClaimedAt == 0 {
+		t.Fatalf("expected claimedAt timestamp to be recorded")
+	}
+
+	historyA, err = manager.PotsoRewardsHistory(participantA)
+	if err != nil {
+		t.Fatalf("history after claim: %v", err)
+	}
+	if len(historyA) != 1 {
+		t.Fatalf("expected one history entry after claim, got %d", len(historyA))
+	}
+	if historyA[0].Mode != potso.RewardPayoutModeClaim {
+		t.Fatalf("unexpected history mode after claim: %s", historyA[0].Mode)
+	}
+
+	paidAgain, _, err := node.PotsoRewardClaim(0, participantA)
+	if err != nil {
+		t.Fatalf("idempotent claim error: %v", err)
+	}
+	if paidAgain {
+		t.Fatalf("expected idempotent claim to report paid=false")
+	}
+
+	updatedTreasury, err := manager.GetAccount(treasury[:])
+	if err != nil {
+		t.Fatalf("reload treasury: %v", err)
+	}
+	expectedTreasury := big.NewInt(900)
+	expectedTreasury.Sub(expectedTreasury, payoutA)
+	if updatedTreasury.BalanceZNHB.Cmp(expectedTreasury) != 0 {
+		t.Fatalf("treasury not debited after claim: %s", updatedTreasury.BalanceZNHB)
+	}
+
+	eventsList = node.state.Events()
+	paidCount = 0
+	for _, evt := range eventsList {
+		if evt.Type == events.TypePotsoRewardPaid {
+			paidCount++
+		}
+	}
+	if paidCount == 0 {
+		t.Fatalf("expected paid event after manual claim")
+	}
+
+	csvData, totalPaid, winners, err := manager.PotsoRewardsBuildCSV(0)
+	if err != nil {
+		t.Fatalf("build csv: %v", err)
+	}
+	if winners != 2 {
+		t.Fatalf("expected two winners in CSV, got %d", winners)
+	}
+	expectedTotal := new(big.Int).Add(payoutA, payoutB)
+	if totalPaid.Cmp(expectedTotal) != 0 {
+		t.Fatalf("csv total mismatch: %s vs %s", totalPaid, expectedTotal)
+	}
+	records, err := csv.NewReader(bytes.NewReader(csvData)).ReadAll()
+	if err != nil {
+		t.Fatalf("parse csv: %v", err)
+	}
+	if len(records) != 3 { // header + 2 rows
+		t.Fatalf("expected 3 CSV rows, got %d", len(records))
+	}
+	addrA := crypto.NewAddress(crypto.NHBPrefix, participantA[:]).String()
+	addrB := crypto.NewAddress(crypto.NHBPrefix, participantB[:]).String()
+	seenA := false
+	seenB := false
+	for _, row := range records[1:] {
+		if len(row) != 5 {
+			t.Fatalf("unexpected CSV columns: %v", row)
+		}
+		switch row[0] {
+		case addrA:
+			seenA = true
+			if row[1] != payoutA.String() {
+				t.Fatalf("csv amount mismatch for A: %s", row[1])
+			}
+			if row[2] != "true" {
+				t.Fatalf("expected A to be marked claimed")
+			}
+			claimedAt, err := strconv.ParseUint(row[3], 10, 64)
+			if err != nil || claimedAt == 0 {
+				t.Fatalf("invalid claimedAt for A: %s", row[3])
+			}
+			if row[4] != string(potso.RewardPayoutModeClaim) {
+				t.Fatalf("expected claim mode in CSV for A, got %s", row[4])
+			}
+		case addrB:
+			seenB = true
+			if row[1] != payoutB.String() {
+				t.Fatalf("csv amount mismatch for B: %s", row[1])
+			}
+			if row[2] != "false" {
+				t.Fatalf("expected B to be unclaimed")
+			}
+			if row[3] != "0" {
+				t.Fatalf("expected claimedAt 0 for B, got %s", row[3])
+			}
+			if row[4] != string(potso.RewardPayoutModeClaim) {
+				t.Fatalf("expected claim mode in CSV for B, got %s", row[4])
+			}
+		}
+	}
+	if !seenA || !seenB {
+		t.Fatalf("csv rows missing: A=%v B=%v", seenA, seenB)
+	}
+}
+
+func TestPotsoRewardHistoryPagination(t *testing.T) {
+	db := storage.NewMemDB()
+	t.Cleanup(db.Close)
+
+	validatorKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key: %v", err)
+	}
+	node, err := NewNode(db, validatorKey, "", true)
+	if err != nil {
+		t.Fatalf("new node: %v", err)
+	}
+
+	treasury := [20]byte{9}
+	cfg := potso.RewardConfig{
+		EpochLengthBlocks:  2,
+		AlphaStakeBps:      7000,
+		MinPayoutWei:       big.NewInt(0),
+		EmissionPerEpoch:   big.NewInt(900),
+		TreasuryAddress:    treasury,
+		MaxWinnersPerEpoch: 10,
+		CarryRemainder:     true,
+		PayoutMode:         potso.RewardPayoutModeAuto,
+	}
+	if err := node.SetPotsoRewardConfig(cfg); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+
+	manager := nhbstate.NewManager(node.state.Trie)
+	treasuryAcc, err := manager.GetAccount(treasury[:])
+	if err != nil {
+		t.Fatalf("treasury account: %v", err)
+	}
+	treasuryAcc.BalanceZNHB = big.NewInt(3000)
+	if err := manager.PutAccount(treasury[:], treasuryAcc); err != nil {
+		t.Fatalf("store treasury: %v", err)
+	}
+
+	participant := [20]byte{4}
+	other := [20]byte{5}
+	if err := manager.PotsoStakeSetBondedTotal(participant, big.NewInt(600)); err != nil {
+		t.Fatalf("set stake participant: %v", err)
+	}
+	if err := manager.PotsoStakeSetBondedTotal(other, big.NewInt(400)); err != nil {
+		t.Fatalf("set stake other: %v", err)
+	}
+
+	base := time.Now().UTC()
+	height := uint64(1)
+	processEpoch := func(day string, ts time.Time) {
+		if err := manager.PotsoPutMeter(participant, &potso.Meter{Day: day, UptimeSeconds: 30 * 60}); err != nil {
+			t.Fatalf("meter participant: %v", err)
+		}
+		if err := manager.PotsoPutMeter(other, &potso.Meter{Day: day, UptimeSeconds: 10 * 60}); err != nil {
+			t.Fatalf("meter other: %v", err)
+		}
+		if err := node.state.ProcessBlockLifecycle(height, ts.Add(-time.Second).Unix()); err != nil {
+			t.Fatalf("process block %d: %v", height, err)
+		}
+		height++
+		if err := node.state.ProcessBlockLifecycle(height, ts.Unix()); err != nil {
+			t.Fatalf("process block %d: %v", height, err)
+		}
+		height++
+	}
+
+	// Epoch 0 auto
+	processEpoch(base.Format(potso.DayFormat), base)
+
+	// Switch to claim mode for epoch 1
+	cfg.PayoutMode = potso.RewardPayoutModeClaim
+	if err := node.SetPotsoRewardConfig(cfg); err != nil {
+		t.Fatalf("switch to claim mode: %v", err)
+	}
+	processEpoch(base.Add(24*time.Hour).Format(potso.DayFormat), base.Add(24*time.Hour))
+	payoutEpoch1, _, err := manager.PotsoRewardsGetPayout(1, participant)
+	if err != nil {
+		t.Fatalf("payout epoch1: %v", err)
+	}
+	if payoutEpoch1.Sign() == 0 {
+		t.Fatalf("expected payout for epoch 1")
+	}
+	if paid, _, err := node.PotsoRewardClaim(1, participant); err != nil || !paid {
+		t.Fatalf("claim epoch1: paid=%v err=%v", paid, err)
+	}
+
+	// Switch back to auto for epoch 2
+	cfg.PayoutMode = potso.RewardPayoutModeAuto
+	if err := node.SetPotsoRewardConfig(cfg); err != nil {
+		t.Fatalf("switch to auto mode: %v", err)
+	}
+	processEpoch(base.Add(48*time.Hour).Format(potso.DayFormat), base.Add(48*time.Hour))
+
+	entries, nextCursor, err := node.PotsoRewardsHistory(participant, "", 2)
+	if err != nil {
+		t.Fatalf("history page 1: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries on first page, got %d", len(entries))
+	}
+	if entries[0].Mode != potso.RewardPayoutModeAuto || entries[0].Epoch != 2 {
+		t.Fatalf("expected latest entry to be epoch 2 auto, got epoch %d mode %s", entries[0].Epoch, entries[0].Mode)
+	}
+	if entries[1].Mode != potso.RewardPayoutModeClaim || entries[1].Epoch != 1 {
+		t.Fatalf("expected second entry to be epoch 1 claim, got epoch %d mode %s", entries[1].Epoch, entries[1].Mode)
+	}
+	if strings.TrimSpace(nextCursor) == "" {
+		t.Fatalf("expected next cursor for remaining history")
+	}
+
+	more, next, err := node.PotsoRewardsHistory(participant, nextCursor, 2)
+	if err != nil {
+		t.Fatalf("history page 2: %v", err)
+	}
+	if len(more) != 1 {
+		t.Fatalf("expected remaining single entry, got %d", len(more))
+	}
+	if more[0].Epoch != 0 || more[0].Mode != potso.RewardPayoutModeAuto {
+		t.Fatalf("unexpected oldest entry epoch=%d mode=%s", more[0].Epoch, more[0].Mode)
+	}
+	if next != "" {
+		t.Fatalf("expected no further cursor, got %q", next)
 	}
 }

--- a/docs/potso/compliance-overview.md
+++ b/docs/potso/compliance-overview.md
@@ -1,0 +1,45 @@
+# POTSO Rewards Compliance Overview
+
+This document explains the POTSO reward mechanics for auditors, regulators, and investors. The goal is to demonstrate that the
+program distributes loyalty-style rebates rather than investment returns.
+
+## Program Purpose
+
+* **Objective:** reward merchants, validators, and ambassadors for on-chain engagement (staking, uptime, transaction volume).
+* **Funding source:** pre-allocated ZapNHB treasury controlled by the foundation. No user deposits are pooled or re-invested.
+* **Deterministic math:** epoch emissions, weight functions, and payout thresholds are configured on-chain via `config.toml` and
+  cannot be modified retroactively for a closed epoch.
+
+## Process Summary
+
+1. During each block the node tracks engagement meters (uptime, escrow activity, etc.).
+2. At the end of an epoch (`EpochLengthBlocks`) the node computes weights and ranks participants using the published parameters.
+3. The budget for the epoch equals `EmissionPerEpochWei` (subject to the treasury balance). No leverage or compounding occurs.
+4. Winners receive a payout proportional to their weight, provided it exceeds `MinPayoutWei`.
+5. Settlement is performed either automatically (`auto` mode) or via signed claims (`claim` mode). In both cases the only funds
+   that move are the budgeted ZapNHB held in the treasury account.
+
+## Key Compliance Points
+
+* **Non-investment contract:** rewards compensate for measurable activity (service provision, network uptime). Winners do not
+  invest capital with an expectation of profit derived from others.
+* **No user custody:** participants never transfer their tokens to POTSO for management. Claims simply release pre-earned
+  rewards from the foundation treasury.
+* **Transparent records:**
+  * `PotsoRewardsGetClaim` and `PotsoRewardsHistory` expose every settlement with timestamps and modes.
+  * `potso_export_epoch` produces immutable CSVs suitable for audit sampling.
+  * Events (`potso.reward.ready`, `potso.reward.paid`) provide real-time attestations.
+* **Controls:** claim signatures ensure only the rightful address can receive funds. Treasury shortfalls raise explicit errors
+  and do not create liabilities to participants.
+
+## Reporting & Disclosures
+
+* **Financial statements:** treat payouts as operating expense (marketing/loyalty). The ledger includes epoch, address, amount,
+  and mode for each entry.
+* **Regulatory reporting:** the deterministic emission schedule and absence of user deposits simplify oversight—regulators can
+  reproduce the weight calculations using public data.
+* **Investor updates:** highlight that claim mode enables deferral of cash outflows until program goals are met, while still
+  honouring earned rewards.
+
+The combination of deterministic budgeting, explicit ledgers, and separation of user funds positions POTSO rewards as a
+compliance-friendly loyalty mechanism rather than a securities offering.

--- a/docs/potso/notifications.md
+++ b/docs/potso/notifications.md
@@ -1,0 +1,64 @@
+# POTSO Reward Notifications
+
+Settlement events are emitted by the node every time a reward becomes claimable or is paid. Operators typically forward these
+events to downstream systems (email, CRM, treasury bots) via webhooks.
+
+## Event Types
+
+| Event | Mode | Attributes |
+|-------|------|------------|
+| `potso.reward.ready` | claim mode only | `epoch`, `address`, `amount`, `mode` (always `claim`) |
+| `potso.reward.paid`  | both modes      | `epoch`, `address`, `amount`, `mode` (`auto` or `claim`) |
+
+Events are queued inside the state processor and accessible through the existing event streaming interfaces. Each attribute is
+encoded as a string. In claim mode the `ready` event is emitted at epoch close while `paid` fires after a successful
+`potso_reward_claim` call.
+
+## Webhook Envelope
+
+Downstream services commonly deliver events using an HTTP POST with the following envelope:
+
+```json
+{
+  "type": "potso.reward.ready",
+  "emittedAt": "2024-03-18T12:30:00Z",
+  "data": {
+    "epoch": 199,
+    "address": "nhb1examplewinner...",
+    "amount": "920000000000000000000",
+    "mode": "claim"
+  },
+  "signature": "sha256=..."
+}
+```
+
+* `type` mirrors the on-chain event type.
+* `emittedAt` should be populated by the webhook dispatcher using the node’s wall clock.
+* `signature` is an HMAC (recommended) or detached signature that allows receivers to verify authenticity.
+
+## Retry & Backoff
+
+1. Use exponential backoff with jitter. A starting delay of 5 seconds doubling up to 10 minutes works well.
+2. Keep a delivery log including the HTTP status and error body for each attempt.
+3. After a maximum number of attempts (e.g. 15) escalate to operators but retain the event in a dead-letter queue for manual
+   replay.
+
+## Implementing Signature Verification
+
+* Choose a shared secret (`POTSO_WEBHOOK_SECRET`).
+* The dispatcher signs `HMAC_SHA256(secret, type + "|" + emittedAt + "|" + base64(data_json))`.
+* Receivers recompute the HMAC and compare using a constant-time check.
+* Rotate the secret periodically and keep the previous secret available during the transition window to avoid losing events.
+
+## Operational Recommendations
+
+* **Idempotency:** include the tuple `(type, epoch, address)` in the webhook payload. Receivers should treat this as an
+  idempotency key to avoid double-processing.
+* **Alerting:** trigger alerts when ready events remain unclaimed past SLA thresholds. History pagination exposes which entries
+  are still pending.
+* **Auditing:** store webhook payloads (after signature verification) alongside the CSV exports to maintain a full audit trail.
+* **Testing:** use `nhb-cli potso reward claim` and `potso_export_epoch` against a devnet to validate webhook consumers before
+  flipping the production node to claim mode.
+
+These guidelines keep notification pipelines resilient and verifiable while delivering real-time visibility into reward
+settlement.

--- a/docs/potso/rewards-api.md
+++ b/docs/potso/rewards-api.md
@@ -1,0 +1,145 @@
+# POTSO Rewards API Reference
+
+This guide documents the settlement endpoints introduced with POTSO settlement claim mode and the supporting history/export
+features. All methods follow JSON-RPC 2.0 semantics and are exposed by the node RPC server.
+
+## RPC Methods
+
+### `potso_reward_claim`
+
+Claims a pending reward. Requires RPC auth and a signature produced by the winning address.
+
+**Parameters**
+
+```json
+{
+  "epoch": 123,
+  "address": "nhb1examplewinner...",
+  "signature": "0x..."   // 65 byte secp256k1 signature over the claim digest
+}
+```
+
+**Digest format**
+
+```
+potso_reward_claim|<epoch>|<lowercase_bech32_address>
+```
+
+**Response**
+
+```json
+{
+  "paid": true,
+  "amount": "899000000000000000000"
+}
+```
+
+`paid` is `false` on idempotent retries. Errors map to:
+
+| Condition | HTTP status | JSON-RPC error | Notes |
+|-----------|-------------|----------------|-------|
+| Invalid signature/parameters | 400 | `codeInvalidParams` | Signature must recover the provided address. |
+| Reward not found | 404 | `codeServerError` | Ledger entry was not created for the epoch/address pair. |
+| Claiming disabled | 400 | `codeInvalidParams` | Current payout mode is `auto`. |
+| Insufficient treasury | 409 | `codeServerError` with data `INSUFFICIENT_TREASURY` | Treasury must be refilled; claim remains pending. |
+
+### `potso_rewards_history`
+
+Returns the chronological settlement history for an address (newest first). No authentication is required.
+
+**Parameters**
+
+```json
+{
+  "address": "nhb1examplewinner...",
+  "cursor": "2",    // optional zero-based offset encoded as a string
+  "limit": 2          // optional page size, defaults to 50
+}
+```
+
+**Response**
+
+```json
+{
+  "address": "nhb1examplewinner...",
+  "entries": [
+    { "epoch": 200, "amount": "850000000000000000000", "mode": "auto" },
+    { "epoch": 199, "amount": "920000000000000000000", "mode": "claim" }
+  ],
+  "nextCursor": "2"
+}
+```
+
+`nextCursor` is omitted when no further pages remain.
+
+### `potso_export_epoch`
+
+Builds a CSV export for reconciliation.
+
+**Parameters**
+
+```json
+{ "epoch": 199 }
+```
+
+**Response**
+
+```json
+{
+  "epoch": 199,
+  "csvBase64": "YWRkcmVzcyxhbW91bnQsY2xhaW1lZCxjbGFpbWVkQXQsbW9kZQpu...",
+  "totalPaid": "1770000000000000000000",
+  "winners": 2
+}
+```
+
+The decoded CSV contains the columns `address,amount,claimed,claimedAt,mode` (claimedAt is a Unix timestamp). The file is
+sorted in winner order.
+
+## CLI Commands
+
+The CLI surfaces helper commands under `nhb-cli potso reward`:
+
+* `nhb-cli potso reward claim --epoch 199 --addr nhb1... [--key wallet.key]`
+* `nhb-cli potso reward history --addr nhb1... [--cursor N] [--limit M]`
+* `nhb-cli potso reward export --epoch 199 > rewards-199.csv`
+
+The claim command signs the digest locally using the provided key file and requires `NHB_RPC_TOKEN` to be set. `history`
+returns the raw JSON payload. `export` streams the decoded CSV bytes to STDOUT, making shell redirects straightforward.
+
+## OpenAPI Fragment
+
+```yaml
+paths:
+  /rpc:
+    post:
+      summary: POTSO reward RPC
+      description: JSON-RPC entry point for POTSO reward settlement methods.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                jsonrpc:
+                  type: string
+                  example: "2.0"
+                method:
+                  type: string
+                  enum: [potso_reward_claim, potso_rewards_history, potso_export_epoch]
+                params:
+                  type: array
+                  items:
+                    type: object
+                id:
+                  type: integer
+      responses:
+        '200':
+          description: JSON-RPC success envelope
+        '4XX':
+          description: JSON-RPC error envelope
+```
+
+For a complete schema include the method-specific parameter/response shapes described above and the shared error envelopes
+defined in `docs/openapi`.

--- a/docs/potso/rewards-modes.md
+++ b/docs/potso/rewards-modes.md
@@ -1,0 +1,79 @@
+# POTSO Reward Payout Modes
+
+The POTSO module now supports two settlement strategies for distributing ZapNHB rewards. Both modes use the same emission
+math and winner selection logic. The only difference is *how* the computed balances are transferred from the treasury to
+participants.
+
+## Mode Comparison
+
+| Mode  | Treasury Movement | Winner Experience | Operational Impact |
+|-------|-------------------|-------------------|--------------------|
+| `auto`  | Treasury debited and winners credited automatically during epoch close. | Funds arrive without user action. | Requires the treasury to stay continuously funded. Failed debits halt the epoch. |
+| `claim` | Treasury debited only when the winner submits a signed claim. A ledger entry is created at epoch close. | Winners receive a webhook/notification and must submit a claim transaction. | Operators gain flexibility to schedule treasury top-ups and apply off-chain checks before approving payouts. |
+
+### Auto Mode
+
+* **When to use:** high-trust, low-latency environments (e.g. public marketing programs) where immediate settlement is
+  more important than workflow control.
+* **How it works:** once `maybeProcessPotsoRewards` finalises an epoch, the node subtracts the total paid amount from the
+  configured treasury account and credits each winner. `potso.reward.paid` events are emitted immediately. A claim record is
+  still written for audit purposes (`claimed=true`, `mode=auto`).
+* **Operational guardrails:** keep the treasury topped up above the configured emission. If the balance cannot cover the
+  computed payout the epoch fails with `potso.ErrInsufficientTreasury` and operators must fund the account before retrying.
+
+### Claim Mode
+
+* **When to use:** controlled payouts (e.g. loyalty rebates, ambassador programs) where finance/compliance teams want to run
+  additional checks or batch treasury top-ups before releasing rewards.
+* **How it works:** epoch processing stores a ledger entry per winner (`claimed=false`, `mode=claim`) and emits
+  `potso.reward.ready` webhooks. No funds move at this stage. Winners (or downstream automation) call the
+  `potso_reward_claim` RPC with a signature that proves ownership. The node debits the treasury at claim time, updates the
+  ledger, appends the history entry, and emits `potso.reward.paid` with `mode=claim`.
+* **Operational guardrails:** treasury must be funded before the claim executes. If insufficient balance exists the claim
+  fails with `INSUFFICIENT_TREASURY` and the ledger remains `claimed=false`. Claims are idempotent; retries after funding the
+  treasury succeed without double-paying.
+
+## Configuration
+
+The payout mode is configured in `config.toml`:
+
+```toml
+[potso.rewards]
+PayoutMode = "auto"   # or "claim"
+TreasuryAddress = "nhb1..."
+EmissionPerEpochWei = "1000000000000000000000"
+MinPayoutWei = "1000000000000000"
+```
+
+`config.PotsoRewardConfig()` normalises the value (`auto` becomes the default when the field is omitted). Mode changes take
+effect immediately after the configuration is reloaded; the next epoch will follow the new settlement flow.
+
+## Mode Switching Guidance
+
+1. **Announce the change.** Notify stakeholders, wallet teams, and downstream services before switching modes.
+2. **Drain the queue.** When moving from `claim` to `auto`, ensure that all outstanding claims are settled to avoid surprises
+   when future exports show mixed modes.
+3. **Monitor webhooks and history.** The new ledger records (`PotsoRewardsGetClaim`, `PotsoRewardsHistory`) expose the mode for
+   every entry. Dashboards should surface the mode to differentiate auto vs. manual payouts.
+4. **Update off-chain automation.** Claim mode requires downstream workers (bots, finance ops) to submit signed claims. CLI
+   support is provided via `nhb-cli potso reward claim`.
+
+## Operational Trade-offs
+
+* **Cash management:** claim mode lets treasury teams bundle top-ups and apply manual review. Auto mode favours simplicity at
+  the cost of needing larger standing balances.
+* **User experience:** auto mode delivers instant gratification. Claim mode introduces an extra step but gives room for UI flows
+  that verify KYC or prompt the user to update payout accounts.
+* **Risk management:** claim mode is resilient to temporary treasury shortages because the ledger remains open until funds are
+  replenished. Auto mode produces a hard failure when balances are insufficient.
+
+## Failure Handling Checklist
+
+| Scenario | Auto Mode Behaviour | Claim Mode Behaviour | Operator Action |
+|----------|--------------------|----------------------|-----------------|
+| Treasury balance below payout | Epoch processing aborts with `potso.ErrInsufficientTreasury`. | Claim attempts return `INSUFFICIENT_TREASURY` until funds arrive. | Fund treasury, rerun claim/epoch. |
+| User retries claim | N/A (already paid). | Idempotent – `paid=false`, amount returned for transparency. | Inform user no additional action is needed. |
+| Mode switched mid-series | New epochs adopt the new mode; historical entries retain their recorded mode. | Same. | Communicate expected behaviour; exports include the `mode` field for reconciliation. |
+
+Keep the mode decision aligned with product goals, treasury governance, and customer expectations. Both paths are available at
+runtime without redeploying the chain.

--- a/docs/potso/treasury-and-controls.md
+++ b/docs/potso/treasury-and-controls.md
@@ -1,0 +1,51 @@
+# Treasury Operations & Controls
+
+The POTSO reward pipeline moves ZapNHB from the configured treasury account to winning addresses. Settlement mode controls *when*
+this movement happens, but finance teams retain responsibility for cash management and controls.
+
+## Key Roles
+
+| Role | Responsibilities |
+|------|------------------|
+| Treasury Operations | Fund the `potso.rewards.TreasuryAddress`, monitor balances, and approve claim batches. |
+| Compliance / Risk | Review claim ledgers, flag anomalous payouts, and maintain access policies for RPC credentials. |
+| Engineering | Maintain node infrastructure, configure payout mode, monitor RPC/webhook health, and ship CLI/bot tooling. |
+
+## Balance Management
+
+* **Working capital:** keep at least one epoch of headroom in auto mode, and enough to satisfy the largest expected claim batch in
+  claim mode. `potso_export_epoch` totals help size replenishments.
+* **Top-ups:** treasury funding is a standard ZapNHB transfer into the configured address. No on-chain configuration change is
+  required.
+* **Shortfalls:**
+  * Auto mode aborts epoch processing with `potso.ErrInsufficientTreasury`.
+  * Claim mode rejects individual claims with `INSUFFICIENT_TREASURY`; the ledger entry remains pending.
+  * In both cases: fund the treasury and retry (epoch processing resumes automatically on the next block; claims can be re-run via
+    CLI or automation).
+
+## Ledger & Audit Trail
+
+* **Claim ledger:** `PotsoRewardsGetClaim(epoch, addr)` exposes `{amount, claimed, claimedAt, mode}`. The ledger is written at
+  epoch close (for both modes) and updated when settlement happens.
+* **History ledger:** `PotsoRewardsHistory(addr)` returns a chronological log of paid entries including the mode. Use it for user
+  statements, reconciliations, and regulator reports.
+* **Exports:** `potso_export_epoch` produces a CSV suitable for archival storage and cross-checking bank statements.
+* **Events:** subscribe to `potso.reward.ready` (claim mode) and `potso.reward.paid` to build downstream audit logs and alerting.
+
+## Controls Checklist
+
+1. **Access separation:** store `NHB_RPC_TOKEN` in a secrets manager. Only treasury automation and approved operators should be
+   able to call `potso_reward_claim`.
+2. **Dual approval (optional):** in claim mode, route ready notifications through internal workflow tools (e.g., Jira, GRC
+   systems) before running the claim bot.
+3. **Reconciliation cadence:**
+   * Daily: export the most recent epoch and reconcile against treasury debits.
+   * Monthly: roll up `PotsoRewardsHistory` per address to satisfy loyalty/compliance reporting.
+4. **Incident response:** if a claim was processed in error, reverse it using standard ZapNHB transfer tooling and mark the ledger
+   entry in the downstream accounting system. On-chain the record remains immutable but subsequent exports show the corrective
+   transfer.
+5. **Key rotation:** rotate the signing keys used by automation that submits claims at least quarterly. Update the CLI/automation
+   configuration accordingly.
+
+Following these controls keeps the POTSO reward program aligned with finance policies while delivering predictable settlement
+experience to participants.

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -333,17 +333,17 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handlePotsoHeartbeat(w, r, req)
 	case "potso_userMeters":
 		s.handlePotsoUserMeters(w, r, req)
-        case "potso_top":
-                s.handlePotsoTop(w, r, req)
-        case "potso_leaderboard":
-                s.handlePotsoLeaderboard(w, r, req)
-        case "potso_params":
-                s.handlePotsoParams(w, r, req)
-        case "potso_stake_lock":
-                if authErr := s.requireAuth(r); authErr != nil {
-                        writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
-                        return
-                }
+	case "potso_top":
+		s.handlePotsoTop(w, r, req)
+	case "potso_leaderboard":
+		s.handlePotsoLeaderboard(w, r, req)
+	case "potso_params":
+		s.handlePotsoParams(w, r, req)
+	case "potso_stake_lock":
+		if authErr := s.requireAuth(r); authErr != nil {
+			writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+			return
+		}
 		s.handlePotsoStakeLock(w, r, req)
 	case "potso_stake_unbond":
 		if authErr := s.requireAuth(r); authErr != nil {
@@ -367,6 +367,16 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handlePotsoEpochInfo(w, r, req)
 	case "potso_epoch_payouts":
 		s.handlePotsoEpochPayouts(w, r, req)
+	case "potso_reward_claim":
+		if authErr := s.requireAuth(r); authErr != nil {
+			writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+			return
+		}
+		s.handlePotsoRewardClaim(w, r, req)
+	case "potso_rewards_history":
+		s.handlePotsoRewardsHistory(w, r, req)
+	case "potso_export_epoch":
+		s.handlePotsoExportEpoch(w, r, req)
 	default:
 		writeError(w, http.StatusNotFound, req.ID, codeMethodNotFound, fmt.Sprintf("unknown method %s", req.Method), nil)
 	}

--- a/rpc/potso_reward_handlers.go
+++ b/rpc/potso_reward_handlers.go
@@ -1,12 +1,20 @@
 package rpc
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"strings"
 
 	"nhbchain/crypto"
+	"nhbchain/native/potso"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
 type potsoEpochInfoParams struct {
@@ -40,6 +48,53 @@ type potsoEpochPayoutEntry struct {
 type potsoEpochPayoutsResult struct {
 	Epoch   uint64                  `json:"epoch"`
 	Payouts []potsoEpochPayoutEntry `json:"payouts"`
+}
+
+type potsoRewardClaimParams struct {
+	Epoch     uint64 `json:"epoch"`
+	Address   string `json:"address"`
+	Signature string `json:"signature"`
+}
+
+type potsoRewardClaimResult struct {
+	Paid   bool   `json:"paid"`
+	Amount string `json:"amount"`
+}
+
+type potsoRewardHistoryParams struct {
+	Address string `json:"address"`
+	Cursor  string `json:"cursor,omitempty"`
+	Limit   int    `json:"limit,omitempty"`
+}
+
+type potsoRewardHistoryEntry struct {
+	Epoch  uint64 `json:"epoch"`
+	Amount string `json:"amount"`
+	Mode   string `json:"mode"`
+}
+
+type potsoRewardHistoryResult struct {
+	Address    string                    `json:"address"`
+	Entries    []potsoRewardHistoryEntry `json:"entries"`
+	NextCursor string                    `json:"nextCursor,omitempty"`
+}
+
+type potsoRewardExportParams struct {
+	Epoch uint64 `json:"epoch"`
+}
+
+type potsoRewardExportResult struct {
+	Epoch     uint64 `json:"epoch"`
+	CSVBase64 string `json:"csvBase64"`
+	TotalPaid string `json:"totalPaid"`
+	Winners   int    `json:"winners"`
+}
+
+func rewardClaimDigest(epoch uint64, addr string) []byte {
+	normalized := strings.ToLower(strings.TrimSpace(addr))
+	payload := fmt.Sprintf("potso_reward_claim|%d|%s", epoch, normalized)
+	digest := sha256.Sum256([]byte(payload))
+	return digest[:]
 }
 
 func (s *Server) handlePotsoEpochInfo(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
@@ -131,6 +186,123 @@ func (s *Server) handlePotsoEpochPayouts(w http.ResponseWriter, _ *http.Request,
 			User:   user,
 			Amount: bigIntString(payout.Amount),
 		}
+	}
+	writeResult(w, req.ID, result)
+}
+
+func (s *Server) handlePotsoRewardClaim(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "claim requires parameter object", nil)
+		return
+	}
+	var params potsoRewardClaimParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameters", err.Error())
+		return
+	}
+	if params.Address == "" || params.Signature == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "address and signature are required", nil)
+		return
+	}
+	addr, err := decodeBech32(params.Address)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid address", err.Error())
+		return
+	}
+	sig, err := decodeHexBytes(params.Signature)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid signature", err.Error())
+		return
+	}
+	if len(sig) != 65 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "signature must be 65 bytes", nil)
+		return
+	}
+	digest := rewardClaimDigest(params.Epoch, params.Address)
+	pubKey, err := ethcrypto.SigToPub(digest, sig)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid signature", err.Error())
+		return
+	}
+	recovered := ethcrypto.PubkeyToAddress(*pubKey)
+	if !strings.EqualFold(recovered.Hex()[2:], hex.EncodeToString(addr[:])) {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "signature does not match address", nil)
+		return
+	}
+
+	paid, amount, claimErr := s.node.PotsoRewardClaim(params.Epoch, addr)
+	if claimErr != nil {
+		switch {
+		case errors.Is(claimErr, potso.ErrRewardNotFound):
+			writeError(w, http.StatusNotFound, req.ID, codeServerError, "reward not found", nil)
+		case errors.Is(claimErr, potso.ErrClaimingDisabled):
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "claiming disabled", nil)
+		case errors.Is(claimErr, potso.ErrInsufficientTreasury):
+			writeError(w, http.StatusConflict, req.ID, codeServerError, "INSUFFICIENT_TREASURY", nil)
+		default:
+			writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "failed to claim reward", claimErr.Error())
+		}
+		return
+	}
+	result := potsoRewardClaimResult{Paid: paid, Amount: bigIntString(amount)}
+	writeResult(w, req.ID, result)
+}
+
+func (s *Server) handlePotsoRewardsHistory(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "history requires parameter object", nil)
+		return
+	}
+	var params potsoRewardHistoryParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameters", err.Error())
+		return
+	}
+	if params.Address == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "address required", nil)
+		return
+	}
+	addr, err := decodeBech32(params.Address)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid address", err.Error())
+		return
+	}
+	entries, nextCursor, histErr := s.node.PotsoRewardsHistory(addr, params.Cursor, params.Limit)
+	if histErr != nil {
+		writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "failed to load history", histErr.Error())
+		return
+	}
+	result := potsoRewardHistoryResult{Address: params.Address, Entries: make([]potsoRewardHistoryEntry, len(entries)), NextCursor: nextCursor}
+	for i, entry := range entries {
+		amount := "0"
+		if entry.Amount != nil {
+			amount = entry.Amount.String()
+		}
+		result.Entries[i] = potsoRewardHistoryEntry{Epoch: entry.Epoch, Amount: amount, Mode: string(entry.Mode.Normalise())}
+	}
+	writeResult(w, req.ID, result)
+}
+
+func (s *Server) handlePotsoExportEpoch(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "export requires parameter object", nil)
+		return
+	}
+	var params potsoRewardExportParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameters", err.Error())
+		return
+	}
+	data, total, winners, err := s.node.PotsoExportEpoch(params.Epoch)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "failed to export epoch", err.Error())
+		return
+	}
+	result := potsoRewardExportResult{
+		Epoch:     params.Epoch,
+		CSVBase64: base64.StdEncoding.EncodeToString(data),
+		TotalPaid: bigIntString(total),
+		Winners:   winners,
 	}
 	writeResult(w, req.ID, result)
 }


### PR DESCRIPTION
## Summary
- add configurable payout modes and claim ledger support for POTSO rewards
- persist reward history, expose CSV exports, and implement RPC/CLI claim + history flows
- document settlement operations, APIs, notifications, treasury controls, and compliance framing

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d429576bac832d8c78b56c5874f0d1