### PR TITLE
Add block execution context for deterministic processing

### DIFF
--- a/core/epoch_state_test.go
+++ b/core/epoch_state_test.go
@@ -3,13 +3,14 @@ package core
 import (
 	"math/big"
 	"testing"
-	"time"
 
 	"nhbchain/core/types"
 	"nhbchain/crypto"
 	"nhbchain/storage"
 	statetrie "nhbchain/storage/trie"
 )
+
+const testEpochTimestamp int64 = 1_700_000_100
 
 func newEpochStateProcessor(t *testing.T) *StateProcessor {
 	t.Helper()
@@ -60,7 +61,7 @@ func TestEpochSnapshotDeterminism(t *testing.T) {
 	b := seedValidator(t, sp, 3000, 5)
 	c := seedValidator(t, sp, 2500, 12)
 
-	if err := sp.ProcessBlockLifecycle(1, time.Now().Unix()); err != nil {
+	if err := sp.ProcessBlockLifecycle(1, testEpochTimestamp); err != nil {
 		t.Fatalf("process block: %v", err)
 	}
 
@@ -125,7 +126,7 @@ func TestEpochTieBreaks(t *testing.T) {
 		a, b = b, a
 	}
 
-	if err := sp.ProcessBlockLifecycle(1, time.Now().Unix()); err != nil {
+	if err := sp.ProcessBlockLifecycle(1, testEpochTimestamp); err != nil {
 		t.Fatalf("process block: %v", err)
 	}
 
@@ -154,7 +155,7 @@ func TestEpochRotationRespectsMinimumStake(t *testing.T) {
 	eligible2 := seedValidator(t, sp, 3000, 5)
 	_ = seedValidator(t, sp, 500, 100) // below minimum stake
 
-	if err := sp.ProcessBlockLifecycle(1, time.Now().Unix()); err != nil {
+	if err := sp.ProcessBlockLifecycle(1, testEpochTimestamp); err != nil {
 		t.Fatalf("process block: %v", err)
 	}
 

--- a/core/node_integration_test.go
+++ b/core/node_integration_test.go
@@ -45,9 +45,10 @@ func TestCommitBlockRollsBackOnApplyError(t *testing.T) {
 		t.Fatalf("compute tx root: %v", err)
 	}
 
+	fixedTime := time.Unix(1_700_000_000, 0).UTC()
 	header := &types.BlockHeader{
 		Height:    node.chain.GetHeight() + 1,
-		Timestamp: time.Now().Unix(),
+		Timestamp: fixedTime.Unix(),
 		PrevHash:  node.chain.Tip(),
 		TxRoot:    txRoot,
 		Validator: validatorKey.PubKey().Address().Bytes(),

--- a/core/potso_rewards_integration_test.go
+++ b/core/potso_rewards_integration_test.go
@@ -62,7 +62,7 @@ func TestProcessPotsoRewardEpoch(t *testing.T) {
 		t.Fatalf("set stake B: %v", err)
 	}
 
-	now := time.Now().UTC()
+	now := time.Unix(1_700_000_300, 0).UTC()
 	day := now.Format(potso.DayFormat)
 	if err := manager.PotsoPutMeter(participantA, &potso.Meter{Day: day, UptimeSeconds: 30 * 60}); err != nil {
 		t.Fatalf("put meter A: %v", err)
@@ -238,7 +238,7 @@ func TestPotsoRewardClaimFlow(t *testing.T) {
 		t.Fatalf("set stake B: %v", err)
 	}
 
-	now := time.Now().UTC()
+	now := time.Unix(1_700_000_400, 0).UTC()
 	day := now.Format(potso.DayFormat)
 	if err := manager.PotsoPutMeter(participantA, &potso.Meter{Day: day, UptimeSeconds: 30 * 60}); err != nil {
 		t.Fatalf("put meter A: %v", err)
@@ -469,7 +469,7 @@ func TestPotsoRewardHistoryPagination(t *testing.T) {
 		t.Fatalf("set stake other: %v", err)
 	}
 
-	base := time.Now().UTC()
+	base := time.Unix(1_700_000_500, 0).UTC()
 	height := uint64(1)
 	processEpoch := func(day string, ts time.Time) {
 		if err := manager.PotsoPutMeter(participant, &potso.Meter{Day: day, UptimeSeconds: 30 * 60}); err != nil {

--- a/core/rewards_logic_test.go
+++ b/core/rewards_logic_test.go
@@ -3,13 +3,17 @@ package core
 import (
 	"math/big"
 	"testing"
-	"time"
 
 	"nhbchain/core/rewards"
 	"nhbchain/core/types"
 	"nhbchain/crypto"
 	"nhbchain/storage"
 	statetrie "nhbchain/storage/trie"
+)
+
+const (
+	rewardBlockTimestamp1 int64 = 1_700_000_200
+	rewardBlockTimestamp2 int64 = 1_700_000_201
 )
 
 func newRewardTestState(t *testing.T) *StateProcessor {
@@ -70,10 +74,10 @@ func seedEligibleValidator(t *testing.T, sp *StateProcessor, stake int64, engage
 
 func finalizeRewardEpoch(t *testing.T, sp *StateProcessor) {
 	t.Helper()
-	if err := sp.ProcessBlockLifecycle(1, time.Now().Unix()); err != nil {
+	if err := sp.ProcessBlockLifecycle(1, rewardBlockTimestamp1); err != nil {
 		t.Fatalf("process block 1: %v", err)
 	}
-	if err := sp.ProcessBlockLifecycle(2, time.Now().Unix()); err != nil {
+	if err := sp.ProcessBlockLifecycle(2, rewardBlockTimestamp2); err != nil {
 		t.Fatalf("process block 2: %v", err)
 	}
 }
@@ -184,7 +188,7 @@ func TestRewardIdempotency(t *testing.T) {
 	}
 	balance := new(big.Int).Set(account.BalanceZNHB)
 	// Re-run final block lifecycle to ensure no double payment.
-	if err := sp.ProcessBlockLifecycle(2, time.Now().Unix()); err != nil {
+	if err := sp.ProcessBlockLifecycle(2, rewardBlockTimestamp2); err != nil {
 		t.Fatalf("reprocess block: %v", err)
 	}
 	second, ok := sp.LatestRewardEpochSettlement()


### PR DESCRIPTION
## Summary
- add a per-block execution context to `StateProcessor` with helpers to expose the active height/timestamp
- wire the execution context into EVM block setup and engagement tracking while ensuring the node sets it before running transactions
- update unit and integration tests to use fixed timestamps so block processing remains deterministic under test

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d450cdfe74832d8182f0f872a9b921