### PR TITLE
Finalize swap ledger and oracle integration

### DIFF
--- a/cmd/nhb-cli/main.go
+++ b/cmd/nhb-cli/main.go
@@ -103,35 +103,41 @@ func main() {
 			os.Exit(code)
 		}
 		return
-        case "claimable":
-                code := runClaimableCommand(args[1:], os.Stdout, os.Stderr)
-                if code != 0 {
-                        os.Exit(code)
-                }
-                return
-        case "p2p":
-                code := runP2PCommand(args[1:], os.Stdout, os.Stderr)
-                if code != 0 {
-                        os.Exit(code)
-                }
-                return
-        case "potso":
-                code := runPotsoCommand(args[1:], os.Stdout, os.Stderr)
-                if code != 0 {
-                        os.Exit(code)
-                }
-                return
-        case "gov":
-                code := runGovCommand(args[1:], os.Stdout, os.Stderr)
-                if code != 0 {
-                        os.Exit(code)
-                }
-                return
-        case "loyalty-create-business":
-                if len(args) < 3 {
-                        fmt.Println("Usage: loyalty-create-business <owner> <name>")
-                        return
-                }
+	case "claimable":
+		code := runClaimableCommand(args[1:], os.Stdout, os.Stderr)
+		if code != 0 {
+			os.Exit(code)
+		}
+		return
+	case "p2p":
+		code := runP2PCommand(args[1:], os.Stdout, os.Stderr)
+		if code != 0 {
+			os.Exit(code)
+		}
+		return
+	case "potso":
+		code := runPotsoCommand(args[1:], os.Stdout, os.Stderr)
+		if code != 0 {
+			os.Exit(code)
+		}
+		return
+	case "swap":
+		code := runSwapCommand(args[1:], os.Stdout, os.Stderr)
+		if code != 0 {
+			os.Exit(code)
+		}
+		return
+	case "gov":
+		code := runGovCommand(args[1:], os.Stdout, os.Stderr)
+		if code != 0 {
+			os.Exit(code)
+		}
+		return
+	case "loyalty-create-business":
+		if len(args) < 3 {
+			fmt.Println("Usage: loyalty-create-business <owner> <name>")
+			return
+		}
 		name := strings.Join(args[2:], " ")
 		loyaltyCreateBusiness(args[1], name)
 	case "loyalty-set-paymaster":
@@ -846,4 +852,5 @@ func printUsage() {
 	fmt.Println("  claimable                          - Hash-lock claimable subcommands")
 	fmt.Println("  p2p                                - P2P trade orchestration subcommands")
 	fmt.Println("  potso                              - POTSO telemetry subcommands")
+	fmt.Println("  swap                               - Swap voucher queries and export")
 }

--- a/cmd/nhb-cli/swap.go
+++ b/cmd/nhb-cli/swap.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func runSwapCommand(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "Usage: nhb-cli swap voucher <get|list|export> ...")
+		return 1
+	}
+	switch strings.ToLower(args[0]) {
+	case "voucher":
+		return runSwapVoucherCommand(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "Unknown swap subcommand %q\n", args[0])
+		return 1
+	}
+}
+
+func runSwapVoucherCommand(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "Usage: nhb-cli swap voucher <get|list|export> ...")
+		return 1
+	}
+	switch strings.ToLower(args[0]) {
+	case "get":
+		if len(args) < 2 {
+			fmt.Fprintln(stderr, "Usage: nhb-cli swap voucher get <providerTxId>")
+			return 1
+		}
+		result, err := callSwapRPC("swap_voucher_get", []interface{}{args[1]})
+		if err != nil {
+			fmt.Fprintf(stderr, "Error: %v\n", err)
+			return 1
+		}
+		var decoded interface{}
+		_ = json.Unmarshal(result, &decoded)
+		pretty, _ := json.MarshalIndent(decoded, "", "  ")
+		fmt.Fprintln(stdout, string(pretty))
+		return 0
+	case "list":
+		if len(args) < 3 {
+			fmt.Fprintln(stderr, "Usage: nhb-cli swap voucher list <startTs> <endTs> [cursor] [limit]")
+			return 1
+		}
+		start, err := strconv.ParseInt(args[1], 10, 64)
+		if err != nil {
+			fmt.Fprintf(stderr, "invalid startTs: %v\n", err)
+			return 1
+		}
+		end, err := strconv.ParseInt(args[2], 10, 64)
+		if err != nil {
+			fmt.Fprintf(stderr, "invalid endTs: %v\n", err)
+			return 1
+		}
+		params := []interface{}{start, end}
+		if len(args) >= 4 && strings.TrimSpace(args[3]) != "" {
+			params = append(params, args[3])
+		}
+		if len(args) >= 5 {
+			limit, err := strconv.Atoi(args[4])
+			if err != nil {
+				fmt.Fprintf(stderr, "invalid limit: %v\n", err)
+				return 1
+			}
+			params = append(params, limit)
+		}
+		result, err := callSwapRPC("swap_voucher_list", params)
+		if err != nil {
+			fmt.Fprintf(stderr, "Error: %v\n", err)
+			return 1
+		}
+		var decoded interface{}
+		_ = json.Unmarshal(result, &decoded)
+		pretty, _ := json.MarshalIndent(decoded, "", "  ")
+		fmt.Fprintln(stdout, string(pretty))
+		return 0
+	case "export":
+		if len(args) < 3 {
+			fmt.Fprintln(stderr, "Usage: nhb-cli swap voucher export <startTs> <endTs> [output.csv]")
+			return 1
+		}
+		start, err := strconv.ParseInt(args[1], 10, 64)
+		if err != nil {
+			fmt.Fprintf(stderr, "invalid startTs: %v\n", err)
+			return 1
+		}
+		end, err := strconv.ParseInt(args[2], 10, 64)
+		if err != nil {
+			fmt.Fprintf(stderr, "invalid endTs: %v\n", err)
+			return 1
+		}
+		result, err := callSwapRPC("swap_voucher_export", []interface{}{start, end})
+		if err != nil {
+			fmt.Fprintf(stderr, "Error: %v\n", err)
+			return 1
+		}
+		var payload struct {
+			CSVBase64    string `json:"csvBase64"`
+			Count        int    `json:"count"`
+			TotalMintWei string `json:"totalMintWei"`
+		}
+		if err := json.Unmarshal(result, &payload); err != nil {
+			fmt.Fprintf(stderr, "decode export response: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "count: %d\n", payload.Count)
+		fmt.Fprintf(stdout, "totalMintWei: %s\n", payload.TotalMintWei)
+		data, err := base64.StdEncoding.DecodeString(payload.CSVBase64)
+		if err != nil {
+			fmt.Fprintf(stderr, "decode csv: %v\n", err)
+			return 1
+		}
+		if len(args) >= 4 && strings.TrimSpace(args[3]) != "" {
+			if err := os.WriteFile(args[3], data, 0o644); err != nil {
+				fmt.Fprintf(stderr, "write file: %v\n", err)
+				return 1
+			}
+			fmt.Fprintf(stdout, "csv saved to %s\n", args[3])
+		} else {
+			fmt.Fprintln(stdout, string(data))
+		}
+		return 0
+	default:
+		fmt.Fprintf(stderr, "Unknown voucher subcommand %q\n", args[0])
+		return 1
+	}
+}
+
+func callSwapRPC(method string, params []interface{}) (json.RawMessage, error) {
+	payload := map[string]interface{}{"id": 1, "method": method, "params": params}
+	body, _ := json.Marshal(payload)
+	resp, err := doRPCRequest(body, false)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var rpcResp struct {
+		Result json.RawMessage `json:"result"`
+		Error  *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response from node")
+	}
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("error from node: %s", rpcResp.Error.Message)
+	}
+	return rpcResp.Result, nil
+}

--- a/config.toml
+++ b/config.toml
@@ -54,3 +54,9 @@ TimelockSeconds = 172800
 QuorumBps = 2000
 PassThresholdBps = 5000
 AllowedParams = ["potso.weights.AlphaStakeBps","potso.rewards.EmissionPerEpochWei","fees.baseFee"]
+
+[swap]
+AllowedFiat = ["USD","EUR","GBP"]
+MaxQuoteAgeSeconds = 120
+SlippageBps = 50
+OraclePriority = ["nowpayments","coingecko","manual"]

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 	"nhbchain/crypto"
 	"nhbchain/native/governance"
 	"nhbchain/native/potso"
+	swap "nhbchain/native/swap"
 
 	"github.com/BurntSushi/toml"
 )
@@ -41,6 +42,7 @@ type Config struct {
 	P2P                   P2PSection  `toml:"p2p"`
 	Potso                 PotsoConfig `toml:"potso"`
 	Governance            GovConfig   `toml:"governance"`
+	Swap                  swap.Config `toml:"swap"`
 }
 
 // P2PSection captures nested configuration for the peer-to-peer subsystem.
@@ -228,6 +230,7 @@ func Load(path string) (*Config, error) {
 		}
 	}
 
+	cfg.Swap = cfg.Swap.Normalise()
 	cfg.syncTopLevelToP2P()
 
 	return cfg, nil
@@ -397,6 +400,14 @@ func (cfg *Config) PotsoWeightConfig() (potso.WeightParams, error) {
 		return result, err
 	}
 	return result, nil
+}
+
+// SwapSettings exposes the swap configuration with defaults applied.
+func (cfg *Config) SwapSettings() swap.Config {
+	if cfg == nil {
+		return swap.Config{}.Normalise()
+	}
+	return cfg.Swap.Normalise()
 }
 
 // Policy converts the governance TOML representation into a runtime proposal policy.

--- a/core/swap.go
+++ b/core/swap.go
@@ -3,20 +3,30 @@ package core
 import "errors"
 
 var (
-        // ErrSwapInvalidDomain indicates the voucher domain does not match the expected identifier.
-        ErrSwapInvalidDomain = errors.New("swap: invalid domain")
-        // ErrSwapInvalidChainID indicates the voucher targets a different chain.
-        ErrSwapInvalidChainID = errors.New("swap: invalid chain id")
-        // ErrSwapExpired indicates the voucher expiry timestamp has elapsed.
-        ErrSwapExpired = errors.New("swap: voucher expired")
-        // ErrSwapInvalidToken indicates the voucher requested an unsupported token.
-        ErrSwapInvalidToken = errors.New("swap: invalid token")
-        // ErrSwapInvalidSignature indicates the signature is malformed or cannot be recovered.
-        ErrSwapInvalidSignature = errors.New("swap: invalid signature")
-        // ErrSwapInvalidSigner indicates the recovered signer does not match the configured mint authority.
-        ErrSwapInvalidSigner = errors.New("swap: invalid signer")
-        // ErrSwapNonceUsed indicates the order identifier has already been processed.
-        ErrSwapNonceUsed = errors.New("swap: order already processed")
-        // ErrSwapMintPaused indicates the token mint has been paused by governance.
-        ErrSwapMintPaused = errors.New("swap: mint paused")
+	// ErrSwapInvalidDomain indicates the voucher domain does not match the expected identifier.
+	ErrSwapInvalidDomain = errors.New("swap: invalid domain")
+	// ErrSwapInvalidChainID indicates the voucher targets a different chain.
+	ErrSwapInvalidChainID = errors.New("swap: invalid chain id")
+	// ErrSwapExpired indicates the voucher expiry timestamp has elapsed.
+	ErrSwapExpired = errors.New("swap: voucher expired")
+	// ErrSwapInvalidToken indicates the voucher requested an unsupported token.
+	ErrSwapInvalidToken = errors.New("swap: invalid token")
+	// ErrSwapInvalidSignature indicates the signature is malformed or cannot be recovered.
+	ErrSwapInvalidSignature = errors.New("swap: invalid signature")
+	// ErrSwapInvalidSigner indicates the recovered signer does not match the configured mint authority.
+	ErrSwapInvalidSigner = errors.New("swap: invalid signer")
+	// ErrSwapNonceUsed indicates the order identifier has already been processed.
+	ErrSwapNonceUsed = errors.New("swap: order already processed")
+	// ErrSwapMintPaused indicates the token mint has been paused by governance.
+	ErrSwapMintPaused = errors.New("swap: mint paused")
+	// ErrSwapUnsupportedFiat indicates the voucher references a fiat currency outside the allow-list.
+	ErrSwapUnsupportedFiat = errors.New("swap: fiat currency not allowed")
+	// ErrSwapOracleUnavailable indicates the price oracle has not been configured.
+	ErrSwapOracleUnavailable = errors.New("swap: price oracle unavailable")
+	// ErrSwapQuoteStale indicates the oracle quote exceeded the configured freshness window.
+	ErrSwapQuoteStale = errors.New("swap: oracle quote stale")
+	// ErrSwapSlippageExceeded indicates the submitted mint amount deviates beyond the allowed slippage threshold.
+	ErrSwapSlippageExceeded = errors.New("swap: slippage exceeds maximum")
+	// ErrSwapDuplicateProviderTx indicates the provider transaction identifier has already been recorded.
+	ErrSwapDuplicateProviderTx = errors.New("swap: provider transaction already processed")
 )

--- a/native/swap/ledger.go
+++ b/native/swap/ledger.go
@@ -1,0 +1,462 @@
+package swap
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/csv"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"math/big"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// Storage abstracts the subset of state manager functionality required by the
+// voucher ledger.
+type Storage interface {
+	KVGet(key []byte, out interface{}) (bool, error)
+	KVPut(key []byte, value interface{}) error
+	KVAppend(key []byte, value []byte) error
+	KVGetList(key []byte, out interface{}) error
+}
+
+var (
+	voucherRecordPrefix = []byte("swap/voucher/")
+	voucherIndexKey     = []byte("swap/voucher/index")
+)
+
+// Voucher statuses recorded within the ledger.
+const (
+	VoucherStatusMinted     = "minted"
+	VoucherStatusReconciled = "reconciled"
+	VoucherStatusReversed   = "reversed"
+)
+
+// VoucherRecord captures the metadata stored for every voucher processed by the
+// mint pipeline.
+type VoucherRecord struct {
+	Provider        string
+	ProviderTxID    string
+	FiatCurrency    string
+	FiatAmount      string
+	USD             string
+	Rate            string
+	Token           string
+	MintAmountWei   *big.Int
+	Recipient       [20]byte
+	Username        string
+	Address         string
+	QuoteTimestamp  int64
+	OracleSource    string
+	MinterSignature string
+	Status          string
+	CreatedAt       int64
+}
+
+// Copy returns a deep copy to avoid callers mutating shared pointers.
+func (v *VoucherRecord) Copy() *VoucherRecord {
+	if v == nil {
+		return nil
+	}
+	clone := *v
+	if v.MintAmountWei != nil {
+		clone.MintAmountWei = new(big.Int).Set(v.MintAmountWei)
+	}
+	return &clone
+}
+
+type storedVoucherRecord struct {
+	Provider        string
+	ProviderTxID    string
+	FiatCurrency    string
+	FiatAmount      string
+	USD             string
+	Rate            string
+	Token           string
+	MintAmountWei   string
+	Recipient       [20]byte
+	Username        string
+	Address         string
+	QuoteTimestamp  uint64
+	OracleSource    string
+	MinterSignature string
+	Status          string
+	CreatedAt       uint64
+}
+
+type voucherIndexEntry struct {
+	ProviderTxID string
+	CreatedAt    uint64
+}
+
+// Ledger persists voucher records in the underlying key-value store.
+type Ledger struct {
+	store Storage
+	clock func() time.Time
+}
+
+// NewLedger constructs a ledger bound to the provided storage backend.
+func NewLedger(store Storage) *Ledger {
+	return &Ledger{store: store, clock: time.Now}
+}
+
+// SetClock overrides the time source (primarily for deterministic testing).
+func (l *Ledger) SetClock(clock func() time.Time) {
+	if l == nil || clock == nil {
+		return
+	}
+	l.clock = clock
+}
+
+// Put stores the voucher record, enforcing append-only semantics keyed by the
+// provider transaction identifier.
+func (l *Ledger) Put(record *VoucherRecord) error {
+	if l == nil {
+		return fmt.Errorf("ledger not initialised")
+	}
+	if record == nil {
+		return fmt.Errorf("ledger: record must not be nil")
+	}
+	key := voucherKey(record.ProviderTxID)
+	if len(key) == len(voucherRecordPrefix) {
+		return fmt.Errorf("ledger: providerTxId required")
+	}
+	var existing storedVoucherRecord
+	ok, err := l.store.KVGet(key, &existing)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return fmt.Errorf("ledger: voucher %s already exists", record.ProviderTxID)
+	}
+	stored := toStoredVoucher(record)
+	if stored.CreatedAt == 0 {
+		now := l.clock().UTC().Unix()
+		if now < 0 {
+			stored.CreatedAt = 0
+		} else {
+			stored.CreatedAt = uint64(now)
+		}
+	}
+	if stored.Status == "" {
+		stored.Status = VoucherStatusMinted
+	}
+	if err := l.store.KVPut(key, stored); err != nil {
+		return err
+	}
+	if _, err := uint64ToInt64(stored.CreatedAt); err != nil {
+		return fmt.Errorf("ledger: created at overflow: %w", err)
+	}
+	entry := voucherIndexEntry{ProviderTxID: stored.ProviderTxID, CreatedAt: stored.CreatedAt}
+	encoded, err := rlp.EncodeToBytes(entry)
+	if err != nil {
+		return err
+	}
+	return l.store.KVAppend(voucherIndexKey, encoded)
+}
+
+// Exists reports whether a voucher with the supplied provider identifier has been
+// recorded in the ledger.
+func (l *Ledger) Exists(providerTxID string) (bool, error) {
+	if l == nil {
+		return false, fmt.Errorf("ledger not initialised")
+	}
+	key := voucherKey(providerTxID)
+	var stored storedVoucherRecord
+	ok, err := l.store.KVGet(key, &stored)
+	if err != nil {
+		return false, err
+	}
+	return ok, nil
+}
+
+// Get retrieves a voucher record by provider transaction identifier.
+func (l *Ledger) Get(providerTxID string) (*VoucherRecord, bool, error) {
+	if l == nil {
+		return nil, false, fmt.Errorf("ledger not initialised")
+	}
+	key := voucherKey(providerTxID)
+	var stored storedVoucherRecord
+	ok, err := l.store.KVGet(key, &stored)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	record, err := fromStoredVoucher(&stored)
+	if err != nil {
+		return nil, false, err
+	}
+	return record, true, nil
+}
+
+// List returns a paginated list of voucher records within the supplied timestamp
+// range. Both bounds are inclusive. The cursor is the provider transaction ID of
+// the last item from the previous page.
+func (l *Ledger) List(startTs, endTs int64, cursor string, limit int) ([]*VoucherRecord, string, error) {
+	if l == nil {
+		return nil, "", fmt.Errorf("ledger not initialised")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	entries, err := l.loadIndex()
+	if err != nil {
+		return nil, "", err
+	}
+	filtered := make([]voucherIndexEntry, 0, len(entries))
+	for _, entry := range entries {
+		createdAt, err := uint64ToInt64(entry.CreatedAt)
+		if err != nil {
+			return nil, "", fmt.Errorf("ledger: index entry overflow: %w", err)
+		}
+		if startTs != 0 && createdAt < startTs {
+			continue
+		}
+		if endTs != 0 && createdAt > endTs {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		if filtered[i].CreatedAt == filtered[j].CreatedAt {
+			return filtered[i].ProviderTxID < filtered[j].ProviderTxID
+		}
+		return filtered[i].CreatedAt < filtered[j].CreatedAt
+	})
+	startIdx := 0
+	cursorID := strings.TrimSpace(cursor)
+	if cursorID != "" {
+		for i, entry := range filtered {
+			if entry.ProviderTxID == cursorID {
+				startIdx = i + 1
+				break
+			}
+		}
+	}
+	nextCursor := ""
+	records := make([]*VoucherRecord, 0, min(limit, len(filtered)-startIdx))
+	for i := startIdx; i < len(filtered) && len(records) < limit; i++ {
+		entry := filtered[i]
+		record, ok, err := l.Get(entry.ProviderTxID)
+		if err != nil {
+			return nil, "", err
+		}
+		if !ok {
+			continue
+		}
+		records = append(records, record)
+		nextCursor = entry.ProviderTxID
+	}
+	if startIdx+len(records) >= len(filtered) {
+		nextCursor = ""
+	}
+	return records, nextCursor, nil
+}
+
+// ExportCSV generates a deterministic CSV export covering the provided timestamp
+// window. The CSV is returned as a base64 encoded string alongside the entry count
+// and total minted amount in wei.
+func (l *Ledger) ExportCSV(startTs, endTs int64) (string, int, *big.Int, error) {
+	if l == nil {
+		return "", 0, nil, fmt.Errorf("ledger not initialised")
+	}
+	entries, _, err := l.List(startTs, endTs, "", 0)
+	if err != nil {
+		return "", 0, nil, err
+	}
+	buf := &bytes.Buffer{}
+	writer := csv.NewWriter(buf)
+	header := []string{"providerTxId", "provider", "fiatCurrency", "fiatAmount", "usd", "rate", "token", "mintAmountWei", "recipient", "username", "address", "quoteTs", "source", "minterSig", "status", "createdAt"}
+	if err := writer.Write(header); err != nil {
+		return "", 0, nil, err
+	}
+	total := big.NewInt(0)
+	for _, record := range entries {
+		if record.MintAmountWei != nil {
+			total = new(big.Int).Add(total, record.MintAmountWei)
+		}
+		row := []string{
+			record.ProviderTxID,
+			record.Provider,
+			record.FiatCurrency,
+			record.FiatAmount,
+			record.USD,
+			record.Rate,
+			record.Token,
+			mintAmountToString(record.MintAmountWei),
+			hex.EncodeToString(record.Recipient[:]),
+			record.Username,
+			record.Address,
+			strconv.FormatInt(record.QuoteTimestamp, 10),
+			record.OracleSource,
+			record.MinterSignature,
+			record.Status,
+			strconv.FormatInt(record.CreatedAt, 10),
+		}
+		if err := writer.Write(row); err != nil {
+			return "", 0, nil, err
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return "", 0, nil, err
+	}
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return encoded, len(entries), total, nil
+}
+
+// MarkReconciled updates the status of the supplied vouchers to "reconciled".
+func (l *Ledger) MarkReconciled(ids []string) error {
+	if l == nil {
+		return fmt.Errorf("ledger not initialised")
+	}
+	for _, id := range ids {
+		key := voucherKey(id)
+		var stored storedVoucherRecord
+		ok, err := l.store.KVGet(key, &stored)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		stored.Status = VoucherStatusReconciled
+		if err := l.store.KVPut(key, stored); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *Ledger) loadIndex() ([]voucherIndexEntry, error) {
+	var raw [][]byte
+	if err := l.store.KVGetList(voucherIndexKey, &raw); err != nil {
+		return nil, err
+	}
+	entries := make([]voucherIndexEntry, 0, len(raw))
+	for _, encoded := range raw {
+		if len(encoded) == 0 {
+			continue
+		}
+		var entry voucherIndexEntry
+		if err := rlp.DecodeBytes(encoded, &entry); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(entry.ProviderTxID) == "" {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func voucherKey(providerTxID string) []byte {
+	trimmed := strings.TrimSpace(providerTxID)
+	buf := make([]byte, len(voucherRecordPrefix)+len(trimmed))
+	copy(buf, voucherRecordPrefix)
+	copy(buf[len(voucherRecordPrefix):], trimmed)
+	return buf
+}
+
+func toStoredVoucher(record *VoucherRecord) storedVoucherRecord {
+	stored := storedVoucherRecord{}
+	if record == nil {
+		return stored
+	}
+	stored.Provider = strings.TrimSpace(record.Provider)
+	stored.ProviderTxID = strings.TrimSpace(record.ProviderTxID)
+	stored.FiatCurrency = strings.TrimSpace(record.FiatCurrency)
+	stored.FiatAmount = strings.TrimSpace(record.FiatAmount)
+	stored.USD = strings.TrimSpace(record.USD)
+	stored.Rate = strings.TrimSpace(record.Rate)
+	stored.Token = strings.TrimSpace(record.Token)
+	if record.MintAmountWei != nil {
+		stored.MintAmountWei = record.MintAmountWei.String()
+	}
+	stored.Recipient = record.Recipient
+	stored.Username = strings.TrimSpace(record.Username)
+	stored.Address = strings.TrimSpace(record.Address)
+	if record.QuoteTimestamp < 0 {
+		stored.QuoteTimestamp = 0
+	} else {
+		stored.QuoteTimestamp = uint64(record.QuoteTimestamp)
+	}
+	stored.OracleSource = strings.TrimSpace(record.OracleSource)
+	stored.MinterSignature = strings.TrimSpace(record.MinterSignature)
+	stored.Status = strings.TrimSpace(record.Status)
+	if record.CreatedAt < 0 {
+		stored.CreatedAt = 0
+	} else {
+		stored.CreatedAt = uint64(record.CreatedAt)
+	}
+	return stored
+}
+
+func fromStoredVoucher(stored *storedVoucherRecord) (*VoucherRecord, error) {
+	if stored == nil {
+		return nil, fmt.Errorf("ledger: nil stored record")
+	}
+	quoteTimestamp, err := uint64ToInt64(stored.QuoteTimestamp)
+	if err != nil {
+		return nil, fmt.Errorf("ledger: quote timestamp overflow: %w", err)
+	}
+	createdAt, err := uint64ToInt64(stored.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("ledger: created at overflow: %w", err)
+	}
+	record := &VoucherRecord{
+		Provider:        stored.Provider,
+		ProviderTxID:    stored.ProviderTxID,
+		FiatCurrency:    stored.FiatCurrency,
+		FiatAmount:      stored.FiatAmount,
+		USD:             stored.USD,
+		Rate:            stored.Rate,
+		Token:           stored.Token,
+		Recipient:       stored.Recipient,
+		Username:        stored.Username,
+		Address:         stored.Address,
+		QuoteTimestamp:  quoteTimestamp,
+		OracleSource:    stored.OracleSource,
+		MinterSignature: stored.MinterSignature,
+		Status:          stored.Status,
+		CreatedAt:       createdAt,
+	}
+	if strings.TrimSpace(stored.MintAmountWei) != "" {
+		amount, ok := new(big.Int).SetString(strings.TrimSpace(stored.MintAmountWei), 10)
+		if !ok {
+			return nil, fmt.Errorf("ledger: invalid amount %q", stored.MintAmountWei)
+		}
+		record.MintAmountWei = amount
+	} else {
+		record.MintAmountWei = big.NewInt(0)
+	}
+	return record, nil
+}
+
+func uint64ToInt64(value uint64) (int64, error) {
+	if value > math.MaxInt64 {
+		return 0, fmt.Errorf("value %d exceeds int64 range", value)
+	}
+	return int64(value), nil
+}
+
+func mintAmountToString(amount *big.Int) string {
+	if amount == nil {
+		return "0"
+	}
+	return amount.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/native/swap/ledger_test.go
+++ b/native/swap/ledger_test.go
@@ -1,0 +1,194 @@
+package swap
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type mockStorage struct {
+	kv    map[string][]byte
+	lists map[string][][]byte
+}
+
+func newMockStorage() *mockStorage {
+	return &mockStorage{kv: make(map[string][]byte), lists: make(map[string][][]byte)}
+}
+
+func (m *mockStorage) KVPut(key []byte, value interface{}) error {
+	encoded, err := rlp.EncodeToBytes(value)
+	if err != nil {
+		return err
+	}
+	m.kv[string(key)] = encoded
+	return nil
+}
+
+func (m *mockStorage) KVGet(key []byte, out interface{}) (bool, error) {
+	encoded, ok := m.kv[string(key)]
+	if !ok {
+		return false, nil
+	}
+	if out == nil {
+		return true, nil
+	}
+	if err := rlp.DecodeBytes(encoded, out); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (m *mockStorage) KVAppend(key []byte, value []byte) error {
+	k := string(key)
+	m.lists[k] = append(m.lists[k], append([]byte(nil), value...))
+	return nil
+}
+
+func (m *mockStorage) KVGetList(key []byte, out interface{}) error {
+	encoded, err := rlp.EncodeToBytes(m.lists[string(key)])
+	if err != nil {
+		return err
+	}
+	return rlp.DecodeBytes(encoded, out)
+}
+
+func TestLedgerPutAndGet(t *testing.T) {
+	store := newMockStorage()
+	ledger := NewLedger(store)
+	ledger.SetClock(func() time.Time { return time.Unix(1700000000, 0) })
+	record := &VoucherRecord{
+		Provider:        "nowpayments",
+		ProviderTxID:    "np-1",
+		FiatCurrency:    "USD",
+		FiatAmount:      "100.00",
+		USD:             "100.00",
+		Rate:            "0.50",
+		Token:           "ZNHB",
+		MintAmountWei:   big.NewInt(5000000000000000000),
+		QuoteTimestamp:  time.Unix(1700000000, 0).Unix(),
+		OracleSource:    "manual",
+		MinterSignature: "0xabc",
+	}
+	if err := ledger.Put(record); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	fetched, ok, err := ledger.Get("np-1")
+	if err != nil || !ok {
+		t.Fatalf("get: %v ok=%v", err, ok)
+	}
+	if fetched.Provider != "nowpayments" {
+		t.Fatalf("unexpected provider %s", fetched.Provider)
+	}
+	if fetched.MintAmountWei.Cmp(record.MintAmountWei) != 0 {
+		t.Fatalf("unexpected amount %s", fetched.MintAmountWei)
+	}
+}
+
+func TestLedgerListAndCursor(t *testing.T) {
+	store := newMockStorage()
+	ledger := NewLedger(store)
+	timestamps := []time.Time{
+		time.Unix(1700000100, 0),
+		time.Unix(1700000200, 0),
+		time.Unix(1700000300, 0),
+	}
+	idx := 0
+	ledger.SetClock(func() time.Time {
+		current := timestamps[idx]
+		if idx < len(timestamps)-1 {
+			idx++
+		}
+		return current
+	})
+	for i := 0; i < 3; i++ {
+		rec := &VoucherRecord{
+			Provider:        "manual",
+			ProviderTxID:    fmt.Sprintf("id-%d", i),
+			FiatCurrency:    "USD",
+			FiatAmount:      "50.00",
+			Rate:            "0.25",
+			Token:           "ZNHB",
+			MintAmountWei:   big.NewInt(int64(i + 1)),
+			QuoteTimestamp:  timestamps[i].Unix(),
+			OracleSource:    "manual",
+			MinterSignature: "0xsig",
+		}
+		if err := ledger.Put(rec); err != nil {
+			t.Fatalf("put %d: %v", i, err)
+		}
+	}
+	page, cursor, err := ledger.List(0, 0, "", 2)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(page) != 2 || cursor == "" {
+		t.Fatalf("unexpected page len=%d cursor=%s", len(page), cursor)
+	}
+	if page[0].ProviderTxID != "id-0" || page[1].ProviderTxID != "id-1" {
+		t.Fatalf("unexpected ordering: %+v", page)
+	}
+	second, next, err := ledger.List(0, 0, cursor, 2)
+	if err != nil {
+		t.Fatalf("list next: %v", err)
+	}
+	if len(second) != 1 || second[0].ProviderTxID != "id-2" {
+		t.Fatalf("unexpected second page: %+v", second)
+	}
+	if next != "" {
+		t.Fatalf("expected empty cursor, got %s", next)
+	}
+}
+
+func TestLedgerExportCSV(t *testing.T) {
+	store := newMockStorage()
+	ledger := NewLedger(store)
+	ledger.SetClock(func() time.Time { return time.Unix(1700000400, 0) })
+	_ = ledger.Put(&VoucherRecord{Provider: "p", ProviderTxID: "a", FiatCurrency: "USD", FiatAmount: "10", Rate: "0.1", Token: "ZNHB", MintAmountWei: big.NewInt(100), QuoteTimestamp: time.Unix(1700000400, 0).Unix(), OracleSource: "manual", MinterSignature: "0xsig"})
+	ledger.SetClock(func() time.Time { return time.Unix(1700000500, 0) })
+	_ = ledger.Put(&VoucherRecord{Provider: "p", ProviderTxID: "b", FiatCurrency: "USD", FiatAmount: "20", Rate: "0.2", Token: "ZNHB", MintAmountWei: big.NewInt(200), QuoteTimestamp: time.Unix(1700000500, 0).Unix(), OracleSource: "manual", MinterSignature: "0xsig"})
+	encoded, count, total, err := ledger.ExportCSV(0, 0)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("unexpected count %d", count)
+	}
+	if total.Cmp(big.NewInt(300)) != 0 {
+		t.Fatalf("unexpected total %s", total)
+	}
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	rows := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+	if !strings.Contains(rows[1], "a") || !strings.Contains(rows[2], "b") {
+		t.Fatalf("unexpected csv rows: %v", rows)
+	}
+}
+
+func TestLedgerMarkReconciled(t *testing.T) {
+	store := newMockStorage()
+	ledger := NewLedger(store)
+	ledger.SetClock(func() time.Time { return time.Unix(1700000600, 0) })
+	if err := ledger.Put(&VoucherRecord{Provider: "p", ProviderTxID: "id", FiatCurrency: "USD", FiatAmount: "1", Rate: "0.1", Token: "ZNHB", MintAmountWei: big.NewInt(1), QuoteTimestamp: time.Unix(1700000600, 0).Unix(), OracleSource: "manual", MinterSignature: "0xsig"}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := ledger.MarkReconciled([]string{"id"}); err != nil {
+		t.Fatalf("mark reconciled: %v", err)
+	}
+	rec, ok, err := ledger.Get("id")
+	if err != nil || !ok {
+		t.Fatalf("get: %v ok=%v", err, ok)
+	}
+	if rec.Status != VoucherStatusReconciled {
+		t.Fatalf("expected reconciled status, got %s", rec.Status)
+	}
+}

--- a/native/swap/oracle.go
+++ b/native/swap/oracle.go
@@ -1,0 +1,522 @@
+package swap
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// PriceQuote captures an exchange rate for a specific currency pair along with the
+// timestamp reported by the upstream oracle and the oracle identifier.
+type PriceQuote struct {
+	Rate      *big.Rat
+	Timestamp time.Time
+	Source    string
+}
+
+// Clone returns a deep copy of the quote to prevent accidental mutations.
+func (q PriceQuote) Clone() PriceQuote {
+	clone := PriceQuote{Timestamp: q.Timestamp, Source: q.Source}
+	if q.Rate != nil {
+		clone.Rate = new(big.Rat).Set(q.Rate)
+	}
+	return clone
+}
+
+// RateString renders the rate using the supplied precision. The value is rounded
+// using bankers rounding in line with big.Rat formatting semantics.
+func (q PriceQuote) RateString(precision int) string {
+	if q.Rate == nil {
+		return ""
+	}
+	if precision < 0 {
+		precision = 18
+	}
+	return q.Rate.FloatString(precision)
+}
+
+// PriceOracle resolves an exchange rate for the provided base/quote currency pair.
+type PriceOracle interface {
+	GetRate(base, quote string) (PriceQuote, error)
+}
+
+// ErrNoFreshQuote indicates that the aggregator could not retrieve a quote within
+// the configured freshness window.
+var ErrNoFreshQuote = errors.New("swap: no fresh oracle quote available")
+
+// OracleAggregator consults a list of registered oracles in priority order until a
+// fresh quote is obtained.
+type OracleAggregator struct {
+	mu       sync.RWMutex
+	priority []string
+	oracles  map[string]PriceOracle
+	maxAge   time.Duration
+}
+
+// NewOracleAggregator constructs a new aggregator with the provided priority and
+// freshness window. When priority is nil a zero-length slice is initialised so that
+// Register can safely append identifiers without additional checks.
+func NewOracleAggregator(priority []string, maxAge time.Duration) *OracleAggregator {
+	prio := append([]string{}, priority...)
+	return &OracleAggregator{
+		priority: prio,
+		oracles:  make(map[string]PriceOracle),
+		maxAge:   maxAge,
+	}
+}
+
+// SetMaxAge updates the freshness window used when filtering quotes.
+func (a *OracleAggregator) SetMaxAge(maxAge time.Duration) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	a.maxAge = maxAge
+	a.mu.Unlock()
+}
+
+// SetPriority replaces the priority ordering used when consulting child oracles.
+func (a *OracleAggregator) SetPriority(priority []string) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	a.priority = append([]string{}, priority...)
+	a.mu.Unlock()
+}
+
+// Register adds or replaces an oracle under the supplied identifier. Identifiers
+// are stored in lowercase to ensure lookups remain consistent regardless of the
+// configuration casing.
+func (a *OracleAggregator) Register(name string, oracle PriceOracle) {
+	if a == nil {
+		return
+	}
+	trimmed := strings.ToLower(strings.TrimSpace(name))
+	if trimmed == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.oracles[trimmed] = oracle
+	exists := false
+	for _, entry := range a.priority {
+		if strings.EqualFold(entry, trimmed) {
+			exists = true
+			break
+		}
+	}
+	if !exists {
+		a.priority = append(a.priority, trimmed)
+	}
+}
+
+// GetRate fetches a rate from the configured oracles respecting the priority
+// ordering. The aggregator enforces the freshness window and ensures the returned
+// quote contains a defensive copy of the upstream value to avoid callers mutating
+// shared state.
+func (a *OracleAggregator) GetRate(base, quote string) (PriceQuote, error) {
+	if a == nil {
+		return PriceQuote{}, fmt.Errorf("oracle aggregator not configured")
+	}
+	a.mu.RLock()
+	priority := append([]string{}, a.priority...)
+	maxAge := a.maxAge
+	a.mu.RUnlock()
+
+	baseSym := normaliseSymbol(base)
+	quoteSym := normaliseSymbol(quote)
+	if baseSym == "" || quoteSym == "" {
+		return PriceQuote{}, fmt.Errorf("oracle: base and quote required")
+	}
+
+	var lastErr error
+	cutoff := time.Time{}
+	if maxAge > 0 {
+		cutoff = time.Now().Add(-maxAge)
+	}
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, name := range priority {
+		oracle := a.oracles[strings.ToLower(name)]
+		if oracle == nil {
+			continue
+		}
+		quote, err := oracle.GetRate(baseSym, quoteSym)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if quote.Rate == nil || quote.Rate.Sign() <= 0 {
+			lastErr = fmt.Errorf("oracle %s returned invalid rate", name)
+			continue
+		}
+		if maxAge > 0 && quote.Timestamp.Before(cutoff) {
+			lastErr = ErrNoFreshQuote
+			continue
+		}
+		result := quote.Clone()
+		if strings.TrimSpace(result.Source) == "" {
+			result.Source = strings.ToLower(name)
+		}
+		return result, nil
+	}
+
+	if lastErr == nil {
+		lastErr = ErrNoFreshQuote
+	}
+	return PriceQuote{}, lastErr
+}
+
+// ManualOracle provides an in-memory oracle implementation used for tests and
+// manual overrides during incident response.
+type ManualOracle struct {
+	mu     sync.RWMutex
+	quotes map[string]PriceQuote
+}
+
+// NewManualOracle constructs an empty manual oracle instance.
+func NewManualOracle() *ManualOracle {
+	return &ManualOracle{quotes: make(map[string]PriceQuote)}
+}
+
+func manualKey(base, quote string) string {
+	return normaliseSymbol(base) + "_" + normaliseSymbol(quote)
+}
+
+// SetDecimal records the supplied decimal rate for the currency pair using the
+// provided timestamp.
+func (m *ManualOracle) SetDecimal(base, quote, rate string, ts time.Time) error {
+	if m == nil {
+		return fmt.Errorf("manual oracle not configured")
+	}
+	trimmed := strings.TrimSpace(rate)
+	if trimmed == "" {
+		return fmt.Errorf("manual oracle: rate required")
+	}
+	rat, ok := new(big.Rat).SetString(trimmed)
+	if !ok {
+		return fmt.Errorf("manual oracle: invalid rate %q", rate)
+	}
+	if rat.Sign() <= 0 {
+		return fmt.Errorf("manual oracle: rate must be positive")
+	}
+	m.Set(base, quote, rat, ts)
+	return nil
+}
+
+// Set stores the provided rational rate for the currency pair.
+func (m *ManualOracle) Set(base, quote string, rate *big.Rat, ts time.Time) {
+	if m == nil || rate == nil {
+		return
+	}
+	key := manualKey(base, quote)
+	if strings.Contains(key, "_") {
+		m.mu.Lock()
+		clone := PriceQuote{Timestamp: ts, Source: "manual"}
+		clone.Rate = new(big.Rat).Set(rate)
+		m.quotes[key] = clone
+		m.mu.Unlock()
+	}
+}
+
+// GetRate retrieves the stored rate for the currency pair.
+func (m *ManualOracle) GetRate(base, quote string) (PriceQuote, error) {
+	if m == nil {
+		return PriceQuote{}, fmt.Errorf("manual oracle not configured")
+	}
+	key := manualKey(base, quote)
+	m.mu.RLock()
+	stored, ok := m.quotes[key]
+	m.mu.RUnlock()
+	if !ok {
+		return PriceQuote{}, fmt.Errorf("manual oracle: quote for %s/%s not found", base, quote)
+	}
+	return stored.Clone(), nil
+}
+
+// HTTPDoer abstracts http.Client for ease of testing.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// NowPaymentsOracle fetches price data from the NOWPayments quote endpoint.
+type NowPaymentsOracle struct {
+	client   HTTPDoer
+	endpoint string
+	apiKey   string
+}
+
+const defaultNowPaymentsEndpoint = "https://api.nowpayments.io/v1/exchange/rates"
+
+// NewNowPaymentsOracle constructs a NOWPayments oracle adapter. When the client is
+// nil http.DefaultClient is used. The API key is optional and only added to the
+// request headers when supplied.
+func NewNowPaymentsOracle(client HTTPDoer, endpoint, apiKey string) *NowPaymentsOracle {
+	ep := strings.TrimSpace(endpoint)
+	if ep == "" {
+		ep = defaultNowPaymentsEndpoint
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &NowPaymentsOracle{client: client, endpoint: ep, apiKey: strings.TrimSpace(apiKey)}
+}
+
+func (o *NowPaymentsOracle) GetRate(base, quote string) (PriceQuote, error) {
+	if o == nil {
+		return PriceQuote{}, fmt.Errorf("nowpayments oracle not configured")
+	}
+	baseSym := normaliseSymbol(base)
+	quoteSym := normaliseSymbol(quote)
+	req, err := http.NewRequest(http.MethodGet, o.endpoint, nil)
+	if err != nil {
+		return PriceQuote{}, err
+	}
+	values := url.Values{}
+	values.Set("from", baseSym)
+	values.Set("to", quoteSym)
+	req.URL.RawQuery = values.Encode()
+	if o.apiKey != "" {
+		req.Header.Set("x-api-key", o.apiKey)
+	}
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return PriceQuote{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return PriceQuote{}, fmt.Errorf("nowpayments oracle: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var payload struct {
+		Rate      string `json:"rate"`
+		Timestamp int64  `json:"timestamp"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return PriceQuote{}, fmt.Errorf("nowpayments oracle: decode: %w", err)
+	}
+	rate := strings.TrimSpace(payload.Rate)
+	if rate == "" {
+		return PriceQuote{}, fmt.Errorf("nowpayments oracle: empty rate")
+	}
+	rat, ok := new(big.Rat).SetString(rate)
+	if !ok || rat.Sign() <= 0 {
+		return PriceQuote{}, fmt.Errorf("nowpayments oracle: invalid rate %q", payload.Rate)
+	}
+	ts := time.Unix(payload.Timestamp, 0)
+	return PriceQuote{Rate: rat, Timestamp: ts, Source: "nowpayments"}, nil
+}
+
+// CoinGeckoOracle adapts the public CoinGecko simple price API.
+type CoinGeckoOracle struct {
+	client   HTTPDoer
+	endpoint string
+	idMap    map[string]string
+}
+
+const defaultCoinGeckoEndpoint = "https://api.coingecko.com/api/v3/simple/price"
+
+// NewCoinGeckoOracle constructs a new adapter. idMap allows the caller to map
+// on-chain token symbols to CoinGecko asset identifiers.
+func NewCoinGeckoOracle(client HTTPDoer, endpoint string, idMap map[string]string) *CoinGeckoOracle {
+	ep := strings.TrimSpace(endpoint)
+	if ep == "" {
+		ep = defaultCoinGeckoEndpoint
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	mapped := make(map[string]string, len(idMap))
+	for k, v := range idMap {
+		mapped[normaliseSymbol(k)] = strings.TrimSpace(v)
+	}
+	return &CoinGeckoOracle{client: client, endpoint: ep, idMap: mapped}
+}
+
+func (o *CoinGeckoOracle) assetID(symbol string) string {
+	if o == nil {
+		return ""
+	}
+	if id, ok := o.idMap[normaliseSymbol(symbol)]; ok && id != "" {
+		return id
+	}
+	return strings.ToLower(strings.TrimSpace(symbol))
+}
+
+func (o *CoinGeckoOracle) GetRate(base, quote string) (PriceQuote, error) {
+	if o == nil {
+		return PriceQuote{}, fmt.Errorf("coingecko oracle not configured")
+	}
+	baseSym := strings.ToLower(normaliseSymbol(base))
+	quoteSym := normaliseSymbol(quote)
+	id := o.assetID(quoteSym)
+	if id == "" {
+		return PriceQuote{}, fmt.Errorf("coingecko oracle: unmapped asset %s", quoteSym)
+	}
+	req, err := http.NewRequest(http.MethodGet, o.endpoint, nil)
+	if err != nil {
+		return PriceQuote{}, err
+	}
+	values := url.Values{}
+	values.Set("ids", id)
+	values.Set("vs_currencies", baseSym)
+	values.Set("include_last_updated_at", "true")
+	req.URL.RawQuery = values.Encode()
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return PriceQuote{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return PriceQuote{}, fmt.Errorf("coingecko oracle: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	decoder := json.NewDecoder(resp.Body)
+	decoder.UseNumber()
+	var payload map[string]map[string]interface{}
+	if err := decoder.Decode(&payload); err != nil {
+		return PriceQuote{}, fmt.Errorf("coingecko oracle: decode: %w", err)
+	}
+	entry, ok := payload[id]
+	if !ok {
+		return PriceQuote{}, fmt.Errorf("coingecko oracle: quote missing for %s", quoteSym)
+	}
+	var priceStr string
+	// Attempt lookups for the requested base currency in different casings.
+	keys := []string{baseSym, strings.ToLower(baseSym), strings.ToUpper(baseSym)}
+	for _, key := range keys {
+		if raw, exists := entry[key]; exists {
+			switch v := raw.(type) {
+			case json.Number:
+				priceStr = v.String()
+			case string:
+				priceStr = v
+			case float64:
+				priceStr = strconv.FormatFloat(v, 'f', -1, 64)
+			default:
+				priceStr = fmt.Sprintf("%v", v)
+			}
+			break
+		}
+	}
+	priceStr = strings.TrimSpace(priceStr)
+	if priceStr == "" {
+		return PriceQuote{}, fmt.Errorf("coingecko oracle: empty price")
+	}
+	rat, ok := new(big.Rat).SetString(priceStr)
+	if !ok || rat.Sign() <= 0 {
+		return PriceQuote{}, fmt.Errorf("coingecko oracle: invalid rate %q", priceStr)
+	}
+	var ts time.Time
+	if rawTs, exists := entry["last_updated_at"]; exists {
+		switch v := rawTs.(type) {
+		case json.Number:
+			if parsed, err := v.Int64(); err == nil && parsed > 0 {
+				ts = time.Unix(parsed, 0)
+			}
+		case string:
+			if parsed, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64); err == nil && parsed > 0 {
+				ts = time.Unix(parsed, 0)
+			}
+		case float64:
+			if v > 0 {
+				ts = time.Unix(int64(v), 0)
+			}
+		}
+	}
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	return PriceQuote{Rate: rat, Timestamp: ts, Source: "coingecko"}, nil
+}
+
+func normaliseSymbol(symbol string) string {
+	return strings.ToUpper(strings.TrimSpace(symbol))
+}
+
+// ComputeMintAmount calculates the mint amount in wei using the provided fiat
+// amount (denominated in USD), oracle rate (USD per token) and token decimals.
+func ComputeMintAmount(fiatAmount string, rate *big.Rat, decimals uint8) (*big.Int, error) {
+	trimmedAmount := strings.TrimSpace(fiatAmount)
+	if trimmedAmount == "" {
+		return nil, fmt.Errorf("swap: fiat amount required")
+	}
+	fiat, ok := new(big.Rat).SetString(trimmedAmount)
+	if !ok {
+		return nil, fmt.Errorf("swap: invalid fiat amount %q", fiatAmount)
+	}
+	if fiat.Sign() <= 0 {
+		return nil, fmt.Errorf("swap: fiat amount must be positive")
+	}
+	if rate == nil || rate.Sign() <= 0 {
+		return nil, fmt.Errorf("swap: oracle rate must be positive")
+	}
+	tokens := new(big.Rat).Quo(fiat, rate)
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil)
+	tokens.Mul(tokens, new(big.Rat).SetInt(scale))
+	result := new(big.Int).Quo(tokens.Num(), tokens.Denom())
+	if result.Sign() < 0 {
+		return nil, fmt.Errorf("swap: computed mint amount negative")
+	}
+	return result, nil
+}
+
+// Config controls swap oracle behaviour and mint validation thresholds.
+type Config struct {
+	AllowedFiat        []string
+	MaxQuoteAgeSeconds int64
+	SlippageBps        uint64
+	OraclePriority     []string
+}
+
+// Normalise applies defaults and canonical casing to the configuration values.
+func (c Config) Normalise() Config {
+	cfg := Config{
+		AllowedFiat:        append([]string{}, c.AllowedFiat...),
+		MaxQuoteAgeSeconds: c.MaxQuoteAgeSeconds,
+		SlippageBps:        c.SlippageBps,
+		OraclePriority:     append([]string{}, c.OraclePriority...),
+	}
+	if len(cfg.AllowedFiat) == 0 {
+		cfg.AllowedFiat = []string{"USD"}
+	}
+	for i := range cfg.AllowedFiat {
+		cfg.AllowedFiat[i] = normaliseSymbol(cfg.AllowedFiat[i])
+	}
+	if cfg.MaxQuoteAgeSeconds <= 0 {
+		cfg.MaxQuoteAgeSeconds = 120
+	}
+	if cfg.SlippageBps == 0 {
+		cfg.SlippageBps = 50
+	}
+	if len(cfg.OraclePriority) == 0 {
+		cfg.OraclePriority = []string{"manual"}
+	}
+	return cfg
+}
+
+// IsFiatAllowed reports whether the provided fiat currency code is accepted.
+func (c Config) IsFiatAllowed(fiat string) bool {
+	needle := normaliseSymbol(fiat)
+	for _, cur := range c.AllowedFiat {
+		if cur == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// MaxQuoteAge returns the configured freshness window as a duration.
+func (c Config) MaxQuoteAge() time.Duration {
+	return time.Duration(c.MaxQuoteAgeSeconds) * time.Second
+}

--- a/native/swap/oracle_test.go
+++ b/native/swap/oracle_test.go
@@ -1,0 +1,120 @@
+package swap
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type oracleFunc func(base, quote string) (PriceQuote, error)
+
+func (f oracleFunc) GetRate(base, quote string) (PriceQuote, error) {
+	return f(base, quote)
+}
+
+func TestManualOracleProvidesQuotes(t *testing.T) {
+	manual := NewManualOracle()
+	now := time.Now().UTC()
+	if err := manual.SetDecimal("USD", "NHB", "0.75", now); err != nil {
+		t.Fatalf("set rate: %v", err)
+	}
+	quote, err := manual.GetRate("usd", "nhb")
+	if err != nil {
+		t.Fatalf("get rate: %v", err)
+	}
+	if quote.Rate == nil || quote.Rate.FloatString(2) != "0.75" {
+		t.Fatalf("unexpected rate: %v", quote.Rate)
+	}
+	if !quote.Timestamp.Equal(now) {
+		t.Fatalf("unexpected timestamp: %v", quote.Timestamp)
+	}
+}
+
+func TestOracleAggregatorStaleQuote(t *testing.T) {
+	manual := NewManualOracle()
+	agg := NewOracleAggregator([]string{"manual"}, time.Second)
+	agg.Register("manual", manual)
+	if err := manual.SetDecimal("USD", "ZNHB", "0.50", time.Now().Add(-2*time.Second)); err != nil {
+		t.Fatalf("set rate: %v", err)
+	}
+	if _, err := agg.GetRate("USD", "ZNHB"); err == nil {
+		t.Fatalf("expected error for stale quote")
+	}
+}
+
+func TestOracleAggregatorPriorityFallback(t *testing.T) {
+	manual := NewManualOracle()
+	agg := NewOracleAggregator([]string{"primary", "manual"}, 5*time.Minute)
+	agg.Register("primary", oracleFunc(func(string, string) (PriceQuote, error) {
+		return PriceQuote{}, fmt.Errorf("primary down")
+	}))
+	agg.Register("manual", manual)
+	if err := manual.SetDecimal("USD", "ZNHB", "1.25", time.Now()); err != nil {
+		t.Fatalf("set rate: %v", err)
+	}
+	quote, err := agg.GetRate("USD", "ZNHB")
+	if err != nil {
+		t.Fatalf("get rate: %v", err)
+	}
+	if quote.Source != "manual" {
+		t.Fatalf("expected manual source, got %s", quote.Source)
+	}
+}
+
+func TestNowPaymentsOracle(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("from"); got != "USD" {
+			t.Fatalf("expected from=USD, got %s", got)
+		}
+		if got := r.URL.Query().Get("to"); got != "ZNHB" {
+			t.Fatalf("expected to=ZNHB, got %s", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"rate": "0.42", "timestamp": time.Now().Unix()})
+	}))
+	defer server.Close()
+	oracle := NewNowPaymentsOracle(server.Client(), server.URL, "")
+	quote, err := oracle.GetRate("usd", "znhb")
+	if err != nil {
+		t.Fatalf("get rate: %v", err)
+	}
+	if quote.Rate == nil || quote.Rate.FloatString(2) != "0.42" {
+		t.Fatalf("unexpected rate: %v", quote.Rate)
+	}
+}
+
+func TestCoinGeckoOracle(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]map[string]interface{}{
+			"znhb": {
+				"usd":             0.91,
+				"last_updated_at": time.Now().Unix(),
+			},
+		})
+	}))
+	defer server.Close()
+	oracle := NewCoinGeckoOracle(server.Client(), server.URL, map[string]string{"ZNHB": "znhb"})
+	quote, err := oracle.GetRate("USD", "ZNHB")
+	if err != nil {
+		t.Fatalf("get rate: %v", err)
+	}
+	if quote.Rate == nil || quote.Rate.FloatString(2) != "0.91" {
+		t.Fatalf("unexpected rate: %v", quote.Rate)
+	}
+}
+
+func TestComputeMintAmount(t *testing.T) {
+	rate := big.NewRat(25, 1) // $25 per token
+	amount, err := ComputeMintAmount("100.00", rate, 18)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	expected := new(big.Int).Mul(big.NewInt(4), scale)
+	if amount.Cmp(expected) != 0 {
+		t.Fatalf("expected %s, got %s", expected, amount)
+	}
+}

--- a/native/swap/voucher.go
+++ b/native/swap/voucher.go
@@ -30,6 +30,18 @@ type VoucherV1 struct {
 	Expiry     int64
 }
 
+// VoucherSubmission bundles the payload supplied by the fiat gateway when
+// requesting a mint alongside auxiliary metadata captured for auditing.
+type VoucherSubmission struct {
+	Voucher      *VoucherV1
+	Signature    []byte
+	Provider     string
+	ProviderTxID string
+	Username     string
+	Address      string
+	USDAmount    string
+}
+
 type voucherJSON struct {
 	Domain     string `json:"domain"`
 	ChainID    uint64 `json:"chainId"`

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -241,6 +241,12 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handleMintWithSig(w, r, req)
 	case "swap_submitVoucher":
 		s.handleSwapSubmitVoucher(w, r, req)
+	case "swap_voucher_get":
+		s.handleSwapVoucherGet(w, r, req)
+	case "swap_voucher_list":
+		s.handleSwapVoucherList(w, r, req)
+	case "swap_voucher_export":
+		s.handleSwapVoucherExport(w, r, req)
 	case "stake_delegate":
 		s.handleStakeDelegate(w, r, req)
 	case "stake_undelegate":

--- a/rpc/loyalty_handlers_test.go
+++ b/rpc/loyalty_handlers_test.go
@@ -7,10 +7,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"nhbchain/core"
 	"nhbchain/crypto"
 	"nhbchain/native/loyalty"
+	swap "nhbchain/native/swap"
 	"nhbchain/storage"
 )
 
@@ -38,6 +40,12 @@ func newTestEnv(t *testing.T) *testEnv {
 	if err != nil {
 		t.Fatalf("new node: %v", err)
 	}
+	node.SetSwapConfig(swap.Config{AllowedFiat: []string{"USD"}, MaxQuoteAgeSeconds: 120, SlippageBps: 50, OraclePriority: []string{"manual"}})
+	manual := swap.NewManualOracle()
+	agg := swap.NewOracleAggregator([]string{"manual"}, 5*time.Minute)
+	agg.Register("manual", manual)
+	node.SetSwapOracle(agg)
+	node.SetSwapManualOracle(manual)
 	server := NewServer(node)
 	return &testEnv{server: server, node: node, token: token}
 }

--- a/rpc/swap_handlers.go
+++ b/rpc/swap_handlers.go
@@ -5,10 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"math/big"
 	"net/http"
 	"strings"
 
 	"nhbchain/core"
+	"nhbchain/crypto"
 	swap "nhbchain/native/swap"
 )
 
@@ -18,8 +20,13 @@ func (s *Server) handleSwapSubmitVoucher(w http.ResponseWriter, _ *http.Request,
 		return
 	}
 	var payload struct {
-		Voucher json.RawMessage `json:"voucher"`
-		Sig     string          `json:"sig"`
+		Voucher      json.RawMessage `json:"voucher"`
+		Sig          string          `json:"sig"`
+		Provider     string          `json:"provider"`
+		ProviderTxID string          `json:"providerTxId"`
+		Username     string          `json:"username,omitempty"`
+		Address      string          `json:"address,omitempty"`
+		USDAmount    string          `json:"usdAmount,omitempty"`
 	}
 	if err := json.Unmarshal(req.Params[0], &payload); err != nil {
 		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid payload", err.Error())
@@ -45,19 +52,32 @@ func (s *Server) handleSwapSubmitVoucher(w http.ResponseWriter, _ *http.Request,
 		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid signature", err.Error())
 		return
 	}
-	txHash, minted, err := s.node.SwapSubmitVoucher(&voucher, signature)
+	submission := &swap.VoucherSubmission{
+		Voucher:      &voucher,
+		Signature:    signature,
+		Provider:     strings.TrimSpace(payload.Provider),
+		ProviderTxID: strings.TrimSpace(payload.ProviderTxID),
+		Username:     strings.TrimSpace(payload.Username),
+		Address:      strings.TrimSpace(payload.Address),
+		USDAmount:    strings.TrimSpace(payload.USDAmount),
+	}
+	txHash, minted, err := s.node.SwapSubmitVoucher(submission)
 	if err != nil {
 		switch {
 		case errors.Is(err, core.ErrSwapInvalidSigner):
 			writeError(w, http.StatusUnauthorized, req.ID, codeUnauthorized, err.Error(), nil)
-		case errors.Is(err, core.ErrSwapNonceUsed):
+		case errors.Is(err, core.ErrSwapNonceUsed), errors.Is(err, core.ErrSwapDuplicateProviderTx):
 			writeError(w, http.StatusConflict, req.ID, codeDuplicateTx, err.Error(), voucher.OrderID)
 		case errors.Is(err, core.ErrSwapInvalidDomain),
 			errors.Is(err, core.ErrSwapInvalidChainID),
 			errors.Is(err, core.ErrSwapExpired),
 			errors.Is(err, core.ErrSwapInvalidToken),
 			errors.Is(err, core.ErrSwapInvalidSignature),
-			errors.Is(err, core.ErrSwapMintPaused):
+			errors.Is(err, core.ErrSwapMintPaused),
+			errors.Is(err, core.ErrSwapUnsupportedFiat),
+			errors.Is(err, core.ErrSwapOracleUnavailable),
+			errors.Is(err, core.ErrSwapQuoteStale),
+			errors.Is(err, core.ErrSwapSlippageExceeded):
 			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
 		default:
 			writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "swap voucher failed", err.Error())
@@ -65,4 +85,143 @@ func (s *Server) handleSwapSubmitVoucher(w http.ResponseWriter, _ *http.Request,
 		return
 	}
 	writeResult(w, req.ID, map[string]interface{}{"txHash": txHash, "minted": minted})
+}
+
+func (s *Server) handleSwapVoucherGet(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected providerTxId", nil)
+		return
+	}
+	var providerTxID string
+	if err := json.Unmarshal(req.Params[0], &providerTxID); err != nil {
+		var wrapper struct {
+			ProviderTxID string `json:"providerTxId"`
+		}
+		if err := json.Unmarshal(req.Params[0], &wrapper); err != nil {
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid providerTxId", nil)
+			return
+		}
+		providerTxID = wrapper.ProviderTxID
+	}
+	providerTxID = strings.TrimSpace(providerTxID)
+	if providerTxID == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "providerTxId required", nil)
+		return
+	}
+	record, ok, err := s.node.SwapGetVoucher(providerTxID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "failed to load voucher", err.Error())
+		return
+	}
+	if !ok {
+		writeError(w, http.StatusNotFound, req.ID, codeInvalidParams, "voucher not found", providerTxID)
+		return
+	}
+	writeResult(w, req.ID, formatVoucherRecord(record))
+}
+
+func (s *Server) handleSwapVoucherList(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) < 2 || len(req.Params) > 4 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected startTs, endTs, [cursor], [limit]", nil)
+		return
+	}
+	var startTs, endTs int64
+	if err := json.Unmarshal(req.Params[0], &startTs); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid startTs", err.Error())
+		return
+	}
+	if err := json.Unmarshal(req.Params[1], &endTs); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid endTs", err.Error())
+		return
+	}
+	cursor := ""
+	if len(req.Params) >= 3 {
+		if err := json.Unmarshal(req.Params[2], &cursor); err != nil {
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid cursor", err.Error())
+			return
+		}
+		cursor = strings.TrimSpace(cursor)
+	}
+	limit := 50
+	if len(req.Params) == 4 {
+		var limit64 int64
+		if err := json.Unmarshal(req.Params[3], &limit64); err != nil {
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid limit", err.Error())
+			return
+		}
+		if limit64 > 0 {
+			limit = int(limit64)
+		}
+	}
+	records, nextCursor, err := s.node.SwapListVouchers(startTs, endTs, cursor, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "failed to list vouchers", err.Error())
+		return
+	}
+	formatted := make([]map[string]interface{}, 0, len(records))
+	for _, record := range records {
+		formatted = append(formatted, formatVoucherRecord(record))
+	}
+	writeResult(w, req.ID, map[string]interface{}{"vouchers": formatted, "nextCursor": nextCursor})
+}
+
+func (s *Server) handleSwapVoucherExport(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 2 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected startTs and endTs", nil)
+		return
+	}
+	var startTs, endTs int64
+	if err := json.Unmarshal(req.Params[0], &startTs); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid startTs", err.Error())
+		return
+	}
+	if err := json.Unmarshal(req.Params[1], &endTs); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid endTs", err.Error())
+		return
+	}
+	csvBase64, count, total, err := s.node.SwapExportVouchers(startTs, endTs)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "failed to export vouchers", err.Error())
+		return
+	}
+	result := map[string]interface{}{
+		"csvBase64":    csvBase64,
+		"count":        count,
+		"totalMintWei": total.String(),
+	}
+	writeResult(w, req.ID, result)
+}
+
+func formatVoucherRecord(record *swap.VoucherRecord) map[string]interface{} {
+	if record == nil {
+		return nil
+	}
+	response := map[string]interface{}{
+		"provider":      record.Provider,
+		"providerTxId":  record.ProviderTxID,
+		"fiatCurrency":  record.FiatCurrency,
+		"fiatAmount":    record.FiatAmount,
+		"usd":           record.USD,
+		"rate":          record.Rate,
+		"token":         record.Token,
+		"mintAmountWei": mintAmountToString(record.MintAmountWei),
+		"username":      record.Username,
+		"address":       record.Address,
+		"quoteTs":       record.QuoteTimestamp,
+		"source":        record.OracleSource,
+		"minterSig":     record.MinterSignature,
+		"status":        record.Status,
+		"createdAt":     record.CreatedAt,
+	}
+	if record.Recipient != ([20]byte{}) {
+		response["recipient"] = crypto.NewAddress(crypto.NHBPrefix, record.Recipient[:]).String()
+	}
+	return response
+}
+
+func mintAmountToString(amount *big.Int) string {
+	if amount == nil {
+		return "0"
+	}
+	return amount.String()
 }

--- a/rpc/swap_handlers_test.go
+++ b/rpc/swap_handlers_test.go
@@ -1,10 +1,12 @@
 package rpc
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"math/big"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,18 +40,33 @@ func configureSwapToken(t *testing.T, node *core.Node, minterAddr [20]byte) {
 	}
 }
 
-func buildSwapVoucher(t *testing.T, chainID uint64, recipient [20]byte) swap.VoucherV1 {
+func (env *testEnv) setManualRate(t *testing.T, rate string, ts time.Time) {
 	t.Helper()
+	if err := env.node.SetSwapManualQuote("USD", "ZNHB", rate, ts); err != nil {
+		t.Fatalf("set manual rate: %v", err)
+	}
+}
+
+func buildSwapVoucher(t *testing.T, chainID uint64, recipient [20]byte, rate string, orderID string) swap.VoucherV1 {
+	t.Helper()
+	rat, ok := new(big.Rat).SetString(rate)
+	if !ok {
+		t.Fatalf("invalid rate %s", rate)
+	}
+	amount, err := swap.ComputeMintAmount("100.00", rat, 18)
+	if err != nil {
+		t.Fatalf("compute amount: %v", err)
+	}
 	return swap.VoucherV1{
 		Domain:     swap.VoucherDomainV1,
 		ChainID:    chainID,
 		Token:      "ZNHB",
 		Recipient:  recipient,
-		Amount:     big.NewInt(1_000_000_000_000_000_000),
+		Amount:     amount,
 		Fiat:       "USD",
 		FiatAmount: "100.00",
-		Rate:       "0.10",
-		OrderID:    "ORDER-123",
+		Rate:       rate,
+		OrderID:    orderID,
 		Nonce:      []byte("nonce-1"),
 		Expiry:     time.Now().Add(time.Hour).Unix(),
 	}
@@ -76,13 +93,16 @@ func TestSwapSubmitVoucherInvalidDomain(t *testing.T) {
 	var recipient [20]byte
 	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
 
-	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient)
+	env.setManualRate(t, "0.10", time.Now())
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient, "0.10", "ORDER-123")
 	voucher.Domain = "BAD_DOMAIN"
 	sig := signSwapVoucher(t, minterKey, voucher)
 
 	payload := map[string]interface{}{
-		"voucher": voucher,
-		"sig":     "0x" + hex.EncodeToString(sig),
+		"voucher":      voucher,
+		"sig":          "0x" + hex.EncodeToString(sig),
+		"provider":     "nowpayments",
+		"providerTxId": "ORDER-123",
 	}
 	req := &RPCRequest{ID: 1, Params: []json.RawMessage{marshalParam(t, payload)}}
 	recorder := httptest.NewRecorder()
@@ -107,12 +127,15 @@ func TestSwapSubmitVoucherInvalidChain(t *testing.T) {
 	var recipient [20]byte
 	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
 
-	voucher := buildSwapVoucher(t, env.node.Chain().ChainID()+1, recipient)
+	env.setManualRate(t, "0.10", time.Now())
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID()+1, recipient, "0.10", "ORDER-123")
 	sig := signSwapVoucher(t, minterKey, voucher)
 
 	payload := map[string]interface{}{
-		"voucher": voucher,
-		"sig":     "0x" + hex.EncodeToString(sig),
+		"voucher":      voucher,
+		"sig":          "0x" + hex.EncodeToString(sig),
+		"provider":     "nowpayments",
+		"providerTxId": "ORDER-123",
 	}
 	req := &RPCRequest{ID: 2, Params: []json.RawMessage{marshalParam(t, payload)}}
 	recorder := httptest.NewRecorder()
@@ -137,13 +160,16 @@ func TestSwapSubmitVoucherExpired(t *testing.T) {
 	var recipient [20]byte
 	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
 
-	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient)
+	env.setManualRate(t, "0.10", time.Now())
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient, "0.10", "ORDER-123")
 	voucher.Expiry = time.Now().Add(-time.Minute).Unix()
 	sig := signSwapVoucher(t, minterKey, voucher)
 
 	payload := map[string]interface{}{
-		"voucher": voucher,
-		"sig":     "0x" + hex.EncodeToString(sig),
+		"voucher":      voucher,
+		"sig":          "0x" + hex.EncodeToString(sig),
+		"provider":     "nowpayments",
+		"providerTxId": "ORDER-123",
 	}
 	req := &RPCRequest{ID: 3, Params: []json.RawMessage{marshalParam(t, payload)}}
 	recorder := httptest.NewRecorder()
@@ -168,13 +194,16 @@ func TestSwapSubmitVoucherInvalidToken(t *testing.T) {
 	var recipient [20]byte
 	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
 
-	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient)
+	env.setManualRate(t, "0.10", time.Now())
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient, "0.10", "ORDER-123")
 	voucher.Token = "NHB"
 	sig := signSwapVoucher(t, minterKey, voucher)
 
 	payload := map[string]interface{}{
-		"voucher": voucher,
-		"sig":     "0x" + hex.EncodeToString(sig),
+		"voucher":      voucher,
+		"sig":          "0x" + hex.EncodeToString(sig),
+		"provider":     "nowpayments",
+		"providerTxId": "ORDER-123",
 	}
 	req := &RPCRequest{ID: 4, Params: []json.RawMessage{marshalParam(t, payload)}}
 	recorder := httptest.NewRecorder()
@@ -200,12 +229,15 @@ func TestSwapSubmitVoucherInvalidSigner(t *testing.T) {
 	var recipient [20]byte
 	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
 
-	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient)
+	env.setManualRate(t, "0.10", time.Now())
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient, "0.10", "ORDER-123")
 	sig := signSwapVoucher(t, rogueKey, voucher)
 
 	payload := map[string]interface{}{
-		"voucher": voucher,
-		"sig":     "0x" + hex.EncodeToString(sig),
+		"voucher":      voucher,
+		"sig":          "0x" + hex.EncodeToString(sig),
+		"provider":     "nowpayments",
+		"providerTxId": "ORDER-123",
 	}
 	req := &RPCRequest{ID: 5, Params: []json.RawMessage{marshalParam(t, payload)}}
 	recorder := httptest.NewRecorder()
@@ -230,12 +262,15 @@ func TestSwapSubmitVoucherSuccessAndReplay(t *testing.T) {
 	var recipient [20]byte
 	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
 
+	env.setManualRate(t, "0.10", time.Now())
 	chainID := env.node.Chain().ChainID()
-	voucher := buildSwapVoucher(t, chainID, recipient)
+	voucher := buildSwapVoucher(t, chainID, recipient, "0.10", "ORDER-123")
 	sig := signSwapVoucher(t, minterKey, voucher)
 	payload := map[string]interface{}{
-		"voucher": voucher,
-		"sig":     "0x" + hex.EncodeToString(sig),
+		"voucher":      voucher,
+		"sig":          "0x" + hex.EncodeToString(sig),
+		"provider":     "nowpayments",
+		"providerTxId": "ORDER-123",
 	}
 	req := &RPCRequest{ID: 6, Params: []json.RawMessage{marshalParam(t, payload)}}
 	recorder := httptest.NewRecorder()
@@ -290,5 +325,198 @@ func TestSwapSubmitVoucherSuccessAndReplay(t *testing.T) {
 	}
 	if replayErr.Code != codeDuplicateTx {
 		t.Fatalf("expected duplicate code, got %d", replayErr.Code)
+	}
+}
+
+func TestSwapSubmitVoucherStaleOracle(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	env.setManualRate(t, "0.10", time.Now().Add(-time.Hour))
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient, "0.10", "ORDER-STALE")
+	sig := signSwapVoucher(t, minterKey, voucher)
+
+	payload := map[string]interface{}{
+		"voucher":      voucher,
+		"sig":          "0x" + hex.EncodeToString(sig),
+		"provider":     "nowpayments",
+		"providerTxId": "ORDER-STALE",
+	}
+	req := &RPCRequest{ID: 7, Params: []json.RawMessage{marshalParam(t, payload)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorder, env.newRequest(), req)
+	_, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr == nil || rpcErr.Code != codeInvalidParams {
+		t.Fatalf("expected invalid params due to stale oracle, got %+v", rpcErr)
+	}
+}
+
+func TestSwapSubmitVoucherSlippageExceeded(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	env.setManualRate(t, "0.10", time.Now())
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient, "0.10", "ORDER-SLIP")
+	voucher.Amount = new(big.Int).Mul(voucher.Amount, big.NewInt(2))
+	sig := signSwapVoucher(t, minterKey, voucher)
+
+	payload := map[string]interface{}{
+		"voucher":      voucher,
+		"sig":          "0x" + hex.EncodeToString(sig),
+		"provider":     "nowpayments",
+		"providerTxId": "ORDER-SLIP",
+	}
+	req := &RPCRequest{ID: 8, Params: []json.RawMessage{marshalParam(t, payload)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorder, env.newRequest(), req)
+	_, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr == nil || rpcErr.Code != codeInvalidParams {
+		t.Fatalf("expected invalid params due to slippage, got %+v", rpcErr)
+	}
+}
+
+func TestSwapSubmitVoucherDuplicateProvider(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	env.setManualRate(t, "0.10", time.Now())
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient, "0.10", "ORDER-A")
+	sig := signSwapVoucher(t, minterKey, voucher)
+	payload := map[string]interface{}{
+		"voucher":      voucher,
+		"sig":          "0x" + hex.EncodeToString(sig),
+		"provider":     "nowpayments",
+		"providerTxId": "PROVIDER-1",
+	}
+	req := &RPCRequest{ID: 9, Params: []json.RawMessage{marshalParam(t, payload)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorder, env.newRequest(), req)
+	result, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr != nil {
+		t.Fatalf("unexpected error: %+v", rpcErr)
+	}
+	if len(result) == 0 {
+		t.Fatalf("expected result")
+	}
+
+	// Second voucher with different order but same providerTxId should be rejected.
+	voucherB := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient, "0.10", "ORDER-B")
+	sigB := signSwapVoucher(t, minterKey, voucherB)
+	payloadB := map[string]interface{}{
+		"voucher":      voucherB,
+		"sig":          "0x" + hex.EncodeToString(sigB),
+		"provider":     "nowpayments",
+		"providerTxId": "PROVIDER-1",
+	}
+	reqB := &RPCRequest{ID: 10, Params: []json.RawMessage{marshalParam(t, payloadB)}}
+	recorderB := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorderB, env.newRequest(), reqB)
+	_, rpcErr = decodeRPCResponse(t, recorderB)
+	if rpcErr == nil || rpcErr.Code != codeDuplicateTx {
+		t.Fatalf("expected duplicate provider error, got %+v", rpcErr)
+	}
+}
+
+func TestSwapVoucherExportAndList(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	env.setManualRate(t, "0.10", time.Now())
+	voucher := buildSwapVoucher(t, env.node.Chain().ChainID(), recipient, "0.10", "ORDER-EXPORT")
+	sig := signSwapVoucher(t, minterKey, voucher)
+	payload := map[string]interface{}{
+		"voucher":      voucher,
+		"sig":          "0x" + hex.EncodeToString(sig),
+		"provider":     "nowpayments",
+		"providerTxId": "PROVIDER-EXP",
+	}
+	req := &RPCRequest{ID: 11, Params: []json.RawMessage{marshalParam(t, payload)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapSubmitVoucher(recorder, env.newRequest(), req)
+	if _, rpcErr := decodeRPCResponse(t, recorder); rpcErr != nil {
+		t.Fatalf("unexpected error: %+v", rpcErr)
+	}
+
+	start := time.Now().Add(-time.Hour).Unix()
+	end := time.Now().Add(time.Hour).Unix()
+
+	// Export
+	exportReq := &RPCRequest{ID: 12, Params: []json.RawMessage{marshalParam(t, start), marshalParam(t, end)}}
+	exportRec := httptest.NewRecorder()
+	env.server.handleSwapVoucherExport(exportRec, env.newRequest(), exportReq)
+	exportResult, rpcErr := decodeRPCResponse(t, exportRec)
+	if rpcErr != nil {
+		t.Fatalf("export error: %+v", rpcErr)
+	}
+	var exportPayload struct {
+		CSVBase64    string `json:"csvBase64"`
+		Count        int    `json:"count"`
+		TotalMintWei string `json:"totalMintWei"`
+	}
+	if err := json.Unmarshal(exportResult, &exportPayload); err != nil {
+		t.Fatalf("decode export: %v", err)
+	}
+	if exportPayload.Count != 1 {
+		t.Fatalf("expected count 1, got %d", exportPayload.Count)
+	}
+	if exportPayload.TotalMintWei != voucher.Amount.String() {
+		t.Fatalf("unexpected total %s", exportPayload.TotalMintWei)
+	}
+	data, err := base64.StdEncoding.DecodeString(exportPayload.CSVBase64)
+	if err != nil {
+		t.Fatalf("decode csv: %v", err)
+	}
+	if !strings.Contains(string(data), "PROVIDER-EXP") {
+		t.Fatalf("csv missing provider: %s", data)
+	}
+
+	// List
+	listReq := &RPCRequest{ID: 13, Params: []json.RawMessage{marshalParam(t, start), marshalParam(t, end)}}
+	listRec := httptest.NewRecorder()
+	env.server.handleSwapVoucherList(listRec, env.newRequest(), listReq)
+	listResult, rpcErr := decodeRPCResponse(t, listRec)
+	if rpcErr != nil {
+		t.Fatalf("list error: %+v", rpcErr)
+	}
+	var listPayload struct {
+		Vouchers   []map[string]interface{} `json:"vouchers"`
+		NextCursor string                   `json:"nextCursor"`
+	}
+	if err := json.Unmarshal(listResult, &listPayload); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listPayload.Vouchers) != 1 {
+		t.Fatalf("expected 1 voucher, got %d", len(listPayload.Vouchers))
+	}
+	if listPayload.Vouchers[0]["providerTxId"].(string) != "PROVIDER-EXP" {
+		t.Fatalf("unexpected voucher record: %+v", listPayload.Vouchers[0])
 	}
 }


### PR DESCRIPTION
## Summary
- ensure ledger persists timestamps as uint64 while exposing int64 API conversion helpers
- harden CoinGecko oracle parsing and surface stale-quote errors as user input issues
- update swap tests and RPC handling to reflect deterministic ledger and oracle behaviour

## Testing
- go test ./native/swap
- go test ./rpc

------
https://chatgpt.com/codex/tasks/task_e_68d4c8e901fc832db4158c0b60ebf7ec