### PR TITLE
Implement governance proposal flow with escrow

### DIFF
--- a/core/state/governance_test.go
+++ b/core/state/governance_test.go
@@ -1,0 +1,98 @@
+package state
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"nhbchain/crypto"
+	"nhbchain/native/governance"
+)
+
+func TestGovernanceEscrowAndProposalHelpers(t *testing.T) {
+	manager := newTestManager(t)
+	proposer := crypto.NewAddress(crypto.NHBPrefix, make([]byte, 20))
+	addrBytes := proposer.Bytes()
+	if balance, err := manager.GovernanceEscrowBalance(addrBytes); err != nil {
+		t.Fatalf("escrow balance: %v", err)
+	} else if balance.Sign() != 0 {
+		t.Fatalf("expected empty escrow balance, got %s", balance.String())
+	}
+
+	first, err := manager.GovernanceEscrowLock(addrBytes, big.NewInt(100))
+	if err != nil {
+		t.Fatalf("lock first: %v", err)
+	}
+	if first.Cmp(big.NewInt(100)) != 0 {
+		t.Fatalf("unexpected first balance: %s", first.String())
+	}
+
+	second, err := manager.GovernanceEscrowLock(addrBytes, big.NewInt(200))
+	if err != nil {
+		t.Fatalf("lock second: %v", err)
+	}
+	if second.Cmp(big.NewInt(300)) != 0 {
+		t.Fatalf("unexpected second balance: %s", second.String())
+	}
+
+	if balance, err := manager.GovernanceEscrowBalance(addrBytes); err != nil {
+		t.Fatalf("escrow balance reload: %v", err)
+	} else if balance.Cmp(big.NewInt(300)) != 0 {
+		t.Fatalf("unexpected reload balance: %s", balance.String())
+	}
+
+	nextID, err := manager.GovernanceNextProposalID()
+	if err != nil {
+		t.Fatalf("next proposal id: %v", err)
+	}
+	if nextID != 1 {
+		t.Fatalf("expected first proposal id 1, got %d", nextID)
+	}
+	nextID, err = manager.GovernanceNextProposalID()
+	if err != nil {
+		t.Fatalf("next proposal id second: %v", err)
+	}
+	if nextID != 2 {
+		t.Fatalf("expected second proposal id 2, got %d", nextID)
+	}
+
+	createdAt := time.Unix(1700000000, 0).UTC()
+	proposal := &governance.Proposal{
+		ID:             2,
+		Submitter:      proposer,
+		Status:         governance.ProposalStatusVotingPeriod,
+		Deposit:        big.NewInt(300),
+		SubmitTime:     createdAt,
+		VotingStart:    createdAt,
+		VotingEnd:      createdAt.Add(24 * time.Hour),
+		TimelockEnd:    createdAt.Add(48 * time.Hour),
+		Target:         "param.update",
+		ProposedChange: `{"fees.baseFee":"1000"}`,
+	}
+	if err := manager.GovernancePutProposal(proposal); err != nil {
+		t.Fatalf("put proposal: %v", err)
+	}
+
+	loaded, ok, err := manager.GovernanceGetProposal(2)
+	if err != nil {
+		t.Fatalf("get proposal: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected proposal to exist")
+	}
+	if loaded.ID != proposal.ID {
+		t.Fatalf("unexpected id: got %d want %d", loaded.ID, proposal.ID)
+	}
+	if loaded.Status != proposal.Status {
+		t.Fatalf("unexpected status: got %d want %d", loaded.Status, proposal.Status)
+	}
+	if loaded.Deposit.Cmp(proposal.Deposit) != 0 {
+		t.Fatalf("unexpected deposit: got %s want %s", loaded.Deposit.String(), proposal.Deposit.String())
+	}
+	if !loaded.SubmitTime.Equal(proposal.SubmitTime) {
+		t.Fatalf("unexpected submit time: got %s want %s", loaded.SubmitTime, proposal.SubmitTime)
+	}
+	if loaded.Target != proposal.Target {
+		t.Fatalf("unexpected target: got %s want %s", loaded.Target, proposal.Target)
+	}
+}

--- a/docs/governance/api.md
+++ b/docs/governance/api.md
@@ -4,4 +4,44 @@
 
 | Endpoint | Method | Description |
 | --- | --- | --- |
-| _TBD_ | _TBD_ | Placeholder for governance RPC endpoints. |
+| `gov_propose` | `POST` | Submit a parameter change proposal and lock the ZNHB deposit. |
+
+### `gov_propose`
+
+Submits a `param.update` proposal. The payload must only contain allow-listed parameter keys. The ZNHB deposit is debited from the proposer account and locked in escrow until the proposal is resolved.
+
+**Request**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "gov_propose",
+  "params": {
+    "proposer": "nhb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp8d7z2",
+    "kind": "param.update",
+    "payload": {
+      "fees.baseFee": "420000000000"
+    },
+    "deposit": "300000000000000000000"
+  }
+}
+```
+
+**Response**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "proposalId": 42,
+    "votingStart": 1700000000,
+    "votingEnd": 1700003600,
+    "timelockEnd": 1700004400,
+    "status": "voting_period"
+  }
+}
+```
+
+On success, a `gov.proposed` event is emitted for downstream consumers.

--- a/docs/overview/README.md
+++ b/docs/overview/README.md
@@ -7,6 +7,15 @@
 * [Loyalty Module](./loyalty.md)
 * [Staking & Delegation](./staking.md)
 
+## Governance & Proposals
+
+The governance module coordinates configuration changes across the network.
+
+1. **Proposal Submission** – A proposer submits a `param.update` payload listing only allow-listed parameter keys and posts the required ZNHB deposit.
+2. **Escrow Lock** – The deposit is debited from the proposer’s liquid ZNHB balance and locked under `gov/escrow/<address>` until the proposal completes.
+3. **Voting Window** – Upon acceptance, the proposal enters the voting period immediately. `VotingStart` is the submission timestamp, `VotingEnd` is computed from the configured voting period, and `TimelockEnd` extends the execution window after a successful vote.
+4. **Events & Indexing** – A `gov.proposed` event is emitted so wallets, dashboards, and indexers can track the proposal lifecycle from creation through timelock.
+
 ## Identity & Username Directory
 
 The identity subsystem introduces human-readable aliases, email discovery, avatars, and claimables for pay-by-username UX.

--- a/native/governance/engine.go
+++ b/native/governance/engine.go
@@ -1,0 +1,258 @@
+package governance
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+	"time"
+
+	"nhbchain/core/events"
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+const (
+	// ProposalKindParamUpdate is the only proposal kind supported in GOV-1B.
+	ProposalKindParamUpdate = "param.update"
+	// EventTypeProposalProposed is emitted when a new proposal is accepted.
+	EventTypeProposalProposed = "gov.proposed"
+)
+
+var (
+	errStateNotConfigured = errors.New("governance: state not configured")
+)
+
+type proposalState interface {
+	GetAccount(addr []byte) (*types.Account, error)
+	PutAccount(addr []byte, account *types.Account) error
+	GovernanceEscrowBalance(addr []byte) (*big.Int, error)
+	GovernanceEscrowLock(addr []byte, amount *big.Int) (*big.Int, error)
+	GovernanceNextProposalID() (uint64, error)
+	GovernancePutProposal(p *Proposal) error
+}
+
+// ProposalPolicy captures the runtime knobs that control proposal admission.
+// The engine expects the values to be pre-normalised (e.g. MinDepositWei in Wei).
+//
+// AllowedParams must contain the canonical parameter keys permitted for
+// parameter update proposals.
+type ProposalPolicy struct {
+	MinDepositWei       *big.Int
+	VotingPeriodSeconds uint64
+	TimelockSeconds     uint64
+	AllowedParams       []string
+}
+
+// Engine orchestrates proposal admission and bookkeeping for governance
+// operations.
+type Engine struct {
+	state               proposalState
+	emitter             events.Emitter
+	nowFn               func() time.Time
+	minDeposit          *big.Int
+	votingPeriodSeconds uint64
+	timelockSeconds     uint64
+	allowedParams       map[string]struct{}
+}
+
+// NewEngine constructs a governance engine with default no-op dependencies.
+func NewEngine() *Engine {
+	return &Engine{
+		emitter:       events.NoopEmitter{},
+		nowFn:         func() time.Time { return time.Now().UTC() },
+		minDeposit:    big.NewInt(0),
+		allowedParams: map[string]struct{}{},
+	}
+}
+
+// SetState wires the engine to the state backend providing persistence helpers.
+func (e *Engine) SetState(state proposalState) { e.state = state }
+
+// SetEmitter configures the event emitter used by the engine. Passing nil resets
+// the emitter to a no-op implementation.
+func (e *Engine) SetEmitter(emitter events.Emitter) {
+	if emitter == nil {
+		e.emitter = events.NoopEmitter{}
+		return
+	}
+	e.emitter = emitter
+}
+
+// SetNowFunc overrides the time source used to stamp proposals. Nil restores the
+// default UTC clock.
+func (e *Engine) SetNowFunc(now func() time.Time) {
+	if now == nil {
+		e.nowFn = func() time.Time { return time.Now().UTC() }
+		return
+	}
+	e.nowFn = now
+}
+
+// SetPolicy updates the runtime policy governing proposal admission.
+func (e *Engine) SetPolicy(policy ProposalPolicy) {
+	if e == nil {
+		return
+	}
+	if policy.MinDepositWei != nil {
+		e.minDeposit = new(big.Int).Set(policy.MinDepositWei)
+	} else {
+		e.minDeposit = big.NewInt(0)
+	}
+	e.votingPeriodSeconds = policy.VotingPeriodSeconds
+	e.timelockSeconds = policy.TimelockSeconds
+	e.allowedParams = make(map[string]struct{}, len(policy.AllowedParams))
+	for _, raw := range policy.AllowedParams {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		e.allowedParams[trimmed] = struct{}{}
+	}
+}
+
+func (e *Engine) emit(event *types.Event) {
+	if e == nil || e.emitter == nil || event == nil {
+		return
+	}
+	e.emitter.Emit(governanceEvent{evt: event})
+}
+
+func (e *Engine) now() time.Time {
+	if e == nil || e.nowFn == nil {
+		return time.Now().UTC()
+	}
+	return e.nowFn()
+}
+
+// ProposeParamChange admits a parameter change proposal after validating the
+// payload, deposit, and kind against the configured policy. The function returns
+// the allocated proposal identifier on success.
+func (e *Engine) ProposeParamChange(proposer [20]byte, kind string, payloadJSON string, deposit *big.Int) (uint64, error) {
+	if e == nil || e.state == nil {
+		return 0, errStateNotConfigured
+	}
+	proposalKind := strings.TrimSpace(kind)
+	if proposalKind != ProposalKindParamUpdate {
+		return 0, fmt.Errorf("governance: unsupported proposal kind %q", kind)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		return 0, fmt.Errorf("governance: invalid payload: %w", err)
+	}
+	for key := range payload {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == "" {
+			return 0, fmt.Errorf("governance: payload key must not be empty")
+		}
+		if _, ok := e.allowedParams[trimmed]; !ok {
+			return 0, fmt.Errorf("governance: parameter %q not in allow-list", trimmed)
+		}
+	}
+
+	lockAmount := big.NewInt(0)
+	if deposit != nil {
+		lockAmount = new(big.Int).Set(deposit)
+	}
+	if lockAmount.Sign() < 0 {
+		return 0, fmt.Errorf("governance: deposit must not be negative")
+	}
+	if e.minDeposit != nil && lockAmount.Cmp(e.minDeposit) < 0 {
+		return 0, fmt.Errorf("governance: deposit below minimum")
+	}
+
+	account, err := e.state.GetAccount(proposer[:])
+	if err != nil {
+		return 0, err
+	}
+	if account == nil {
+		account = &types.Account{}
+	}
+	if account.BalanceZNHB == nil {
+		account.BalanceZNHB = big.NewInt(0)
+	}
+	if account.BalanceZNHB.Cmp(lockAmount) < 0 {
+		return 0, fmt.Errorf("governance: insufficient ZNHB balance for deposit")
+	}
+	account.BalanceZNHB = new(big.Int).Sub(account.BalanceZNHB, lockAmount)
+	if err := e.state.PutAccount(proposer[:], account); err != nil {
+		return 0, err
+	}
+	if _, err := e.state.GovernanceEscrowLock(proposer[:], lockAmount); err != nil {
+		return 0, err
+	}
+
+	proposalID, err := e.state.GovernanceNextProposalID()
+	if err != nil {
+		return 0, err
+	}
+
+	now := e.now()
+	votingEnd := now.Add(time.Duration(e.votingPeriodSeconds) * time.Second)
+	timelockEnd := votingEnd.Add(time.Duration(e.timelockSeconds) * time.Second)
+
+	submitter := crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), proposer[:]...))
+	depositCopy := new(big.Int).Set(lockAmount)
+	proposal := &Proposal{
+		ID:             proposalID,
+		Submitter:      submitter,
+		Status:         ProposalStatusVotingPeriod,
+		Deposit:        depositCopy,
+		SubmitTime:     now,
+		VotingStart:    now,
+		VotingEnd:      votingEnd,
+		TimelockEnd:    timelockEnd,
+		Target:         proposalKind,
+		ProposedChange: payloadJSON,
+	}
+	if err := e.state.GovernancePutProposal(proposal); err != nil {
+		return 0, err
+	}
+
+	e.emit(newProposedEvent(proposal))
+	return proposalID, nil
+}
+
+type governanceEvent struct {
+	evt *types.Event
+}
+
+func (g governanceEvent) EventType() string {
+	if g.evt == nil {
+		return ""
+	}
+	return g.evt.Type
+}
+
+func (g governanceEvent) Event() *types.Event { return g.evt }
+
+func newProposedEvent(p *Proposal) *types.Event {
+	attrs := make(map[string]string)
+	if p == nil {
+		return &types.Event{Type: EventTypeProposalProposed, Attributes: attrs}
+	}
+	attrs["id"] = strconv.FormatUint(p.ID, 10)
+	if bytes := p.Submitter.Bytes(); len(bytes) == 20 {
+		attrs["proposer"] = hex.EncodeToString(bytes)
+	}
+	if strings.TrimSpace(p.Target) != "" {
+		attrs["kind"] = p.Target
+	}
+	if p.Deposit != nil {
+		attrs["deposit"] = p.Deposit.String()
+	}
+	if !p.VotingStart.IsZero() {
+		attrs["votingStart"] = strconv.FormatInt(p.VotingStart.Unix(), 10)
+	}
+	if !p.VotingEnd.IsZero() {
+		attrs["votingEnd"] = strconv.FormatInt(p.VotingEnd.Unix(), 10)
+	}
+	if !p.TimelockEnd.IsZero() {
+		attrs["timelockEnd"] = strconv.FormatInt(p.TimelockEnd.Unix(), 10)
+	}
+	return &types.Event{Type: EventTypeProposalProposed, Attributes: attrs}
+}

--- a/native/governance/engine_test.go
+++ b/native/governance/engine_test.go
@@ -1,0 +1,235 @@
+package governance
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"nhbchain/core/events"
+	"nhbchain/core/types"
+)
+
+type mockGovernanceState struct {
+	accounts       map[string]*types.Account
+	escrowBalances map[string]*big.Int
+	proposals      map[uint64]*Proposal
+	nextID         uint64
+}
+
+func newMockGovernanceState(initial map[[20]byte]*types.Account) *mockGovernanceState {
+	accounts := make(map[string]*types.Account)
+	for addr, acc := range initial {
+		accounts[string(addr[:])] = cloneAccount(acc)
+	}
+	return &mockGovernanceState{
+		accounts:       accounts,
+		escrowBalances: make(map[string]*big.Int),
+		proposals:      make(map[uint64]*Proposal),
+	}
+}
+
+func (m *mockGovernanceState) GetAccount(addr []byte) (*types.Account, error) {
+	if acc, ok := m.accounts[string(addr)]; ok {
+		return cloneAccount(acc), nil
+	}
+	return &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)}, nil
+}
+
+func (m *mockGovernanceState) PutAccount(addr []byte, account *types.Account) error {
+	m.accounts[string(addr)] = cloneAccount(account)
+	return nil
+}
+
+func (m *mockGovernanceState) GovernanceEscrowBalance(addr []byte) (*big.Int, error) {
+	if bal, ok := m.escrowBalances[string(addr)]; ok {
+		return new(big.Int).Set(bal), nil
+	}
+	return big.NewInt(0), nil
+}
+
+func (m *mockGovernanceState) GovernanceEscrowLock(addr []byte, amount *big.Int) (*big.Int, error) {
+	if amount == nil {
+		amount = big.NewInt(0)
+	}
+	current, _ := m.GovernanceEscrowBalance(addr)
+	updated := new(big.Int).Add(current, amount)
+	m.escrowBalances[string(addr)] = updated
+	return new(big.Int).Set(updated), nil
+}
+
+func (m *mockGovernanceState) GovernanceNextProposalID() (uint64, error) {
+	m.nextID++
+	return m.nextID, nil
+}
+
+func (m *mockGovernanceState) GovernancePutProposal(p *Proposal) error {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+	if p.Deposit != nil {
+		clone.Deposit = new(big.Int).Set(p.Deposit)
+	}
+	m.proposals[p.ID] = &clone
+	return nil
+}
+
+type captureEmitter struct {
+	events []events.Event
+}
+
+func (c *captureEmitter) Emit(evt events.Event) { c.events = append(c.events, evt) }
+
+func cloneAccount(acc *types.Account) *types.Account {
+	if acc == nil {
+		return &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)}
+	}
+	cloned := *acc
+	if acc.BalanceZNHB != nil {
+		cloned.BalanceZNHB = new(big.Int).Set(acc.BalanceZNHB)
+	} else {
+		cloned.BalanceZNHB = big.NewInt(0)
+	}
+	if acc.BalanceNHB != nil {
+		cloned.BalanceNHB = new(big.Int).Set(acc.BalanceNHB)
+	} else {
+		cloned.BalanceNHB = big.NewInt(0)
+	}
+	if acc.Stake != nil {
+		cloned.Stake = new(big.Int).Set(acc.Stake)
+	} else {
+		cloned.Stake = big.NewInt(0)
+	}
+	if acc.LockedZNHB != nil {
+		cloned.LockedZNHB = new(big.Int).Set(acc.LockedZNHB)
+	} else {
+		cloned.LockedZNHB = big.NewInt(0)
+	}
+	return &cloned
+}
+
+func TestProposeParamChangeRejectsUnknownParam(t *testing.T) {
+	var proposer [20]byte
+	proposer[19] = 1
+	state := newMockGovernanceState(map[[20]byte]*types.Account{
+		proposer: &types.Account{BalanceZNHB: big.NewInt(1000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)},
+	})
+
+	engine := NewEngine()
+	engine.SetState(state)
+	engine.SetPolicy(ProposalPolicy{
+		MinDepositWei:       big.NewInt(100),
+		VotingPeriodSeconds: 3600,
+		TimelockSeconds:     600,
+		AllowedParams:       []string{"fees.baseFee"},
+	})
+
+	_, err := engine.ProposeParamChange(proposer, ProposalKindParamUpdate, `{"escrow.maxOpenDisputes":5}`, big.NewInt(200))
+	if err == nil || !strings.Contains(err.Error(), "allow-list") {
+		t.Fatalf("expected allow-list rejection, got %v", err)
+	}
+}
+
+func TestProposeParamChangeRejectsLowDeposit(t *testing.T) {
+	var proposer [20]byte
+	proposer[10] = 2
+	state := newMockGovernanceState(map[[20]byte]*types.Account{
+		proposer: &types.Account{BalanceZNHB: big.NewInt(1000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)},
+	})
+
+	engine := NewEngine()
+	engine.SetState(state)
+	engine.SetPolicy(ProposalPolicy{
+		MinDepositWei:       big.NewInt(500),
+		VotingPeriodSeconds: 100,
+		TimelockSeconds:     50,
+		AllowedParams:       []string{"fees.baseFee"},
+	})
+
+	_, err := engine.ProposeParamChange(proposer, ProposalKindParamUpdate, `{"fees.baseFee":5}`, big.NewInt(200))
+	if err == nil || !strings.Contains(err.Error(), "deposit below minimum") {
+		t.Fatalf("expected deposit rejection, got %v", err)
+	}
+}
+
+func TestProposeParamChangeLocksDepositAndEmitsEvent(t *testing.T) {
+	var proposer [20]byte
+	proposer[5] = 3
+	state := newMockGovernanceState(map[[20]byte]*types.Account{
+		proposer: &types.Account{BalanceZNHB: big.NewInt(1000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)},
+	})
+
+	engine := NewEngine()
+	engine.SetState(state)
+	engine.SetPolicy(ProposalPolicy{
+		MinDepositWei:       big.NewInt(100),
+		VotingPeriodSeconds: 600,
+		TimelockSeconds:     120,
+		AllowedParams:       []string{"fees.baseFee"},
+	})
+	engine.SetNowFunc(func() time.Time { return time.Unix(1700000000, 0).UTC() })
+	emitter := &captureEmitter{}
+	engine.SetEmitter(emitter)
+
+	payload := `{"fees.baseFee":1000}`
+	deposit := big.NewInt(300)
+	proposalID, err := engine.ProposeParamChange(proposer, ProposalKindParamUpdate, payload, deposit)
+	if err != nil {
+		t.Fatalf("propose: %v", err)
+	}
+	if proposalID != 1 {
+		t.Fatalf("unexpected proposal id: %d", proposalID)
+	}
+
+	acct, _ := state.GetAccount(proposer[:])
+	expectedBalance := big.NewInt(700)
+	if acct.BalanceZNHB.Cmp(expectedBalance) != 0 {
+		t.Fatalf("unexpected balance: got %s want %s", acct.BalanceZNHB.String(), expectedBalance.String())
+	}
+
+	escrow, _ := state.GovernanceEscrowBalance(proposer[:])
+	if escrow.Cmp(deposit) != 0 {
+		t.Fatalf("unexpected escrow balance: got %s want %s", escrow.String(), deposit.String())
+	}
+
+	stored := state.proposals[proposalID]
+	if stored == nil {
+		t.Fatalf("expected stored proposal")
+	}
+	if stored.Target != ProposalKindParamUpdate {
+		t.Fatalf("unexpected target: %s", stored.Target)
+	}
+	if stored.ProposedChange != payload {
+		t.Fatalf("unexpected payload: %s", stored.ProposedChange)
+	}
+	if stored.Deposit.Cmp(deposit) != 0 {
+		t.Fatalf("unexpected stored deposit: got %s want %s", stored.Deposit.String(), deposit.String())
+	}
+	wantVotingEnd := time.Unix(1700000000+600, 0).UTC()
+	if !stored.VotingEnd.Equal(wantVotingEnd) {
+		t.Fatalf("unexpected voting end: got %s want %s", stored.VotingEnd, wantVotingEnd)
+	}
+	wantTimelock := time.Unix(1700000000+600+120, 0).UTC()
+	if !stored.TimelockEnd.Equal(wantTimelock) {
+		t.Fatalf("unexpected timelock: got %s want %s", stored.TimelockEnd, wantTimelock)
+	}
+
+	if len(emitter.events) != 1 {
+		t.Fatalf("expected one event, got %d", len(emitter.events))
+	}
+	evt, ok := emitter.events[0].(governanceEvent)
+	if !ok {
+		t.Fatalf("unexpected event type %T", emitter.events[0])
+	}
+	payloadEvent := evt.Event()
+	if payloadEvent.Type != EventTypeProposalProposed {
+		t.Fatalf("unexpected event type: %s", payloadEvent.Type)
+	}
+	if payloadEvent.Attributes["id"] != "1" {
+		t.Fatalf("unexpected event id: %s", payloadEvent.Attributes["id"])
+	}
+	if payloadEvent.Attributes["deposit"] != deposit.String() {
+		t.Fatalf("unexpected event deposit: %s", payloadEvent.Attributes["deposit"])
+	}
+}


### PR DESCRIPTION
## Summary
- add a governance engine that validates allow-listed param updates, locks deposits in escrow, and emits proposal events
- extend state manager with governance escrow/proposal storage helpers and cover them with tests
- document the governance proposal flow and add gov_propose API examples

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4a23b8430832d995b9a2218e14c8f