### PR TITLE
Add swap risk controls and admin tooling

### DIFF
--- a/cmd/swap-audit/main.go
+++ b/cmd/swap-audit/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"nhbchain/config"
+)
+
+type auditReport struct {
+	AllowedFiat []string `json:"allowedFiat"`
+	Risk        struct {
+		PerAddressDailyCapWei   string `json:"perAddressDailyCapWei"`
+		PerAddressMonthlyCapWei string `json:"perAddressMonthlyCapWei"`
+		PerTxMinWei             string `json:"perTxMinWei"`
+		PerTxMaxWei             string `json:"perTxMaxWei"`
+		VelocityWindowSeconds   uint64 `json:"velocityWindowSeconds"`
+		VelocityMaxMints        uint64 `json:"velocityMaxMints"`
+		SanctionsCheckEnabled   bool   `json:"sanctionsCheckEnabled"`
+	} `json:"risk"`
+	Providers []string `json:"providers"`
+}
+
+func main() {
+	configPath := flag.String("config", "./config.toml", "Path to node configuration file")
+	flag.Parse()
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	swapCfg := cfg.SwapSettings()
+	params, err := swapCfg.Risk.Parameters()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse risk parameters: %v\n", err)
+		os.Exit(1)
+	}
+
+	report := auditReport{AllowedFiat: swapCfg.AllowedFiat, Providers: swapCfg.Providers.AllowList()}
+	report.Risk.PerAddressDailyCapWei = swapCfg.Risk.PerAddressDailyCapWei
+	report.Risk.PerAddressMonthlyCapWei = swapCfg.Risk.PerAddressMonthlyCapWei
+	report.Risk.PerTxMinWei = swapCfg.Risk.PerTxMinWei
+	report.Risk.PerTxMaxWei = swapCfg.Risk.PerTxMaxWei
+	report.Risk.VelocityWindowSeconds = params.VelocityWindowSeconds
+	report.Risk.VelocityMaxMints = params.VelocityMaxMints
+	report.Risk.SanctionsCheckEnabled = params.SanctionsCheckEnabled
+
+	output, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to encode report: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(output))
+}

--- a/config.toml
+++ b/config.toml
@@ -60,3 +60,15 @@ AllowedFiat = ["USD","EUR","GBP"]
 MaxQuoteAgeSeconds = 120
 SlippageBps = 50
 OraclePriority = ["nowpayments","coingecko","manual"]
+
+[swap.risk]
+PerAddressDailyCapWei = "10000e18"
+PerAddressMonthlyCapWei = "300000e18"
+PerTxMinWei = "1e18"
+PerTxMaxWei = "50000e18"
+VelocityWindowSeconds = 600
+VelocityMaxMints = 5
+SanctionsCheckEnabled = true
+
+[swap.providers]
+Allow = ["nowpayments"]

--- a/core/events/swap.go
+++ b/core/events/swap.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"math/big"
+	"strconv"
 	"strings"
 
 	"nhbchain/core/types"
@@ -11,6 +12,12 @@ import (
 const (
 	// TypeSwapMinted is emitted whenever a swap voucher mints ZNHB on-chain.
 	TypeSwapMinted = "swap.minted"
+	// TypeSwapAlertLimitHit indicates that a voucher submission triggered a configured limit.
+	TypeSwapAlertLimitHit = "swap.alert.limit_hit"
+	// TypeSwapAlertSanction indicates that a voucher recipient failed the sanctions hook.
+	TypeSwapAlertSanction = "swap.alert.sanction"
+	// TypeSwapAlertVelocity indicates that a voucher breached the mint velocity guardrail.
+	TypeSwapAlertVelocity = "swap.alert.velocity"
 )
 
 type SwapMinted struct {
@@ -44,4 +51,92 @@ func (e SwapMinted) Event() *types.Event {
 			"rate":       strings.TrimSpace(e.Rate),
 		},
 	}
+}
+
+// SwapLimitAlert captures metadata describing a limit violation.
+type SwapLimitAlert struct {
+	Address      [20]byte
+	Provider     string
+	ProviderTxID string
+	Limit        string
+	Amount       *big.Int
+	LimitValue   *big.Int
+	CurrentValue *big.Int
+}
+
+// EventType returns the canonical event type string.
+func (SwapLimitAlert) EventType() string { return TypeSwapAlertLimitHit }
+
+// Event renders the event payload for downstream consumers.
+func (a SwapLimitAlert) Event() *types.Event {
+	attrs := map[string]string{
+		"provider":     strings.TrimSpace(a.Provider),
+		"providerTxId": strings.TrimSpace(a.ProviderTxID),
+		"limit":        strings.TrimSpace(a.Limit),
+	}
+	if a.Address != ([20]byte{}) {
+		attrs["address"] = crypto.NewAddress(crypto.NHBPrefix, a.Address[:]).String()
+	}
+	amount := big.NewInt(0)
+	if a.Amount != nil {
+		amount = new(big.Int).Set(a.Amount)
+	}
+	attrs["amount"] = amount.String()
+	if a.LimitValue != nil {
+		attrs["limitValue"] = new(big.Int).Set(a.LimitValue).String()
+	}
+	if a.CurrentValue != nil {
+		attrs["currentValue"] = new(big.Int).Set(a.CurrentValue).String()
+	}
+	return &types.Event{Type: TypeSwapAlertLimitHit, Attributes: attrs}
+}
+
+// SwapSanctionAlert indicates a sanctions failure for a voucher recipient.
+type SwapSanctionAlert struct {
+	Address      [20]byte
+	Provider     string
+	ProviderTxID string
+}
+
+// EventType returns the canonical event type string.
+func (SwapSanctionAlert) EventType() string { return TypeSwapAlertSanction }
+
+// Event renders the sanction alert payload.
+func (a SwapSanctionAlert) Event() *types.Event {
+	attrs := map[string]string{
+		"provider":     strings.TrimSpace(a.Provider),
+		"providerTxId": strings.TrimSpace(a.ProviderTxID),
+	}
+	if a.Address != ([20]byte{}) {
+		attrs["address"] = crypto.NewAddress(crypto.NHBPrefix, a.Address[:]).String()
+	}
+	return &types.Event{Type: TypeSwapAlertSanction, Attributes: attrs}
+}
+
+// SwapVelocityAlert records a velocity guardrail violation.
+type SwapVelocityAlert struct {
+	Address       [20]byte
+	Provider      string
+	ProviderTxID  string
+	WindowSeconds uint64
+	ObservedCount int
+	AllowedMints  uint64
+}
+
+// EventType returns the canonical event type string.
+func (SwapVelocityAlert) EventType() string { return TypeSwapAlertVelocity }
+
+// Event renders the velocity alert payload.
+func (a SwapVelocityAlert) Event() *types.Event {
+	attrs := map[string]string{
+		"provider":      strings.TrimSpace(a.Provider),
+		"providerTxId":  strings.TrimSpace(a.ProviderTxID),
+		"windowSeconds": strconv.FormatUint(a.WindowSeconds, 10),
+		"allowedMints":  strconv.FormatUint(a.AllowedMints, 10),
+		"observedCount": strconv.Itoa(a.ObservedCount),
+	}
+	if a.Address != ([20]byte{}) {
+		attrs["address"] = crypto.NewAddress(crypto.NHBPrefix, a.Address[:]).String()
+	}
+	return &types.Event{Type: TypeSwapAlertVelocity, Attributes: attrs}
 }

--- a/core/swap.go
+++ b/core/swap.go
@@ -3,10 +3,10 @@ package core
 import "errors"
 
 var (
-	// ErrSwapInvalidDomain indicates the voucher domain does not match the expected identifier.
-	ErrSwapInvalidDomain = errors.New("swap: invalid domain")
-	// ErrSwapInvalidChainID indicates the voucher targets a different chain.
-	ErrSwapInvalidChainID = errors.New("swap: invalid chain id")
+        // ErrSwapInvalidDomain indicates the voucher domain does not match the expected identifier.
+        ErrSwapInvalidDomain = errors.New("swap: invalid domain")
+        // ErrSwapInvalidChainID indicates the voucher targets a different chain.
+        ErrSwapInvalidChainID = errors.New("swap: invalid chain id")
 	// ErrSwapExpired indicates the voucher expiry timestamp has elapsed.
 	ErrSwapExpired = errors.New("swap: voucher expired")
 	// ErrSwapInvalidToken indicates the voucher requested an unsupported token.
@@ -26,7 +26,27 @@ var (
 	// ErrSwapQuoteStale indicates the oracle quote exceeded the configured freshness window.
 	ErrSwapQuoteStale = errors.New("swap: oracle quote stale")
 	// ErrSwapSlippageExceeded indicates the submitted mint amount deviates beyond the allowed slippage threshold.
-	ErrSwapSlippageExceeded = errors.New("swap: slippage exceeds maximum")
-	// ErrSwapDuplicateProviderTx indicates the provider transaction identifier has already been recorded.
-	ErrSwapDuplicateProviderTx = errors.New("swap: provider transaction already processed")
+        ErrSwapSlippageExceeded = errors.New("swap: slippage exceeds maximum")
+        // ErrSwapDuplicateProviderTx indicates the provider transaction identifier has already been recorded.
+        ErrSwapDuplicateProviderTx = errors.New("swap: provider transaction already processed")
+        // ErrSwapProviderNotAllowed indicates the mint originated from a non-whitelisted provider.
+        ErrSwapProviderNotAllowed = errors.New("swap: provider not allowed")
+        // ErrSwapAmountBelowMinimum indicates the mint fell below the configured minimum threshold.
+        ErrSwapAmountBelowMinimum = errors.New("swap: amount below minimum")
+        // ErrSwapAmountAboveMaximum indicates the mint exceeded the configured per-transaction ceiling.
+        ErrSwapAmountAboveMaximum = errors.New("swap: amount exceeds maximum")
+        // ErrSwapDailyCapExceeded indicates the address exhausted its daily mint allowance.
+        ErrSwapDailyCapExceeded = errors.New("swap: daily limit exceeded")
+        // ErrSwapMonthlyCapExceeded indicates the address exhausted its monthly mint allowance.
+        ErrSwapMonthlyCapExceeded = errors.New("swap: monthly limit exceeded")
+        // ErrSwapVelocityExceeded indicates the mint frequency surpassed the configured burst threshold.
+        ErrSwapVelocityExceeded = errors.New("swap: velocity limit exceeded")
+        // ErrSwapSanctioned indicates the sanctions hook rejected the address.
+        ErrSwapSanctioned = errors.New("swap: address failed sanctions check")
+        // ErrSwapVoucherNotMinted indicates the voucher is not in a reversible state.
+        ErrSwapVoucherNotMinted = errors.New("swap: voucher not in minted state")
+        // ErrSwapVoucherAlreadyReversed indicates the voucher reversal has already been processed.
+        ErrSwapVoucherAlreadyReversed = errors.New("swap: voucher already reversed")
+        // ErrSwapReversalInsufficientBalance indicates the treasury or custody account cannot fund the reversal sink.
+        ErrSwapReversalInsufficientBalance = errors.New("swap: insufficient balance to reverse voucher")
 )

--- a/docs/api.md
+++ b/docs/api.md
@@ -145,6 +145,87 @@ Close voting, tally results, and update status.
 }
 ```
 
+# Swap Admin RPC
+
+## swap_limits
+
+Return usage buckets, remaining room, and velocity observations for the supplied address. Requires the admin bearer token.
+
+**Request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "swap_limits",
+  "params": ["nhb1customer000000000000000000000000000"]
+}
+```
+
+**Response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "address": "nhb1customer000000000000000000000000000",
+    "day": {"bucket": "2024-04-01", "mintedWei": "1000000000000000000"},
+    "dayRemainingWei": "9000000000000000000",
+    "month": {"bucket": "2024-04", "mintedWei": "1500000000000000000"},
+    "monthRemainingWei": "98500000000000000000",
+    "velocity": {"windowSeconds": 600, "maxMints": 5, "observed": 2, "remaining": 3}
+  }
+}
+```
+
+## swap_provider_status
+
+Report the configured provider allow list and the timestamp of the last successful oracle health check.
+
+**Request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "swap_provider_status",
+  "params": []
+}
+```
+
+**Response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "allow": ["nowpayments"],
+    "lastOracleHealthCheck": 0
+  }
+}
+```
+
+## swap_voucher_reverse
+
+Reverse a minted voucher and transfer funds from the custodial account to the refund sink.
+
+**Request**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "method": "swap_voucher_reverse",
+  "params": ["order-12345"]
+}
+```
+
+**Response**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "result": {"ok": true}
+}
+```
+
 **Response**
 ```json
 {

--- a/docs/swap/admin.md
+++ b/docs/swap/admin.md
@@ -1,0 +1,92 @@
+# Swap Mint Admin Runbook
+
+This guide is for operations, treasury, and compliance staff managing the SWAP-4 mint pipeline. It covers reversal policy, admin-only RPCs, and day-to-day responsibilities.
+
+## Responsibilities
+
+* **Operations** – Monitor `swap.alert.*` events, run `swap_limits` for escalations, and coordinate with PSPs when limits trip.
+* **Treasury** – Maintain balances in the refund sink address to cover customer clawbacks and reconcile the `swap.alert.limit_hit` stream daily.
+* **Compliance** – Periodically review sanctions hook integrations and ensure the provider allow list matches the approved PSP roster.
+
+## Reversal Policy
+
+Reversals are an emergency tool for clawing back mistaken mints.
+
+* Only vouchers in `minted` status can be reversed.
+* The recipient’s custodial balance must cover the mint amount; otherwise the request fails.
+* Reversals transfer funds from the recipient to the configured refund sink. No burn is performed—funds stay on-chain for auditors.
+* Reversal attempts are idempotent. A second call returns `{ "ok": true }` if the voucher is already reversed.
+
+Document the customer ticket, PSP communication, and reason for reversal in the compliance system before executing the command.
+
+## Admin RPC Endpoints
+
+All admin endpoints require the bearer token (`NHB_RPC_TOKEN`).
+
+### `swap_limits`
+
+Retrieve counters and remaining room for a customer address.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "swap_limits",
+  "params": ["nhb1customer000000000000000000000000000"]
+}
+```
+
+Response fields:
+
+* `day` and `month` – UTC buckets with minted totals.
+* `dayRemainingWei` / `monthRemainingWei` – Remaining room when caps are enabled.
+* `velocity` – Observed mints inside the configured window and remaining allowance.
+
+### `swap_provider_status`
+
+Reports the provider allow list and the timestamp of the last successful oracle health check.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "swap_provider_status",
+  "params": []
+}
+```
+
+Use this endpoint in dashboards to confirm that PSP integrations remain enabled.
+
+### `swap_voucher_reverse`
+
+Reverse a voucher by provider transaction identifier.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "swap_voucher_reverse",
+  "params": ["order-12345"]
+}
+```
+
+Checklist before executing:
+
+1. Confirm the fiat transaction has been refunded or voided with the PSP.
+2. Verify the customer’s on-chain balance covers the mint.
+3. Ensure the refund sink wallet is controlled by treasury.
+4. Run the command and record the RPC response, event hash, and the internal ticket ID.
+
+If the command returns an error, inspect the JSON error message for guidance:
+
+* `daily limit exceeded` – the voucher was already processed under a new identifier.
+* `insufficient balance` – the custodial account lacks funds; coordinate with treasury.
+* `voucher not found` – confirm the `providerTxId` matches the PSP record exactly.
+
+## Incident Response
+
+* Spike in `swap.alert.velocity` – confirm PSP behaviour, temporarily raise `VelocityMaxMints` if needed, and log the change.
+* Sanctions alert – freeze the account, notify compliance, and coordinate with the sanctions provider.
+* Repeated provider rejections – verify the allow list matches the operational roster and update `[swap.providers]` if a new PSP is onboarded.
+
+Maintain a weekly audit of reversal activity by exporting the voucher ledger and filtering for `status = reversed`.

--- a/docs/swap/regulatory-brief.md
+++ b/docs/swap/regulatory-brief.md
@@ -1,0 +1,40 @@
+# SWAP-4 Regulatory Brief
+
+The SWAP-4 release hardens the fiat on-ramp against operational and financial crime risks. This brief summarises the controls for regulators, auditors, and investors.
+
+## Custody Model
+
+* Mints originate from PSP-cleared fiat deposits. Tokens are minted into custodial accounts controlled by the on-ramp until customer withdrawals occur.
+* Reversal operations debit the custodial account and credit a treasury-managed refund sink. Funds remain on-chain—no silent burns occur.
+* Ledger records are immutable and store provider IDs, mint amounts, oracle source, and status transitions (`minted`, `reconciled`, `reversed`).
+
+## Risk Controls
+
+* **Provider allow list** – Only PSP identifiers approved in `[swap.providers]` can submit vouchers. Requests from unknown providers are rejected and logged via `swap.alert.limit_hit` events.
+* **Limit buckets** – Per-transaction, daily, monthly, and velocity thresholds are enforced before minting. Breaches emit auditable events with contextual attributes.
+* **Sanctions hook** – When enabled, every voucher recipient is evaluated. Failures block the mint and emit `swap.alert.sanction` events for compliance review.
+* **Alerting** – All guardrails emit deterministic events appended to the block event log so external monitors and auditors can replay history.
+
+## KYC and Sanctions Responsibilities
+
+* **PSP** – Responsible for full KYC/AML on the fiat leg, transaction monitoring, and providing provider transaction IDs.
+* **On-ramp** – Enforces blockchain-level guardrails, maintains the sanctions hook, and honours regulator-mandated reversals.
+* **Third-party sanctions service** – Optional integration; SWAP-4 exposes a hook so operators can plug in proprietary or vendor services without protocol changes.
+
+## Audit Trail
+
+* Use `swap_limits` to retrieve real-time counters and confirm that customers remain under policy thresholds.
+* Export voucher history via `swap_voucher_export` for reconciliation. Filter for `status=reversed` to review clawbacks.
+* The optional `cmd/swap-audit` utility prints the currently loaded risk configuration for config-change reviews.
+
+## Governance & Change Management
+
+* Limit changes require config updates and should be recorded in change-control logs with effective timestamps.
+* Provider onboarding involves both PSP legal review and a config update. Ensure the allow list is version-controlled.
+* Sanctions hook upgrades must be regression-tested in a non-production environment before activation (`SanctionsCheckEnabled = true`).
+
+## Investor Assurance
+
+* Limits and alerts demonstrate prudent control over token issuance, reducing regulatory risk.
+* Refund sink balances are transparent on-chain, enabling proof-of-liabilities exercises.
+* The design minimises manual interventions—most failures are prevented pre-mint and surfaced via events, reducing clawback costs.

--- a/docs/swap/risk-controls.md
+++ b/docs/swap/risk-controls.md
@@ -1,0 +1,85 @@
+# Swap Mint Risk Controls
+
+The SWAP-4 upgrade introduces deterministic guardrails around on-ramp mints so operations teams can prove adherence to policy while regulators and investors can audit behaviour. The limits below are enforced inside `swap_submitVoucher` before any state changes and violations raise structured alerts.
+
+## Configuration
+
+Configure limits in `config.toml` under `[swap.risk]` and the provider allow list under `[swap.providers]`.
+
+```toml
+[swap.risk]
+PerAddressDailyCapWei = "10000e18"
+PerAddressMonthlyCapWei = "300000e18"
+PerTxMinWei = "1e18"
+PerTxMaxWei = "50000e18"
+VelocityWindowSeconds = 600
+VelocityMaxMints = 5
+SanctionsCheckEnabled = true
+
+[swap.providers]
+Allow = ["nowpayments"]
+```
+
+| Setting | Description |
+| --- | --- |
+| `PerTxMinWei` | Reject vouchers below this mint amount. `0` disables the check. |
+| `PerTxMaxWei` | Reject vouchers above this mint amount. |
+| `PerAddressDailyCapWei` | Aggregate recipient mints per UTC day and block the next mint when the cap is exceeded. |
+| `PerAddressMonthlyCapWei` | Aggregate per calendar month using UTC. |
+| `VelocityWindowSeconds` & `VelocityMaxMints` | Count successful mints inside a rolling window and block the next mint when the count reaches `VelocityMaxMints`. |
+| `SanctionsCheckEnabled` | When `true`, run the sanctions hook before minting. |
+| `[swap.providers].Allow` | Lower-case allow list of PSP identifiers. Empty array allows all providers. |
+
+All numeric values accept scientific notation (e.g. `10000e18`).
+
+## Runtime Behaviour
+
+1. **Provider allow-list** – Rejects vouchers whose `provider` field is not in the allow list. Emits `swap.alert.limit_hit` with `limit=provider`.
+2. **Sanctions hook** – Calls the configured checker. A `false` response blocks the mint and emits `swap.alert.sanction`.
+3. **Per-transaction limits** – Enforced before checking historical buckets. Violations emit `swap.alert.limit_hit` with `limit=per_tx_min` or `per_tx_max`.
+4. **Daily & monthly caps** – UTC buckets keyed per address. Hitting a cap blocks the mint and emits `swap.alert.limit_hit` with `limit=daily_cap` or `monthly_cap`.
+5. **Velocity window** – Evaluates mints inside the configured rolling window and emits `swap.alert.velocity` when the threshold is met. The event reports `windowSeconds`, `allowedMints`, and the observed count.
+
+All alerts are appended to the state event log for audit trails.
+
+## Example: Policy Update
+
+Use governance or manual updates to raise limits temporarily:
+
+```toml
+[swap.risk]
+PerAddressDailyCapWei = "25000e18"
+PerAddressMonthlyCapWei = "500000e18"
+PerTxMinWei = "5e18"
+PerTxMaxWei = "75000e18"
+VelocityWindowSeconds = 900
+VelocityMaxMints = 3
+SanctionsCheckEnabled = true
+```
+
+Restart the node (or trigger a config reload) after editing the file to apply the new guardrails.
+
+## Monitoring
+
+* Subscribe to the event stream for:
+  * `swap.alert.limit_hit`
+  * `swap.alert.velocity`
+  * `swap.alert.sanction`
+* Inspect counters via the new RPC:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "swap_limits",
+  "params": ["nhb1recipientaddress000000000000000000000000"]
+}
+```
+
+The response includes day/month totals, remaining capacity, and velocity observations for the address.
+
+## Operational Tips
+
+* Set `VelocityWindowSeconds` high enough to account for expected PSP bursts but low enough to prevent scripted abuse.
+* Use the optional `cmd/swap-audit` tool to print the currently loaded configuration: `go run ./cmd/swap-audit --config ./config.toml`.
+* When raising limits for incident response, document the change in the compliance log and ensure alerts are reviewed for potential abuse attempts.

--- a/native/swap/oracle.go
+++ b/native/swap/oracle.go
@@ -477,6 +477,8 @@ type Config struct {
 	MaxQuoteAgeSeconds int64
 	SlippageBps        uint64
 	OraclePriority     []string
+	Risk               RiskConfig     `toml:"risk"`
+	Providers          ProviderConfig `toml:"providers"`
 }
 
 // Normalise applies defaults and canonical casing to the configuration values.
@@ -486,6 +488,8 @@ func (c Config) Normalise() Config {
 		MaxQuoteAgeSeconds: c.MaxQuoteAgeSeconds,
 		SlippageBps:        c.SlippageBps,
 		OraclePriority:     append([]string{}, c.OraclePriority...),
+		Risk:               c.Risk.Normalise(),
+		Providers:          c.Providers.Normalise(),
 	}
 	if len(cfg.AllowedFiat) == 0 {
 		cfg.AllowedFiat = []string{"USD"}

--- a/native/swap/risk.go
+++ b/native/swap/risk.go
@@ -1,0 +1,562 @@
+package swap
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RiskConfig captures operator-defined mint guardrails parsed from configuration.
+type RiskConfig struct {
+	PerAddressDailyCapWei   string `toml:"PerAddressDailyCapWei"`
+	PerAddressMonthlyCapWei string `toml:"PerAddressMonthlyCapWei"`
+	PerTxMinWei             string `toml:"PerTxMinWei"`
+	PerTxMaxWei             string `toml:"PerTxMaxWei"`
+	VelocityWindowSeconds   int64  `toml:"VelocityWindowSeconds"`
+	VelocityMaxMints        uint64 `toml:"VelocityMaxMints"`
+	SanctionsCheckEnabled   bool   `toml:"SanctionsCheckEnabled"`
+}
+
+// RiskParameters represents canonical, runtime-ready interpretations of the risk settings.
+type RiskParameters struct {
+	PerAddressDailyCapWei   *big.Int
+	PerAddressMonthlyCapWei *big.Int
+	PerTxMinWei             *big.Int
+	PerTxMaxWei             *big.Int
+	VelocityWindowSeconds   uint64
+	VelocityMaxMints        uint64
+	SanctionsCheckEnabled   bool
+}
+
+// Normalise trims whitespace and applies canonical defaults to defensive copies.
+func (rc RiskConfig) Normalise() RiskConfig {
+	cfg := RiskConfig{
+		PerAddressDailyCapWei:   strings.TrimSpace(rc.PerAddressDailyCapWei),
+		PerAddressMonthlyCapWei: strings.TrimSpace(rc.PerAddressMonthlyCapWei),
+		PerTxMinWei:             strings.TrimSpace(rc.PerTxMinWei),
+		PerTxMaxWei:             strings.TrimSpace(rc.PerTxMaxWei),
+		VelocityWindowSeconds:   rc.VelocityWindowSeconds,
+		VelocityMaxMints:        rc.VelocityMaxMints,
+		SanctionsCheckEnabled:   rc.SanctionsCheckEnabled,
+	}
+	if cfg.VelocityWindowSeconds < 0 {
+		cfg.VelocityWindowSeconds = 0
+	}
+	return cfg
+}
+
+// Parameters converts the textual configuration into runtime big integers and bounds.
+func (rc RiskConfig) Parameters() (RiskParameters, error) {
+	normalized := rc.Normalise()
+	params := RiskParameters{SanctionsCheckEnabled: normalized.SanctionsCheckEnabled}
+	if normalized.PerAddressDailyCapWei != "" {
+		amount, err := parseWeiAmount(normalized.PerAddressDailyCapWei)
+		if err != nil {
+			return params, fmt.Errorf("risk: invalid PerAddressDailyCapWei: %w", err)
+		}
+		params.PerAddressDailyCapWei = amount
+	}
+	if normalized.PerAddressMonthlyCapWei != "" {
+		amount, err := parseWeiAmount(normalized.PerAddressMonthlyCapWei)
+		if err != nil {
+			return params, fmt.Errorf("risk: invalid PerAddressMonthlyCapWei: %w", err)
+		}
+		params.PerAddressMonthlyCapWei = amount
+	}
+	if normalized.PerTxMinWei != "" {
+		amount, err := parseWeiAmount(normalized.PerTxMinWei)
+		if err != nil {
+			return params, fmt.Errorf("risk: invalid PerTxMinWei: %w", err)
+		}
+		params.PerTxMinWei = amount
+	}
+	if normalized.PerTxMaxWei != "" {
+		amount, err := parseWeiAmount(normalized.PerTxMaxWei)
+		if err != nil {
+			return params, fmt.Errorf("risk: invalid PerTxMaxWei: %w", err)
+		}
+		params.PerTxMaxWei = amount
+	}
+	if normalized.VelocityWindowSeconds > 0 {
+		params.VelocityWindowSeconds = uint64(normalized.VelocityWindowSeconds)
+	}
+	if normalized.VelocityMaxMints > 0 {
+		params.VelocityMaxMints = normalized.VelocityMaxMints
+	}
+	return params, nil
+}
+
+// ProviderConfig describes which fiat providers are authorised to submit mints.
+type ProviderConfig struct {
+	Allow []string `toml:"Allow"`
+}
+
+// Normalise returns a deduplicated, lower-cased allow list to simplify downstream checks.
+func (pc ProviderConfig) Normalise() ProviderConfig {
+	trimmed := make([]string, 0, len(pc.Allow))
+	seen := make(map[string]struct{}, len(pc.Allow))
+	for _, entry := range pc.Allow {
+		normalised := strings.ToLower(strings.TrimSpace(entry))
+		if normalised == "" {
+			continue
+		}
+		if _, exists := seen[normalised]; exists {
+			continue
+		}
+		seen[normalised] = struct{}{}
+		trimmed = append(trimmed, normalised)
+	}
+	sort.Strings(trimmed)
+	return ProviderConfig{Allow: trimmed}
+}
+
+// AllowList returns a defensive copy of the configured provider identifiers.
+func (pc ProviderConfig) AllowList() []string {
+	return append([]string{}, pc.Allow...)
+}
+
+// IsAllowed reports whether the provided provider identifier is present in the allow list.
+func (pc ProviderConfig) IsAllowed(provider string) bool {
+	needle := strings.ToLower(strings.TrimSpace(provider))
+	if needle == "" {
+		return false
+	}
+	for _, entry := range pc.Allow {
+		if entry == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ProviderStatus summarises the provider controls for operator dashboards and tooling.
+type ProviderStatus struct {
+	Allow                 []string
+	LastOracleHealthCheck int64
+}
+
+// RiskCode enumerates supported limit violation categories.
+type RiskCode string
+
+const (
+	// RiskCodePerTxMin indicates the mint amount was below the allowed floor.
+	RiskCodePerTxMin RiskCode = "per_tx_min"
+	// RiskCodePerTxMax indicates the mint amount exceeded the configured ceiling.
+	RiskCodePerTxMax RiskCode = "per_tx_max"
+	// RiskCodeDailyCap indicates the recipient exhausted the daily allowance.
+	RiskCodeDailyCap RiskCode = "daily_cap"
+	// RiskCodeMonthlyCap indicates the recipient exhausted the monthly allowance.
+	RiskCodeMonthlyCap RiskCode = "monthly_cap"
+	// RiskCodeVelocity indicates the mint frequency exceeded the allowed burst.
+	RiskCodeVelocity RiskCode = "velocity"
+)
+
+// RiskViolation conveys a violated guardrail alongside diagnostic context for alerts.
+type RiskViolation struct {
+	Code          RiskCode
+	Message       string
+	Limit         *big.Int
+	Current       *big.Int
+	WindowSeconds uint64
+	Count         int
+}
+
+// Error satisfies the error interface to allow RiskViolation to propagate through call sites.
+func (rv *RiskViolation) Error() string {
+	if rv == nil {
+		return ""
+	}
+	if strings.TrimSpace(rv.Message) != "" {
+		return rv.Message
+	}
+	return fmt.Sprintf("risk violation: %s", rv.Code)
+}
+
+// RiskEngine manages per-address mint counters and velocity samples within storage.
+type RiskEngine struct {
+	store Storage
+	clock func() time.Time
+}
+
+// NewRiskEngine constructs a risk engine backed by the provided storage adapter.
+func NewRiskEngine(store Storage) *RiskEngine {
+	return &RiskEngine{store: store, clock: time.Now}
+}
+
+// SetClock overrides the time source, enabling deterministic unit tests.
+func (re *RiskEngine) SetClock(clock func() time.Time) {
+	if re == nil || clock == nil {
+		return
+	}
+	re.clock = clock
+}
+
+// CheckLimits evaluates the configured limits against the pending mint and returns a violation when enforcement should block the mint.
+func (re *RiskEngine) CheckLimits(addr [20]byte, amount *big.Int, params RiskParameters) (*RiskViolation, error) {
+	if re == nil {
+		return nil, fmt.Errorf("risk engine not initialised")
+	}
+	if amount == nil || amount.Sign() <= 0 {
+		return nil, fmt.Errorf("risk: amount must be positive")
+	}
+	now := re.clock().UTC()
+	if params.PerTxMinWei != nil && params.PerTxMinWei.Sign() > 0 {
+		if amount.Cmp(params.PerTxMinWei) < 0 {
+			return &RiskViolation{
+				Code:    RiskCodePerTxMin,
+				Message: fmt.Sprintf("amount %s below minimum %s", amount, params.PerTxMinWei),
+				Limit:   new(big.Int).Set(params.PerTxMinWei),
+				Current: new(big.Int).Set(amount),
+			}, nil
+		}
+	}
+	if params.PerTxMaxWei != nil && params.PerTxMaxWei.Sign() > 0 {
+		if amount.Cmp(params.PerTxMaxWei) > 0 {
+			return &RiskViolation{
+				Code:    RiskCodePerTxMax,
+				Message: fmt.Sprintf("amount %s exceeds maximum %s", amount, params.PerTxMaxWei),
+				Limit:   new(big.Int).Set(params.PerTxMaxWei),
+				Current: new(big.Int).Set(amount),
+			}, nil
+		}
+	}
+	dayKey := riskDailyKey(now, addr)
+	dayTotal, err := re.bucketTotal(dayKey)
+	if err != nil {
+		return nil, err
+	}
+	if params.PerAddressDailyCapWei != nil && params.PerAddressDailyCapWei.Sign() > 0 {
+		projected := new(big.Int).Add(dayTotal, amount)
+		if projected.Cmp(params.PerAddressDailyCapWei) > 0 {
+			return &RiskViolation{
+				Code:    RiskCodeDailyCap,
+				Message: fmt.Sprintf("daily cap %s exceeded", params.PerAddressDailyCapWei),
+				Limit:   new(big.Int).Set(params.PerAddressDailyCapWei),
+				Current: projected,
+			}, nil
+		}
+	}
+	monthKey := riskMonthlyKey(now, addr)
+	monthTotal, err := re.bucketTotal(monthKey)
+	if err != nil {
+		return nil, err
+	}
+	if params.PerAddressMonthlyCapWei != nil && params.PerAddressMonthlyCapWei.Sign() > 0 {
+		projected := new(big.Int).Add(monthTotal, amount)
+		if projected.Cmp(params.PerAddressMonthlyCapWei) > 0 {
+			return &RiskViolation{
+				Code:    RiskCodeMonthlyCap,
+				Message: fmt.Sprintf("monthly cap %s exceeded", params.PerAddressMonthlyCapWei),
+				Limit:   new(big.Int).Set(params.PerAddressMonthlyCapWei),
+				Current: projected,
+			}, nil
+		}
+	}
+	if params.VelocityWindowSeconds > 0 && params.VelocityMaxMints > 0 {
+		samples, err := re.loadVelocity(addr)
+		if err != nil {
+			return nil, err
+		}
+		cutoff := now.Add(-time.Duration(params.VelocityWindowSeconds) * time.Second)
+		recent := filterSamples(samples, cutoff)
+		if len(recent) >= int(params.VelocityMaxMints) {
+			return &RiskViolation{
+				Code:          RiskCodeVelocity,
+				Message:       fmt.Sprintf("velocity exceeded %d events in %d seconds", params.VelocityMaxMints, params.VelocityWindowSeconds),
+				WindowSeconds: params.VelocityWindowSeconds,
+				Count:         len(recent),
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+// RecordMint persists the mint against the relevant counters following a successful mint.
+func (re *RiskEngine) RecordMint(addr [20]byte, amount *big.Int) error {
+	if re == nil {
+		return fmt.Errorf("risk engine not initialised")
+	}
+	if amount == nil || amount.Sign() <= 0 {
+		return fmt.Errorf("risk: amount must be positive")
+	}
+	now := re.clock().UTC()
+	dayKey := riskDailyKey(now, addr)
+	if err := re.addToBucket(dayKey, amount); err != nil {
+		return err
+	}
+	monthKey := riskMonthlyKey(now, addr)
+	if err := re.addToBucket(monthKey, amount); err != nil {
+		return err
+	}
+	if err := re.appendVelocity(addr, now); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RiskUsage captures the aggregated counters for an address.
+type RiskUsage struct {
+	Address            [20]byte
+	Day                string
+	DayTotalWei        *big.Int
+	Month              string
+	MonthTotalWei      *big.Int
+	VelocityTimestamps []int64
+}
+
+// Copy returns a deep copy to shield callers from accidental mutation.
+func (ru *RiskUsage) Copy() *RiskUsage {
+	if ru == nil {
+		return nil
+	}
+	clone := &RiskUsage{
+		Address:            ru.Address,
+		Day:                ru.Day,
+		Month:              ru.Month,
+		VelocityTimestamps: append([]int64{}, ru.VelocityTimestamps...),
+	}
+	if ru.DayTotalWei != nil {
+		clone.DayTotalWei = new(big.Int).Set(ru.DayTotalWei)
+	}
+	if ru.MonthTotalWei != nil {
+		clone.MonthTotalWei = new(big.Int).Set(ru.MonthTotalWei)
+	}
+	return clone
+}
+
+// Usage retrieves the current counters for the provided address.
+func (re *RiskEngine) Usage(addr [20]byte) (*RiskUsage, error) {
+	if re == nil {
+		return nil, fmt.Errorf("risk engine not initialised")
+	}
+	now := re.clock().UTC()
+	day := formatDay(now)
+	month := formatMonth(now)
+	dayTotal, err := re.bucketTotal(riskDailyKey(now, addr))
+	if err != nil {
+		return nil, err
+	}
+	monthTotal, err := re.bucketTotal(riskMonthlyKey(now, addr))
+	if err != nil {
+		return nil, err
+	}
+	samples, err := re.loadVelocity(addr)
+	if err != nil {
+		return nil, err
+	}
+	timestamps := make([]int64, len(samples))
+	for i := range samples {
+		timestamps[i] = int64(samples[i])
+	}
+	usage := &RiskUsage{
+		Address:            addr,
+		Day:                day,
+		DayTotalWei:        dayTotal,
+		Month:              month,
+		MonthTotalWei:      monthTotal,
+		VelocityTimestamps: timestamps,
+	}
+	return usage, nil
+}
+
+func (re *RiskEngine) bucketTotal(key []byte) (*big.Int, error) {
+	var record amountRecord
+	ok, err := re.store.KVGet(key, &record)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || strings.TrimSpace(record.Amount) == "" {
+		return big.NewInt(0), nil
+	}
+	value, err := parseWeiAmount(record.Amount)
+	if err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func (re *RiskEngine) addToBucket(key []byte, amount *big.Int) error {
+	current, err := re.bucketTotal(key)
+	if err != nil {
+		return err
+	}
+	updated := new(big.Int).Add(current, amount)
+	record := amountRecord{Amount: updated.String()}
+	return re.store.KVPut(key, record)
+}
+
+func (re *RiskEngine) appendVelocity(addr [20]byte, now time.Time) error {
+	samples, err := re.loadVelocity(addr)
+	if err != nil {
+		return err
+	}
+	cleaned := filterSamples(samples, now.Add(-24*time.Hour))
+	cleaned = append(cleaned, uint64(now.UTC().Unix()))
+	record := velocityRecord{Samples: cleaned}
+	return re.store.KVPut(riskVelocityKey(addr), record)
+}
+
+func (re *RiskEngine) loadVelocity(addr [20]byte) ([]uint64, error) {
+	var record velocityRecord
+	ok, err := re.store.KVGet(riskVelocityKey(addr), &record)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || len(record.Samples) == 0 {
+		return []uint64{}, nil
+	}
+	out := append([]uint64{}, record.Samples...)
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+func parseWeiAmount(value string) (*big.Int, error) {
+	trimmed := strings.ReplaceAll(strings.TrimSpace(value), "_", "")
+	if trimmed == "" {
+		return big.NewInt(0), nil
+	}
+	normalized := trimmed
+	var exponent int64
+	if idx := strings.IndexAny(normalized, "eE"); idx != -1 {
+		expPart := strings.TrimSpace(normalized[idx+1:])
+		if expPart == "" {
+			return nil, fmt.Errorf("invalid scientific notation")
+		}
+		expValue, err := strconv.ParseInt(expPart, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid scientific notation")
+		}
+		exponent = expValue
+		normalized = strings.TrimSpace(normalized[:idx])
+	}
+	normalized = strings.TrimPrefix(normalized, "+")
+	if strings.HasPrefix(normalized, "-") {
+		return nil, fmt.Errorf("amount must not be negative")
+	}
+	parts := strings.Split(normalized, ".")
+	if len(parts) > 2 {
+		return nil, fmt.Errorf("invalid amount format")
+	}
+	integerPart := parts[0]
+	fractionalPart := ""
+	if len(parts) == 2 {
+		fractionalPart = parts[1]
+	}
+	digits := integerPart + fractionalPart
+	if digits == "" {
+		return big.NewInt(0), nil
+	}
+	if !isDigits(digits) {
+		return nil, fmt.Errorf("invalid amount format")
+	}
+	fracLen := len(fractionalPart)
+	for fracLen > 0 && len(digits) > 0 && digits[len(digits)-1] == '0' {
+		digits = digits[:len(digits)-1]
+		fracLen--
+	}
+	digits = strings.TrimLeft(digits, "0")
+	totalExponent := exponent - int64(fracLen)
+	if totalExponent < 0 {
+		return nil, fmt.Errorf("amount must be an integer")
+	}
+	if digits == "" {
+		digits = "0"
+	}
+	if totalExponent > 0 {
+		digits += strings.Repeat("0", int(totalExponent))
+	}
+	amount := new(big.Int)
+	if _, ok := amount.SetString(digits, 10); !ok {
+		return nil, fmt.Errorf("invalid amount value")
+	}
+	return amount, nil
+}
+
+func isDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func riskDailyKey(now time.Time, addr [20]byte) []byte {
+	day := formatDay(now)
+	suffix := hex.EncodeToString(addr[:])
+	key := make([]byte, len(riskDailyPrefix)+len(day)+1+len(suffix))
+	copy(key, riskDailyPrefix)
+	copy(key[len(riskDailyPrefix):], day)
+	key[len(riskDailyPrefix)+len(day)] = '/'
+	copy(key[len(riskDailyPrefix)+len(day)+1:], suffix)
+	return key
+}
+
+func riskMonthlyKey(now time.Time, addr [20]byte) []byte {
+	month := formatMonth(now)
+	suffix := hex.EncodeToString(addr[:])
+	key := make([]byte, len(riskMonthlyPrefix)+len(month)+1+len(suffix))
+	copy(key, riskMonthlyPrefix)
+	copy(key[len(riskMonthlyPrefix):], month)
+	key[len(riskMonthlyPrefix)+len(month)] = '/'
+	copy(key[len(riskMonthlyPrefix)+len(month)+1:], suffix)
+	return key
+}
+
+func riskVelocityKey(addr [20]byte) []byte {
+	suffix := hex.EncodeToString(addr[:])
+	key := make([]byte, len(riskVelocityPrefix)+len(suffix))
+	copy(key, riskVelocityPrefix)
+	copy(key[len(riskVelocityPrefix):], suffix)
+	return key
+}
+
+func formatDay(ts time.Time) string {
+	return ts.UTC().Format("2006-01-02")
+}
+
+func formatMonth(ts time.Time) string {
+	return ts.UTC().Format("2006-01")
+}
+
+func filterSamples(samples []uint64, cutoff time.Time) []uint64 {
+	if len(samples) == 0 {
+		return []uint64{}
+	}
+	threshold := cutoff.Unix()
+	filtered := make([]uint64, 0, len(samples))
+	for _, sample := range samples {
+		if int64(sample) >= threshold {
+			filtered = append(filtered, sample)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool { return filtered[i] < filtered[j] })
+	return filtered
+}
+
+type amountRecord struct {
+	Amount string
+}
+
+type velocityRecord struct {
+	Samples []uint64
+}
+
+var (
+	riskDailyPrefix    = []byte("swap/risk/daily/")
+	riskMonthlyPrefix  = []byte("swap/risk/monthly/")
+	riskVelocityPrefix = []byte("swap/risk/velocity/")
+)
+
+// SanctionsChecker evaluates whether an address is eligible for mints.
+type SanctionsChecker func([20]byte) bool
+
+// DefaultSanctionsChecker allows all addresses, providing a safe default when operators do not wire external services.
+func DefaultSanctionsChecker([20]byte) bool { return true }

--- a/native/swap/risk_test.go
+++ b/native/swap/risk_test.go
@@ -1,0 +1,177 @@
+package swap
+
+import (
+	"math/big"
+	"testing"
+	"time"
+)
+
+type memoryStore struct {
+	data map[string]interface{}
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{data: make(map[string]interface{})}
+}
+
+func (m *memoryStore) KVGet(key []byte, out interface{}) (bool, error) {
+	value, ok := m.data[string(key)]
+	if !ok {
+		return false, nil
+	}
+	switch dst := out.(type) {
+	case *amountRecord:
+		if src, ok := value.(amountRecord); ok {
+			*dst = src
+			return true, nil
+		}
+	case *velocityRecord:
+		if src, ok := value.(velocityRecord); ok {
+			*dst = src
+			return true, nil
+		}
+	default:
+		return false, nil
+	}
+	return false, nil
+}
+
+func (m *memoryStore) KVPut(key []byte, value interface{}) error {
+	m.data[string(key)] = value
+	return nil
+}
+
+func (m *memoryStore) KVAppend(key []byte, value []byte) error {
+	return nil
+}
+
+func (m *memoryStore) KVGetList(key []byte, out interface{}) error {
+	return nil
+}
+
+func TestRiskParametersParse(t *testing.T) {
+	cfg := RiskConfig{
+		PerAddressDailyCapWei:   "10000e18",
+		PerAddressMonthlyCapWei: "300000e18",
+		PerTxMinWei:             "1e18",
+		PerTxMaxWei:             "50000e18",
+		VelocityWindowSeconds:   600,
+		VelocityMaxMints:        5,
+	}
+	params, err := cfg.Parameters()
+	if err != nil {
+		t.Fatalf("parse parameters: %v", err)
+	}
+	wantDaily, _ := new(big.Int).SetString("10000", 10)
+	wantDaily.Mul(wantDaily, new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+	if params.PerAddressDailyCapWei.Cmp(wantDaily) != 0 {
+		t.Fatalf("unexpected daily cap: %s", params.PerAddressDailyCapWei.String())
+	}
+	if params.VelocityWindowSeconds != 600 || params.VelocityMaxMints != 5 {
+		t.Fatalf("unexpected velocity params: %+v", params)
+	}
+}
+
+func TestRiskEnginePerTxLimits(t *testing.T) {
+	engine := NewRiskEngine(newMemoryStore())
+	params := RiskParameters{
+		PerTxMinWei: big.NewInt(10),
+		PerTxMaxWei: big.NewInt(100),
+	}
+	violation, err := engine.CheckLimits([20]byte{}, big.NewInt(5), params)
+	if err != nil {
+		t.Fatalf("check limits: %v", err)
+	}
+	if violation == nil || violation.Code != RiskCodePerTxMin {
+		t.Fatalf("expected per tx min violation")
+	}
+	violation, err = engine.CheckLimits([20]byte{}, big.NewInt(101), params)
+	if err != nil {
+		t.Fatalf("check limits: %v", err)
+	}
+	if violation == nil || violation.Code != RiskCodePerTxMax {
+		t.Fatalf("expected per tx max violation")
+	}
+}
+
+func TestRiskEngineDailyMonthlyLimits(t *testing.T) {
+	store := newMemoryStore()
+	engine := NewRiskEngine(store)
+	now := time.Unix(1_000_000, 0)
+	engine.SetClock(func() time.Time { return now })
+	addr := [20]byte{1}
+	params := RiskParameters{
+		PerAddressDailyCapWei:   big.NewInt(100),
+		PerAddressMonthlyCapWei: big.NewInt(150),
+	}
+	if err := engine.RecordMint(addr, big.NewInt(90)); err != nil {
+		t.Fatalf("record mint: %v", err)
+	}
+	violation, err := engine.CheckLimits(addr, big.NewInt(11), params)
+	if err != nil {
+		t.Fatalf("check limits: %v", err)
+	}
+	if violation == nil || violation.Code != RiskCodeDailyCap {
+		t.Fatalf("expected daily cap violation")
+	}
+	engine.SetClock(func() time.Time { return now.Add(24 * time.Hour) })
+	if err := engine.RecordMint(addr, big.NewInt(60)); err != nil {
+		t.Fatalf("record second mint: %v", err)
+	}
+	engine.SetClock(func() time.Time { return now.Add(36 * time.Hour) })
+	violation, err = engine.CheckLimits(addr, big.NewInt(10), params)
+	if err != nil {
+		t.Fatalf("check limits: %v", err)
+	}
+	if violation == nil || violation.Code != RiskCodeMonthlyCap {
+		t.Fatalf("expected monthly cap violation")
+	}
+}
+
+func TestRiskEngineVelocityLimit(t *testing.T) {
+	store := newMemoryStore()
+	engine := NewRiskEngine(store)
+	addr := [20]byte{2}
+	params := RiskParameters{VelocityWindowSeconds: 600, VelocityMaxMints: 2}
+	base := time.Unix(2_000_000, 0)
+	engine.SetClock(func() time.Time { return base.Add(-time.Minute * 5) })
+	if err := engine.RecordMint(addr, big.NewInt(1)); err != nil {
+		t.Fatalf("record mint: %v", err)
+	}
+	engine.SetClock(func() time.Time { return base.Add(-time.Minute * 2) })
+	if err := engine.RecordMint(addr, big.NewInt(1)); err != nil {
+		t.Fatalf("record mint: %v", err)
+	}
+	engine.SetClock(func() time.Time { return base })
+	violation, err := engine.CheckLimits(addr, big.NewInt(1), params)
+	if err != nil {
+		t.Fatalf("check limits: %v", err)
+	}
+	if violation == nil || violation.Code != RiskCodeVelocity {
+		t.Fatalf("expected velocity violation")
+	}
+}
+
+func TestRiskEngineUsage(t *testing.T) {
+	store := newMemoryStore()
+	engine := NewRiskEngine(store)
+	addr := [20]byte{3}
+	now := time.Unix(3_000_000, 0)
+	engine.SetClock(func() time.Time { return now })
+	if err := engine.RecordMint(addr, big.NewInt(50)); err != nil {
+		t.Fatalf("record mint: %v", err)
+	}
+	usage, err := engine.Usage(addr)
+	if err != nil {
+		t.Fatalf("usage: %v", err)
+	}
+	if usage.DayTotalWei.Cmp(big.NewInt(50)) != 0 {
+		t.Fatalf("expected day total 50, got %s", usage.DayTotalWei.String())
+	}
+	if usage.MonthTotalWei.Cmp(big.NewInt(50)) != 0 {
+		t.Fatalf("expected month total 50, got %s", usage.MonthTotalWei.String())
+	}
+	if len(usage.VelocityTimestamps) != 1 {
+		t.Fatalf("expected velocity sample recorded")
+	}
+}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -247,6 +247,24 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handleSwapVoucherList(w, r, req)
 	case "swap_voucher_export":
 		s.handleSwapVoucherExport(w, r, req)
+	case "swap_limits":
+		if authErr := s.requireAuth(r); authErr != nil {
+			writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+			return
+		}
+		s.handleSwapLimits(w, r, req)
+	case "swap_provider_status":
+		if authErr := s.requireAuth(r); authErr != nil {
+			writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+			return
+		}
+		s.handleSwapProviderStatus(w, r, req)
+	case "swap_voucher_reverse":
+		if authErr := s.requireAuth(r); authErr != nil {
+			writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+			return
+		}
+		s.handleSwapVoucherReverse(w, r, req)
 	case "stake_delegate":
 		s.handleStakeDelegate(w, r, req)
 	case "stake_undelegate":

--- a/rpc/swap_admin_handlers.go
+++ b/rpc/swap_admin_handlers.go
@@ -1,0 +1,159 @@
+package rpc
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"nhbchain/core"
+	"nhbchain/crypto"
+)
+
+// handleSwapLimits returns the current usage counters and remaining capacity for a swap participant.
+func (s *Server) handleSwapLimits(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected address", nil)
+		return
+	}
+	var addrStr string
+	if err := json.Unmarshal(req.Params[0], &addrStr); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid address", err.Error())
+		return
+	}
+	decoded, err := crypto.DecodeAddress(strings.TrimSpace(addrStr))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid address", err.Error())
+		return
+	}
+	var addr [20]byte
+	copy(addr[:], decoded.Bytes())
+
+	usage, params, err := s.node.SwapLimits(addr)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "failed to load limits", err.Error())
+		return
+	}
+	dayMinted := big.NewInt(0)
+	if usage.DayTotalWei != nil {
+		dayMinted = new(big.Int).Set(usage.DayTotalWei)
+	}
+	monthMinted := big.NewInt(0)
+	if usage.MonthTotalWei != nil {
+		monthMinted = new(big.Int).Set(usage.MonthTotalWei)
+	}
+	var dayRemaining *big.Int
+	if params.PerAddressDailyCapWei != nil && params.PerAddressDailyCapWei.Sign() > 0 {
+		dayRemaining = new(big.Int).Sub(params.PerAddressDailyCapWei, dayMinted)
+		if dayRemaining.Sign() < 0 {
+			dayRemaining = big.NewInt(0)
+		}
+	}
+	var monthRemaining *big.Int
+	if params.PerAddressMonthlyCapWei != nil && params.PerAddressMonthlyCapWei.Sign() > 0 {
+		monthRemaining = new(big.Int).Sub(params.PerAddressMonthlyCapWei, monthMinted)
+		if monthRemaining.Sign() < 0 {
+			monthRemaining = big.NewInt(0)
+		}
+	}
+	velocityObserved := 0
+	velocityRemaining := int64(-1)
+	if params.VelocityWindowSeconds > 0 && params.VelocityMaxMints > 0 {
+		cutoff := time.Now().Add(-time.Duration(params.VelocityWindowSeconds) * time.Second).Unix()
+		for _, sample := range usage.VelocityTimestamps {
+			if sample >= cutoff {
+				velocityObserved++
+			}
+		}
+		remaining := int64(params.VelocityMaxMints) - int64(velocityObserved)
+		if remaining < 0 {
+			remaining = 0
+		}
+		velocityRemaining = remaining
+	}
+	result := map[string]interface{}{
+		"address": decoded.String(),
+		"day": map[string]string{
+			"bucket":    usage.Day,
+			"mintedWei": dayMinted.String(),
+		},
+		"month": map[string]string{
+			"bucket":    usage.Month,
+			"mintedWei": monthMinted.String(),
+		},
+	}
+	if dayRemaining != nil {
+		result["dayRemainingWei"] = dayRemaining.String()
+	}
+	if monthRemaining != nil {
+		result["monthRemainingWei"] = monthRemaining.String()
+	}
+	if params.VelocityWindowSeconds > 0 && params.VelocityMaxMints > 0 {
+		velocityInfo := map[string]interface{}{
+			"windowSeconds": params.VelocityWindowSeconds,
+			"maxMints":      params.VelocityMaxMints,
+			"observed":      velocityObserved,
+		}
+		if velocityRemaining >= 0 {
+			velocityInfo["remaining"] = velocityRemaining
+		}
+		result["velocity"] = velocityInfo
+	}
+	writeResult(w, req.ID, result)
+}
+
+// handleSwapProviderStatus returns the configured provider allow list and oracle health metadata.
+func (s *Server) handleSwapProviderStatus(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 0 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "no parameters expected", nil)
+		return
+	}
+	status := s.node.SwapProviderStatus()
+	result := map[string]interface{}{
+		"allow":                 status.Allow,
+		"lastOracleHealthCheck": status.LastOracleHealthCheck,
+	}
+	writeResult(w, req.ID, result)
+}
+
+// handleSwapVoucherReverse reverses a minted voucher and moves funds into the refund sink.
+func (s *Server) handleSwapVoucherReverse(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected providerTxId", nil)
+		return
+	}
+	var providerTxID string
+	if err := json.Unmarshal(req.Params[0], &providerTxID); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid providerTxId", err.Error())
+		return
+	}
+	trimmed := strings.TrimSpace(providerTxID)
+	if trimmed == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "providerTxId required", nil)
+		return
+	}
+	err := s.node.SwapReverseVoucher(trimmed)
+	if err != nil {
+		switch {
+		case errors.Is(err, core.ErrSwapVoucherAlreadyReversed):
+			writeResult(w, req.ID, map[string]bool{"ok": true})
+			return
+		case errors.Is(err, core.ErrSwapVoucherNotMinted):
+			writeError(w, http.StatusConflict, req.ID, codeInvalidParams, err.Error(), nil)
+			return
+		case errors.Is(err, core.ErrSwapReversalInsufficientBalance):
+			writeError(w, http.StatusConflict, req.ID, codeInvalidParams, err.Error(), nil)
+			return
+		default:
+			if strings.Contains(err.Error(), "not found") {
+				writeError(w, http.StatusNotFound, req.ID, codeInvalidParams, err.Error(), trimmed)
+				return
+			}
+			writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "failed to reverse voucher", err.Error())
+			return
+		}
+	}
+	writeResult(w, req.ID, map[string]bool{"ok": true})
+}

--- a/rpc/swap_admin_handlers_test.go
+++ b/rpc/swap_admin_handlers_test.go
@@ -1,0 +1,214 @@
+package rpc
+
+import (
+	"encoding/json"
+	"math/big"
+	"net/http/httptest"
+	"testing"
+
+	nhbstate "nhbchain/core/state"
+	"nhbchain/crypto"
+	swap "nhbchain/native/swap"
+)
+
+type limitsResponse struct {
+	Address           string            `json:"address"`
+	Day               map[string]string `json:"day"`
+	Month             map[string]string `json:"month"`
+	DayRemainingWei   string            `json:"dayRemainingWei"`
+	MonthRemainingWei string            `json:"monthRemainingWei"`
+	Velocity          struct {
+		WindowSeconds uint64 `json:"windowSeconds"`
+		MaxMints      uint64 `json:"maxMints"`
+		Observed      int    `json:"observed"`
+		Remaining     int64  `json:"remaining"`
+	} `json:"velocity"`
+}
+
+func TestHandleSwapLimitsSuccess(t *testing.T) {
+	env := newTestEnv(t)
+	cfg := swap.Config{
+		AllowedFiat:        []string{"USD"},
+		MaxQuoteAgeSeconds: 120,
+		SlippageBps:        50,
+		OraclePriority:     []string{"manual"},
+		Risk: swap.RiskConfig{
+			PerAddressDailyCapWei:   "1000",
+			PerAddressMonthlyCapWei: "5000",
+			PerTxMinWei:             "1",
+			PerTxMaxWei:             "2000",
+			VelocityWindowSeconds:   600,
+			VelocityMaxMints:        5,
+			SanctionsCheckEnabled:   true,
+		},
+	}
+	env.node.SetSwapConfig(cfg)
+
+	key, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	addr := key.PubKey().Address().String()
+
+	req := &RPCRequest{ID: 1, Params: []json.RawMessage{marshalParam(t, addr)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapLimits(recorder, env.newRequest(), req)
+
+	raw, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	var resp limitsResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Address != addr {
+		t.Fatalf("expected address %s, got %s", addr, resp.Address)
+	}
+	if resp.Day["mintedWei"] != "0" {
+		t.Fatalf("expected day minted 0, got %s", resp.Day["mintedWei"])
+	}
+	if resp.Month["mintedWei"] != "0" {
+		t.Fatalf("expected month minted 0, got %s", resp.Month["mintedWei"])
+	}
+	if resp.DayRemainingWei != "1000" {
+		t.Fatalf("expected day remaining 1000, got %s", resp.DayRemainingWei)
+	}
+	if resp.MonthRemainingWei != "5000" {
+		t.Fatalf("expected month remaining 5000, got %s", resp.MonthRemainingWei)
+	}
+	if resp.Velocity.MaxMints != 5 || resp.Velocity.Remaining != 5 {
+		t.Fatalf("unexpected velocity payload: %+v", resp.Velocity)
+	}
+}
+
+func TestHandleSwapProviderStatus(t *testing.T) {
+	env := newTestEnv(t)
+	cfg := swap.Config{
+		AllowedFiat:        []string{"USD"},
+		MaxQuoteAgeSeconds: 120,
+		SlippageBps:        50,
+		OraclePriority:     []string{"manual"},
+		Providers:          swap.ProviderConfig{Allow: []string{"nowpayments"}},
+	}
+	env.node.SetSwapConfig(cfg)
+
+	req := &RPCRequest{ID: 2}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapProviderStatus(recorder, env.newRequest(), req)
+
+	raw, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	var payload struct {
+		Allow                 []string `json:"allow"`
+		LastOracleHealthCheck int64    `json:"lastOracleHealthCheck"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.Allow) != 1 || payload.Allow[0] != "nowpayments" {
+		t.Fatalf("unexpected allow list: %+v", payload.Allow)
+	}
+	if payload.LastOracleHealthCheck != 0 {
+		t.Fatalf("expected zero oracle health, got %d", payload.LastOracleHealthCheck)
+	}
+}
+
+func TestHandleSwapVoucherReverse(t *testing.T) {
+	env := newTestEnv(t)
+	minterKey, _ := crypto.GeneratePrivateKey()
+	var minterAddr [20]byte
+	copy(minterAddr[:], minterKey.PubKey().Address().Bytes())
+	configureSwapToken(t, env.node, minterAddr)
+
+	sinkKey, _ := crypto.GeneratePrivateKey()
+	var sinkAddr [20]byte
+	copy(sinkAddr[:], sinkKey.PubKey().Address().Bytes())
+	env.node.SetSwapRefundSink(sinkAddr)
+
+	recipientKey, _ := crypto.GeneratePrivateKey()
+	var recipient [20]byte
+	copy(recipient[:], recipientKey.PubKey().Address().Bytes())
+
+	amount := big.NewInt(250)
+	providerTxID := "order-1"
+
+	if err := env.node.WithState(func(m *nhbstate.Manager) error {
+		ledger := swap.NewLedger(m)
+		record := &swap.VoucherRecord{
+			Provider:      "nowpayments",
+			ProviderTxID:  providerTxID,
+			Token:         "ZNHB",
+			MintAmountWei: amount,
+			Recipient:     recipient,
+			Status:        swap.VoucherStatusMinted,
+		}
+		if err := ledger.Put(record); err != nil {
+			return err
+		}
+		return m.SetBalance(recipient[:], "ZNHB", new(big.Int).Set(amount))
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	req := &RPCRequest{ID: 3, Params: []json.RawMessage{marshalParam(t, providerTxID)}}
+	recorder := httptest.NewRecorder()
+	env.server.handleSwapVoucherReverse(recorder, env.newRequest(), req)
+
+	raw, rpcErr := decodeRPCResponse(t, recorder)
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	var okResp struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal(raw, &okResp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !okResp.OK {
+		t.Fatalf("expected ok response")
+	}
+
+	if err := env.node.WithState(func(m *nhbstate.Manager) error {
+		ledger := swap.NewLedger(m)
+		record, _, err := ledger.Get(providerTxID)
+		if err != nil {
+			return err
+		}
+		if record.Status != swap.VoucherStatusReversed {
+			t.Fatalf("expected reversed status, got %s", record.Status)
+		}
+		balance, err := m.Balance(recipient[:], "ZNHB")
+		if err != nil {
+			return err
+		}
+		if balance.Cmp(big.NewInt(0)) != 0 {
+			t.Fatalf("expected recipient balance 0, got %s", balance.String())
+		}
+		sinkBalance, err := m.Balance(sinkAddr[:], "ZNHB")
+		if err != nil {
+			return err
+		}
+		if sinkBalance.Cmp(amount) != 0 {
+			t.Fatalf("expected sink balance %s, got %s", amount.String(), sinkBalance.String())
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("verify state: %v", err)
+	}
+
+	recorder2 := httptest.NewRecorder()
+	env.server.handleSwapVoucherReverse(recorder2, env.newRequest(), req)
+	raw2, rpcErr2 := decodeRPCResponse(t, recorder2)
+	if rpcErr2 != nil {
+		t.Fatalf("unexpected rpc error on second call: %+v", rpcErr2)
+	}
+	if err := json.Unmarshal(raw2, &okResp); err != nil {
+		t.Fatalf("decode second response: %v", err)
+	}
+	if !okResp.OK {
+		t.Fatalf("expected ok response on idempotent call")
+	}
+}

--- a/rpc/swap_handlers.go
+++ b/rpc/swap_handlers.go
@@ -66,6 +66,17 @@ func (s *Server) handleSwapSubmitVoucher(w http.ResponseWriter, _ *http.Request,
 		switch {
 		case errors.Is(err, core.ErrSwapInvalidSigner):
 			writeError(w, http.StatusUnauthorized, req.ID, codeUnauthorized, err.Error(), nil)
+		case errors.Is(err, core.ErrSwapProviderNotAllowed):
+			writeError(w, http.StatusForbidden, req.ID, codeUnauthorized, err.Error(), nil)
+		case errors.Is(err, core.ErrSwapSanctioned):
+			writeError(w, http.StatusForbidden, req.ID, codeUnauthorized, err.Error(), nil)
+		case errors.Is(err, core.ErrSwapAmountBelowMinimum),
+			errors.Is(err, core.ErrSwapAmountAboveMaximum),
+			errors.Is(err, core.ErrSwapDailyCapExceeded),
+			errors.Is(err, core.ErrSwapMonthlyCapExceeded):
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		case errors.Is(err, core.ErrSwapVelocityExceeded):
+			writeError(w, http.StatusTooManyRequests, req.ID, codeRateLimited, err.Error(), nil)
 		case errors.Is(err, core.ErrSwapNonceUsed), errors.Is(err, core.ErrSwapDuplicateProviderTx):
 			writeError(w, http.StatusConflict, req.ID, codeDuplicateTx, err.Error(), voucher.OrderID)
 		case errors.Is(err, core.ErrSwapInvalidDomain),


### PR DESCRIPTION
## Summary
- add swap risk engine, provider allow list enforcement, sanctions hook, and voucher reversal handling with alerts
- expose admin RPCs and audit CLI for inspecting swap limits, provider status, and voucher reversals
- document risk controls, admin runbooks, and regulatory brief plus update API docs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4d09e9f6c832db8a7f4d34433ad75