### PR TITLE
Enforce nonce validation for native transactions

### DIFF
--- a/core/engagement_state_test.go
+++ b/core/engagement_state_test.go
@@ -72,7 +72,15 @@ func TestEngagementEMAScore(t *testing.T) {
 		if err := tx.Sign(priv.PrivateKey); err != nil {
 			t.Fatalf("sign tx: %v", err)
 		}
-		if err := sp.applyHeartbeat(tx); err != nil {
+		sender, err := tx.From()
+		if err != nil {
+			t.Fatalf("derive sender: %v", err)
+		}
+		account, err := sp.getAccount(sender)
+		if err != nil {
+			t.Fatalf("load account: %v", err)
+		}
+		if err := sp.applyHeartbeat(tx, sender, account); err != nil {
 			t.Fatalf("apply heartbeat: %v", err)
 		}
 	}
@@ -170,7 +178,15 @@ func TestEngagementDailyCap(t *testing.T) {
 		if err := tx.Sign(priv.PrivateKey); err != nil {
 			t.Fatalf("sign tx: %v", err)
 		}
-		if err := sp.applyHeartbeat(tx); err != nil {
+		sender, err := tx.From()
+		if err != nil {
+			t.Fatalf("derive sender: %v", err)
+		}
+		account, err := sp.getAccount(sender)
+		if err != nil {
+			t.Fatalf("load account: %v", err)
+		}
+		if err := sp.applyHeartbeat(tx, sender, account); err != nil {
 			t.Fatalf("apply heartbeat: %v", err)
 		}
 	}
@@ -190,7 +206,16 @@ func TestEngagementDailyCap(t *testing.T) {
 	if err := tx.Sign(priv.PrivateKey); err != nil {
 		t.Fatalf("sign tx: %v", err)
 	}
-	if err := sp.applyHeartbeat(tx); err != nil {
+	var from []byte
+	from, err = tx.From()
+	if err != nil {
+		t.Fatalf("derive sender: %v", err)
+	}
+	senderAccount, err := sp.getAccount(from)
+	if err != nil {
+		t.Fatalf("load account: %v", err)
+	}
+	if err := sp.applyHeartbeat(tx, from, senderAccount); err != nil {
 		t.Fatalf("final heartbeat: %v", err)
 	}
 

--- a/core/state_transition_nonce_test.go
+++ b/core/state_transition_nonce_test.go
@@ -1,0 +1,172 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+func TestApplyTransactionRejectsNativeNonceReplay(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, sp *StateProcessor, addr []byte)
+		build func(t *testing.T, sp *StateProcessor, priv *crypto.PrivateKey) *types.Transaction
+	}{
+		{
+			name: "register identity",
+			setup: func(t *testing.T, sp *StateProcessor, addr []byte) {
+				t.Helper()
+				account := &types.Account{
+					BalanceNHB:  big.NewInt(0),
+					BalanceZNHB: big.NewInt(0),
+					Stake:       big.NewInt(0),
+				}
+				if err := sp.setAccount(addr, account); err != nil {
+					t.Fatalf("seed account: %v", err)
+				}
+			},
+			build: func(t *testing.T, _ *StateProcessor, priv *crypto.PrivateKey) *types.Transaction {
+				t.Helper()
+				tx := &types.Transaction{
+					ChainID:  types.NHBChainID(),
+					Type:     types.TxTypeRegisterIdentity,
+					Nonce:    0,
+					Data:     []byte("alice"),
+					GasLimit: 21000,
+					GasPrice: big.NewInt(1),
+				}
+				if err := tx.Sign(priv.PrivateKey); err != nil {
+					t.Fatalf("sign tx: %v", err)
+				}
+				return tx
+			},
+		},
+		{
+			name: "create escrow",
+			setup: func(t *testing.T, sp *StateProcessor, addr []byte) {
+				t.Helper()
+				account := &types.Account{
+					BalanceNHB:  big.NewInt(1_000),
+					BalanceZNHB: big.NewInt(0),
+					Stake:       big.NewInt(0),
+				}
+				if err := sp.setAccount(addr, account); err != nil {
+					t.Fatalf("seed escrow account: %v", err)
+				}
+			},
+			build: func(t *testing.T, _ *StateProcessor, priv *crypto.PrivateKey) *types.Transaction {
+				t.Helper()
+				payload := struct {
+					Amount *big.Int `json:"amount"`
+				}{Amount: big.NewInt(100)}
+				data, err := json.Marshal(payload)
+				if err != nil {
+					t.Fatalf("marshal payload: %v", err)
+				}
+				tx := &types.Transaction{
+					ChainID:  types.NHBChainID(),
+					Type:     types.TxTypeCreateEscrow,
+					Nonce:    0,
+					Data:     data,
+					GasLimit: 21000,
+					GasPrice: big.NewInt(1),
+				}
+				if err := tx.Sign(priv.PrivateKey); err != nil {
+					t.Fatalf("sign tx: %v", err)
+				}
+				return tx
+			},
+		},
+		{
+			name: "heartbeat",
+			setup: func(t *testing.T, sp *StateProcessor, addr []byte) {
+				t.Helper()
+				account := &types.Account{
+					BalanceNHB:  big.NewInt(0),
+					BalanceZNHB: big.NewInt(0),
+					Stake:       big.NewInt(0),
+				}
+				if err := sp.setAccount(addr, account); err != nil {
+					t.Fatalf("seed heartbeat account: %v", err)
+				}
+			},
+			build: func(t *testing.T, _ *StateProcessor, priv *crypto.PrivateKey) *types.Transaction {
+				t.Helper()
+				payload := types.HeartbeatPayload{Timestamp: time.Now().UTC().Unix()}
+				data, err := json.Marshal(payload)
+				if err != nil {
+					t.Fatalf("marshal heartbeat: %v", err)
+				}
+				tx := &types.Transaction{
+					ChainID:  types.NHBChainID(),
+					Type:     types.TxTypeHeartbeat,
+					Nonce:    0,
+					Data:     data,
+					GasLimit: 21000,
+					GasPrice: big.NewInt(1),
+				}
+				if err := tx.Sign(priv.PrivateKey); err != nil {
+					t.Fatalf("sign tx: %v", err)
+				}
+				return tx
+			},
+		},
+		{
+			name: "stake",
+			setup: func(t *testing.T, sp *StateProcessor, addr []byte) {
+				t.Helper()
+				account := &types.Account{
+					BalanceNHB:  big.NewInt(0),
+					BalanceZNHB: big.NewInt(2_000),
+					Stake:       big.NewInt(0),
+				}
+				if err := sp.setAccount(addr, account); err != nil {
+					t.Fatalf("seed staking account: %v", err)
+				}
+			},
+			build: func(t *testing.T, _ *StateProcessor, priv *crypto.PrivateKey) *types.Transaction {
+				t.Helper()
+				tx := &types.Transaction{
+					ChainID:  types.NHBChainID(),
+					Type:     types.TxTypeStake,
+					Nonce:    0,
+					Value:    big.NewInt(500),
+					GasLimit: 21000,
+					GasPrice: big.NewInt(1),
+				}
+				if err := tx.Sign(priv.PrivateKey); err != nil {
+					t.Fatalf("sign tx: %v", err)
+				}
+				return tx
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			sp := newStakingStateProcessor(t)
+			priv, err := crypto.GeneratePrivateKey()
+			if err != nil {
+				t.Fatalf("generate key: %v", err)
+			}
+			addr := priv.PubKey().Address().Bytes()
+			tc.setup(t, sp, addr)
+			tx := tc.build(t, sp, priv)
+
+			if err := sp.ApplyTransaction(tx); err != nil {
+				t.Fatalf("apply transaction: %v", err)
+			}
+			if err := sp.ApplyTransaction(tx); err == nil {
+				t.Fatalf("expected nonce replay to be rejected")
+			} else if !errors.Is(err, ErrNonceMismatch) {
+				t.Fatalf("expected ErrNonceMismatch, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- validate the sender account at the start of ApplyTransaction and reuse the preloaded account across native handlers
- require native handlers to operate on the validated account data and update heartbeat handling to accept the cached sender
- add regression tests that replay native transactions with reused nonces and update existing engagement tests accordingly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d453bc7090832db8c977afe82d6be3