### PR TITLE
Add governance RPC endpoints and CLI wrappers

### DIFF
--- a/cmd/nhb-cli/gov.go
+++ b/cmd/nhb-cli/gov.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var govRPCCall = callEscrowRPC
+
+func runGovCommand(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, govUsage())
+		return 1
+	}
+	switch args[0] {
+	case "propose":
+		return runGovPropose(args[1:], stdout, stderr)
+	case "vote":
+		return runGovVote(args[1:], stdout, stderr)
+	case "finalize":
+		return runGovFinalize(args[1:], stdout, stderr)
+	case "queue":
+		return runGovQueue(args[1:], stdout, stderr)
+	case "execute":
+		return runGovExecute(args[1:], stdout, stderr)
+	case "show":
+		return runGovShow(args[1:], stdout, stderr)
+	case "list":
+		return runGovList(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "Unknown gov subcommand: %s\n", args[0])
+		fmt.Fprintln(stderr, govUsage())
+		return 1
+	}
+}
+
+func runGovPropose(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("gov propose", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		kind    string
+		payload string
+		from    string
+		deposit string
+	)
+	fs.StringVar(&kind, "kind", "", "proposal kind (e.g. param.update)")
+	fs.StringVar(&payload, "payload", "", "proposal payload JSON or @path to file")
+	fs.StringVar(&from, "from", "", "proposer bech32 address")
+	fs.StringVar(&deposit, "deposit", "0", "deposit amount in wei (supports 1000e18 shorthand)")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "Error: unexpected positional arguments")
+		return 1
+	}
+	if strings.TrimSpace(kind) == "" {
+		fmt.Fprintln(stderr, "Error: --kind is required")
+		return 1
+	}
+	if strings.TrimSpace(payload) == "" {
+		fmt.Fprintln(stderr, "Error: --payload is required")
+		return 1
+	}
+	if strings.TrimSpace(from) == "" {
+		fmt.Fprintln(stderr, "Error: --from is required")
+		return 1
+	}
+	payloadBody, err := readGovPayload(payload)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 1
+	}
+	normalizedDeposit, err := normalizeGovAmount(deposit)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 1
+	}
+	params := map[string]interface{}{
+		"kind":    kind,
+		"payload": payloadBody,
+		"from":    from,
+		"deposit": normalizedDeposit,
+	}
+	result, rpcErr, err := govRPCCall("gov_propose", params, true)
+	if err != nil {
+		return handleRPCCallError(stderr, err)
+	}
+	if rpcErr != nil {
+		return handleRPCError(stderr, rpcErr)
+	}
+	writeRPCResult(stdout, result)
+	return 0
+}
+
+func runGovVote(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("gov vote", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		id     uint64
+		from   string
+		choice string
+	)
+	fs.Uint64Var(&id, "id", 0, "proposal identifier")
+	fs.StringVar(&from, "from", "", "voter bech32 address")
+	fs.StringVar(&choice, "choice", "", "vote choice (yes|no|abstain)")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "Error: unexpected positional arguments")
+		return 1
+	}
+	if id == 0 {
+		fmt.Fprintln(stderr, "Error: --id is required")
+		return 1
+	}
+	if strings.TrimSpace(from) == "" {
+		fmt.Fprintln(stderr, "Error: --from is required")
+		return 1
+	}
+	normalizedChoice := strings.ToLower(strings.TrimSpace(choice))
+	switch normalizedChoice {
+	case "yes", "no", "abstain":
+	default:
+		fmt.Fprintln(stderr, "Error: --choice must be yes, no, or abstain")
+		return 1
+	}
+	params := map[string]interface{}{
+		"id":     id,
+		"from":   from,
+		"choice": normalizedChoice,
+	}
+	result, rpcErr, err := govRPCCall("gov_vote", params, true)
+	if err != nil {
+		return handleRPCCallError(stderr, err)
+	}
+	if rpcErr != nil {
+		return handleRPCError(stderr, rpcErr)
+	}
+	writeRPCResult(stdout, result)
+	return 0
+}
+
+func runGovFinalize(args []string, stdout, stderr io.Writer) int {
+	return runGovSimpleIDCommand("gov_finalize", args, stdout, stderr, true)
+}
+
+func runGovQueue(args []string, stdout, stderr io.Writer) int {
+	return runGovSimpleIDCommand("gov_queue", args, stdout, stderr, true)
+}
+
+func runGovExecute(args []string, stdout, stderr io.Writer) int {
+	return runGovSimpleIDCommand("gov_execute", args, stdout, stderr, true)
+}
+
+func runGovShow(args []string, stdout, stderr io.Writer) int {
+	return runGovSimpleIDCommand("gov_proposal", args, stdout, stderr, false)
+}
+
+func runGovList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("gov list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		cursor uint64
+		limit  int
+	)
+	fs.Uint64Var(&cursor, "cursor", 0, "optional pagination cursor")
+	fs.IntVar(&limit, "limit", 0, "max proposals to return (default 20)")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "Error: unexpected positional arguments")
+		return 1
+	}
+	params := map[string]interface{}{}
+	if cursor > 0 {
+		params["cursor"] = cursor
+	}
+	if limit > 0 {
+		params["limit"] = limit
+	}
+	var paramPayload interface{}
+	if len(params) > 0 {
+		paramPayload = params
+	}
+	result, rpcErr, err := govRPCCall("gov_list", paramPayload, false)
+	if err != nil {
+		return handleRPCCallError(stderr, err)
+	}
+	if rpcErr != nil {
+		return handleRPCError(stderr, rpcErr)
+	}
+	writeRPCResult(stdout, result)
+	return 0
+}
+
+func runGovSimpleIDCommand(method string, args []string, stdout, stderr io.Writer, requireAuth bool) int {
+	fs := flag.NewFlagSet(method, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var id uint64
+	fs.Uint64Var(&id, "id", 0, "proposal identifier")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintln(stderr, "Error: unexpected positional arguments")
+		return 1
+	}
+	if id == 0 {
+		fmt.Fprintln(stderr, "Error: --id is required")
+		return 1
+	}
+	params := map[string]interface{}{"id": id}
+	result, rpcErr, err := govRPCCall(method, params, requireAuth)
+	if err != nil {
+		return handleRPCCallError(stderr, err)
+	}
+	if rpcErr != nil {
+		return handleRPCError(stderr, rpcErr)
+	}
+	writeRPCResult(stdout, result)
+	return 0
+}
+
+func readGovPayload(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(trimmed, "@") {
+		path := strings.TrimPrefix(trimmed, "@")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("failed to read payload file: %w", err)
+		}
+		return string(data), nil
+	}
+	return trimmed, nil
+}
+
+func govUsage() string {
+	return `Usage: nhb gov <command>
+
+Commands:
+  propose   Submit a new governance proposal
+  vote      Cast a vote on a proposal
+  finalize  Finalize voting and tally a proposal
+  queue     Queue a passed proposal for execution
+  execute   Execute a queued proposal
+  show      Show proposal details
+  list      List proposals`
+}
+
+func normalizeGovAmount(value string) (string, error) {
+	trimmed := strings.ReplaceAll(strings.TrimSpace(value), "_", "")
+	if trimmed == "" {
+		return "0", nil
+	}
+	normalized := strings.TrimPrefix(trimmed, "+")
+	if strings.HasPrefix(normalized, "-") {
+		return "", fmt.Errorf("--deposit must not be negative")
+	}
+	base := normalized
+	var exponent int64
+	if idx := strings.IndexAny(base, "eE"); idx != -1 {
+		expPart := strings.TrimSpace(base[idx+1:])
+		if expPart == "" {
+			return "", fmt.Errorf("invalid scientific notation in --deposit")
+		}
+		expValue, err := strconv.ParseInt(expPart, 10, 32)
+		if err != nil {
+			return "", fmt.Errorf("invalid scientific notation in --deposit")
+		}
+		exponent = expValue
+		base = strings.TrimSpace(base[:idx])
+	}
+	parts := strings.Split(base, ".")
+	if len(parts) > 2 {
+		return "", fmt.Errorf("invalid deposit amount")
+	}
+	integerPart := parts[0]
+	fractionalPart := ""
+	if len(parts) == 2 {
+		fractionalPart = parts[1]
+	}
+	digits := integerPart + fractionalPart
+	if digits == "" {
+		return "0", nil
+	}
+	if !isDigits(digits) {
+		return "", fmt.Errorf("invalid deposit amount")
+	}
+	fracLen := len(fractionalPart)
+	for fracLen > 0 && len(digits) > 0 && digits[len(digits)-1] == '0' {
+		digits = digits[:len(digits)-1]
+		fracLen--
+	}
+	digits = strings.TrimLeft(digits, "0")
+	totalExponent := exponent - int64(fracLen)
+	if totalExponent < 0 {
+		return "", fmt.Errorf("--deposit must be an integer amount")
+	}
+	if digits == "" {
+		digits = "0"
+	}
+	if totalExponent > 0 {
+		digits += strings.Repeat("0", int(totalExponent))
+	}
+	return digits, nil
+}

--- a/cmd/nhb-cli/main.go
+++ b/cmd/nhb-cli/main.go
@@ -103,29 +103,35 @@ func main() {
 			os.Exit(code)
 		}
 		return
-	case "claimable":
-		code := runClaimableCommand(args[1:], os.Stdout, os.Stderr)
-		if code != 0 {
-			os.Exit(code)
-		}
-		return
-	case "p2p":
-		code := runP2PCommand(args[1:], os.Stdout, os.Stderr)
-		if code != 0 {
-			os.Exit(code)
-		}
-		return
-	case "potso":
-		code := runPotsoCommand(args[1:], os.Stdout, os.Stderr)
-		if code != 0 {
-			os.Exit(code)
-		}
-		return
-	case "loyalty-create-business":
-		if len(args) < 3 {
-			fmt.Println("Usage: loyalty-create-business <owner> <name>")
-			return
-		}
+        case "claimable":
+                code := runClaimableCommand(args[1:], os.Stdout, os.Stderr)
+                if code != 0 {
+                        os.Exit(code)
+                }
+                return
+        case "p2p":
+                code := runP2PCommand(args[1:], os.Stdout, os.Stderr)
+                if code != 0 {
+                        os.Exit(code)
+                }
+                return
+        case "potso":
+                code := runPotsoCommand(args[1:], os.Stdout, os.Stderr)
+                if code != 0 {
+                        os.Exit(code)
+                }
+                return
+        case "gov":
+                code := runGovCommand(args[1:], os.Stdout, os.Stderr)
+                if code != 0 {
+                        os.Exit(code)
+                }
+                return
+        case "loyalty-create-business":
+                if len(args) < 3 {
+                        fmt.Println("Usage: loyalty-create-business <owner> <name>")
+                        return
+                }
 		name := strings.Join(args[2:], " ")
 		loyaltyCreateBusiness(args[1], name)
 	case "loyalty-set-paymaster":

--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -57,6 +57,12 @@ func main() {
 		panic(fmt.Sprintf("Failed to create node: %v", err))
 	}
 
+	govPolicy, err := cfg.Governance.Policy()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to parse governance policy: %v", err))
+	}
+	node.SetGovernancePolicy(govPolicy)
+
 	potsoCfg, err := cfg.PotsoRewardConfig()
 	if err != nil {
 		panic(fmt.Sprintf("Failed to parse POTSO rewards config: %v", err))

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,228 @@
+# Governance JSON-RPC API
+
+The governance RPC surface exposes proposal lifecycle operations for devnet environments. Each request is a JSON-RPC 2.0 call posted to the node's RPC endpoint.
+
+## gov_propose
+Submit a new proposal with an optional deposit.
+
+**Request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "gov_propose",
+  "params": [
+    {
+      "kind": "param.update",
+      "payload": "{\"fees.baseFee\":\"1000\"}",
+      "from": "nhb1exampleaddress000000000000000000000000",
+      "deposit": "1000000000000000000000"
+    }
+  ]
+}
+```
+
+**Response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "proposalId": 7
+  }
+}
+```
+
+## gov_vote
+Record or update a vote for the proposal.
+
+**Request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "gov_vote",
+  "params": [
+    {
+      "id": 7,
+      "from": "nhb1exampleaddress000000000000000000000000",
+      "choice": "yes"
+    }
+  ]
+}
+```
+
+**Response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "ok": true
+  }
+}
+```
+
+## gov_proposal
+Fetch proposal details by identifier.
+
+**Request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "gov_proposal",
+  "params": [
+    { "id": 7 }
+  ]
+}
+```
+
+**Response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "id": 7,
+    "target": "param.update",
+    "status": 2,
+    "deposit": "1000000000000000000000",
+    "voting_start": "2024-01-01T00:00:00Z",
+    "voting_end": "2024-01-08T00:00:00Z",
+    "timelock_end": "2024-01-10T00:00:00Z",
+    "queued": false,
+    "proposed_change": "{\"fees.baseFee\":\"1000\"}"
+  }
+}
+```
+
+## gov_list
+List proposals in descending order with optional cursor and limit.
+
+**Request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "gov_list",
+  "params": [
+    {
+      "cursor": 7,
+      "limit": 2
+    }
+  ]
+}
+```
+
+**Response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "proposals": [
+      { "id": 7, "status": 2, "queued": false },
+      { "id": 6, "status": 3, "queued": true }
+    ],
+    "nextCursor": 5
+  }
+}
+```
+
+## gov_finalize
+Close voting, tally results, and update status.
+
+**Request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "gov_finalize",
+  "params": [
+    { "id": 7 }
+  ]
+}
+```
+
+**Response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "proposal": {
+      "id": 7,
+      "status": 3,
+      "queued": false
+    },
+    "tally": {
+      "turnout_bps": 4200,
+      "yes_power_bps": 3000,
+      "no_power_bps": 1000,
+      "abstain_power_bps": 200
+    }
+  }
+}
+```
+
+## gov_queue
+Mark a passed proposal as queued for execution.
+
+**Request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "gov_queue",
+  "params": [
+    { "id": 7 }
+  ]
+}
+```
+
+**Response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "ok": true,
+    "proposal": {
+      "id": 7,
+      "queued": true
+    }
+  }
+}
+```
+
+## gov_execute
+Execute a queued proposal once the timelock has elapsed.
+
+**Request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "gov_execute",
+  "params": [
+    { "id": 7 }
+  ]
+}
+```
+
+**Response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "ok": true,
+    "proposal": {
+      "id": 7,
+      "status": 6,
+      "queued": true
+    }
+  }
+}
+```

--- a/rpc/governance_handlers.go
+++ b/rpc/governance_handlers.go
@@ -1,0 +1,292 @@
+package rpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+
+	"nhbchain/native/governance"
+)
+
+type govProposeParams struct {
+	Kind    string `json:"kind"`
+	Payload string `json:"payload"`
+	From    string `json:"from"`
+	Deposit string `json:"deposit,omitempty"`
+}
+
+type govVoteParams struct {
+	ID     uint64 `json:"id"`
+	From   string `json:"from"`
+	Choice string `json:"choice"`
+}
+
+type govIDParams struct {
+	ID uint64 `json:"id"`
+}
+
+type govListParams struct {
+	Cursor *uint64 `json:"cursor,omitempty"`
+	Limit  *int    `json:"limit,omitempty"`
+}
+
+type govProposeResponse struct {
+	ProposalID uint64 `json:"proposalId"`
+}
+
+type govAckResponse struct {
+	OK       bool                 `json:"ok"`
+	Proposal *governance.Proposal `json:"proposal,omitempty"`
+}
+
+type govFinalizeResponse struct {
+	Proposal *governance.Proposal `json:"proposal"`
+	Tally    *governance.Tally    `json:"tally"`
+}
+
+type govListResponse struct {
+	Proposals  []*governance.Proposal `json:"proposals"`
+	NextCursor *uint64                `json:"nextCursor,omitempty"`
+}
+
+func parseNonNegativeAmount(value string) (*big.Int, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return big.NewInt(0), nil
+	}
+	normalized := strings.TrimPrefix(trimmed, "+")
+	if strings.HasPrefix(normalized, "-") {
+		return nil, fmt.Errorf("amount must not be negative")
+	}
+	amount, ok := new(big.Int).SetString(normalized, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid amount")
+	}
+	if amount.Sign() < 0 {
+		return nil, fmt.Errorf("amount must not be negative")
+	}
+	return amount, nil
+}
+
+func (s *Server) handleGovernancePropose(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params govProposeParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	kind := strings.TrimSpace(params.Kind)
+	if kind == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "kind is required", nil)
+		return
+	}
+	payload := strings.TrimSpace(params.Payload)
+	if payload == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "payload is required", nil)
+		return
+	}
+	if strings.TrimSpace(params.From) == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "from is required", nil)
+		return
+	}
+	proposer, err := decodeBech32(params.From)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid from address", err.Error())
+		return
+	}
+	deposit, err := parseNonNegativeAmount(params.Deposit)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	proposalID, err := s.node.GovernancePropose(proposer, kind, payload, deposit)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	writeResult(w, req.ID, govProposeResponse{ProposalID: proposalID})
+}
+
+func (s *Server) handleGovernanceVote(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params govVoteParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	if params.ID == 0 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "id is required", nil)
+		return
+	}
+	if strings.TrimSpace(params.From) == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "from is required", nil)
+		return
+	}
+	voter, err := decodeBech32(params.From)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid from address", err.Error())
+		return
+	}
+	choice := strings.TrimSpace(params.Choice)
+	if choice == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "choice is required", nil)
+		return
+	}
+	if err := s.node.GovernanceVote(params.ID, voter, choice); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	writeResult(w, req.ID, govAckResponse{OK: true})
+}
+
+func (s *Server) handleGovernanceProposal(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params govIDParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	if params.ID == 0 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "id is required", nil)
+		return
+	}
+	proposal, ok, err := s.node.GovernanceProposal(params.ID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	if !ok {
+		writeError(w, http.StatusNotFound, req.ID, codeInvalidParams, "proposal not found", nil)
+		return
+	}
+	writeResult(w, req.ID, proposal)
+}
+
+func (s *Server) handleGovernanceList(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	var params govListParams
+	if len(req.Params) > 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "at most one parameter object expected", nil)
+		return
+	}
+	if len(req.Params) == 1 {
+		if err := json.Unmarshal(req.Params[0], &params); err != nil {
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+			return
+		}
+	}
+	var cursor uint64
+	if params.Cursor != nil {
+		cursor = *params.Cursor
+	}
+	limit := 0
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	proposals, nextCursor, err := s.node.GovernanceListProposals(cursor, limit)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	resp := govListResponse{Proposals: proposals}
+	if nextCursor > 0 {
+		resp.NextCursor = &nextCursor
+	}
+	writeResult(w, req.ID, resp)
+}
+
+func (s *Server) handleGovernanceFinalize(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params govIDParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	if params.ID == 0 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "id is required", nil)
+		return
+	}
+	proposal, tally, err := s.node.GovernanceFinalize(params.ID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	writeResult(w, req.ID, govFinalizeResponse{Proposal: proposal, Tally: tally})
+}
+
+func (s *Server) handleGovernanceQueue(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params govIDParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	if params.ID == 0 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "id is required", nil)
+		return
+	}
+	proposal, err := s.node.GovernanceQueue(params.ID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	writeResult(w, req.ID, govAckResponse{OK: true, Proposal: proposal})
+}
+
+func (s *Server) handleGovernanceExecute(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params govIDParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	if params.ID == 0 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "id is required", nil)
+		return
+	}
+	proposal, err := s.node.GovernanceExecute(params.ID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	writeResult(w, req.ID, govAckResponse{OK: true, Proposal: proposal})
+}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -381,6 +381,20 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handlePotsoRewardsHistory(w, r, req)
 	case "potso_export_epoch":
 		s.handlePotsoExportEpoch(w, r, req)
+	case "gov_propose":
+		s.handleGovernancePropose(w, r, req)
+	case "gov_vote":
+		s.handleGovernanceVote(w, r, req)
+	case "gov_proposal":
+		s.handleGovernanceProposal(w, r, req)
+	case "gov_list":
+		s.handleGovernanceList(w, r, req)
+	case "gov_finalize":
+		s.handleGovernanceFinalize(w, r, req)
+	case "gov_queue":
+		s.handleGovernanceQueue(w, r, req)
+	case "gov_execute":
+		s.handleGovernanceExecute(w, r, req)
 	default:
 		writeError(w, http.StatusNotFound, req.ID, codeMethodNotFound, fmt.Sprintf("unknown method %s", req.Method), nil)
 	}


### PR DESCRIPTION
## Summary
- add JSON-RPC handlers for governance proposal lifecycle actions and document the API
- expose `nhb gov` CLI commands with file payload support and deposit parsing utilities
- load governance policy from config and wire node helpers to drive the governance engine

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4b02b92e0832d8fd7a4912da57305