### PR TITLE
Implement governance timelock queue and execution

### DIFF
--- a/docs/governance/params.md
+++ b/docs/governance/params.md
@@ -2,10 +2,12 @@
 
 > Include function-level documentation for developer integrations and technical specs; docs must be generated into /docs/governance/* for auditors, investors, regulators, and consumers.
 
-The following parameters are governable by default:
+The following parameters are governable by default. Governance payloads must
+respect the validation guidance for each key; values outside the documented
+range are rejected during execution.
 
-| Key | Description |
-| --- | --- |
-| `potso.weights.AlphaStakeBps` | Controls the proportion of POTSO rewards attributed to validator staking weight. |
-| `potso.rewards.EmissionPerEpochWei` | Defines the raw ZNHB emission allocated per epoch for POTSO incentives. |
-| `fees.baseFee` | Sets the minimum base fee charged for network transactions. |
+| Key | Description | Validation Guidance |
+| --- | --- | --- |
+| `potso.weights.AlphaStakeBps` | Controls the proportion of POTSO rewards attributed to validator staking weight. | Integer basis points in the range `0`–`10,000`. Values above `10,000` would over-allocate rewards and are rejected. |
+| `potso.rewards.EmissionPerEpochWei` | Defines the raw ZNHB emission allocated per epoch for POTSO incentives. | Unsigned integer encoded in Wei. Must be greater than or equal to `0` and should remain within 64-bit safe bounds (`< 9.22e18`) to avoid downstream overflow in accounting pipelines. |
+| `fees.baseFee` | Sets the minimum base fee charged for network transactions. | Unsigned integer in Wei per gas. Must be non-negative; most deployments target a range between `0` and `1e15` (0.001 ZNHB) to keep fees affordable. |

--- a/docs/governance/security-and-audit.md
+++ b/docs/governance/security-and-audit.md
@@ -15,7 +15,20 @@ part of routine state audits to ensure voting power remains tamper-evident.
 
 ## Timelock Review
 
-_TODO: Detail timelock enforcement, bypass protections, and alerting._
+Passed proposals must be explicitly queued before they can execute. Once
+queued, the governance engine enforces the configured timelock by refusing to
+apply the payload until `now >= TimelockEnd`. Operators should monitor for
+`gov.queued` events to confirm that a passed proposal has entered the timelock
+queue, and alert if an execution attempt occurs before the unlock timestamp
+(`gov.executed` will not be emitted in that case). This ensures downstream
+systems have a deterministic grace period to audit the queued change.
+
+Execution is idempotent: after a proposal is applied the engine transitions it
+to `executed` status and future calls are rejected. Auditors can therefore rely
+on `gov.executed` as a single-source-of-truth signal that the param store
+modifications were committed exactly once. Attempted replays or duplicate
+messages will fail with an explicit error, preserving change-control logs and
+reducing the risk of multi-apply bugs.
 
 ## Tally Reproducibility
 

--- a/native/governance/types.go
+++ b/native/governance/types.go
@@ -56,6 +56,7 @@ type Proposal struct {
 	TimelockEnd    time.Time      `json:"timelock_end"`
 	Target         string         `json:"target"`
 	ProposedChange string         `json:"proposed_change"`
+	Queued         bool           `json:"queued"`
 }
 
 // VoteChoice enumerates the supported governance ballot selections.


### PR DESCRIPTION
## Summary
- add queue and execute paths for governance proposals with new events and idempotent status tracking
- extend state manager with param store helpers and persist queued flag
- document parameter validation guidance and timelock/idempotency guarantees

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d4ac4281e8832da7c8a7c27c94cd7c