### PR TITLE
NET-2A: add persistent node identity, signed handshake, and ping/pong keepalive

### DIFF
--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -50,6 +51,12 @@ func main() {
 	privKey, err := loadValidatorKey(cfg)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to load validator key: %v", err))
+	}
+
+	identityPath := filepath.Join(cfg.DataDir, "p2p", "node_key.json")
+	identity, err := p2p.LoadOrCreateIdentity(identityPath)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to load node identity: %v", err))
 	}
 
 	// 1. Create the core node.
@@ -111,8 +118,10 @@ func main() {
 		BanScore:         cfg.P2P.BanScore,
 		GreyScore:        cfg.P2P.GreyScore,
 		HandshakeTimeout: time.Duration(cfg.P2P.HandshakeTimeoutMs) * time.Millisecond,
+		PingInterval:     time.Duration(cfg.P2P.PingIntervalSeconds) * time.Second,
+		PingTimeout:      time.Duration(cfg.P2P.PingTimeoutSeconds) * time.Second,
 	}
-	p2pServer := p2p.NewServer(node, privKey, p2pCfg)
+	p2pServer := p2p.NewServer(node, identity.PrivateKey, p2pCfg)
 	node.SetP2PServer(p2pServer)
 
 	// 3. Create the BFT engine, passing the node (as NodeInterface) and P2P server (as Broadcaster).

--- a/config-local.toml
+++ b/config-local.toml
@@ -18,6 +18,8 @@ GreyScore = 50
 RateMsgsPerSec = 50
 Burst = 200
 HandshakeTimeoutMs = 5000
+PingIntervalSeconds = 30
+PingTimeoutSeconds = 90
 
 PeerBanSeconds = 900
 ReadTimeout = 90

--- a/config-peer.toml
+++ b/config-peer.toml
@@ -18,6 +18,8 @@ GreyScore = 50
 RateMsgsPerSec = 50
 Burst = 200
 HandshakeTimeoutMs = 5000
+PingIntervalSeconds = 30
+PingTimeoutSeconds = 90
 
 PeerBanSeconds = 900
 ReadTimeout = 90

--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,8 @@ GreyScore = 50
 RateMsgsPerSec = 50
 Burst = 200
 HandshakeTimeoutMs = 5000
+PingIntervalSeconds = 30
+PingTimeoutSeconds = 90
 
 PeerBanSeconds = 900
 ReadTimeout = 90

--- a/config/config.go
+++ b/config/config.go
@@ -47,17 +47,19 @@ type Config struct {
 
 // P2PSection captures nested configuration for the peer-to-peer subsystem.
 type P2PSection struct {
-	NetworkID          uint64   `toml:"NetworkId"`
-	MaxPeers           int      `toml:"MaxPeers"`
-	MaxInbound         int      `toml:"MaxInbound"`
-	MaxOutbound        int      `toml:"MaxOutbound"`
-	Bootnodes          []string `toml:"Bootnodes"`
-	PersistentPeers    []string `toml:"PersistentPeers"`
-	BanScore           int      `toml:"BanScore"`
-	GreyScore          int      `toml:"GreyScore"`
-	RateMsgsPerSec     float64  `toml:"RateMsgsPerSec"`
-	Burst              float64  `toml:"Burst"`
-	HandshakeTimeoutMs int      `toml:"HandshakeTimeoutMs"`
+	NetworkID           uint64   `toml:"NetworkId"`
+	MaxPeers            int      `toml:"MaxPeers"`
+	MaxInbound          int      `toml:"MaxInbound"`
+	MaxOutbound         int      `toml:"MaxOutbound"`
+	Bootnodes           []string `toml:"Bootnodes"`
+	PersistentPeers     []string `toml:"PersistentPeers"`
+	BanScore            int      `toml:"BanScore"`
+	GreyScore           int      `toml:"GreyScore"`
+	RateMsgsPerSec      float64  `toml:"RateMsgsPerSec"`
+	Burst               float64  `toml:"Burst"`
+	HandshakeTimeoutMs  int      `toml:"HandshakeTimeoutMs"`
+	PingIntervalSeconds int      `toml:"PingIntervalSeconds"`
+	PingTimeoutSeconds  int      `toml:"PingTimeoutSeconds"`
 }
 
 // PotsoConfig groups POTSO-specific configuration segments.

--- a/docs/networking/overview.md
+++ b/docs/networking/overview.md
@@ -1,0 +1,128 @@
+# Networking Overview
+
+This document captures the foundational pieces of the NHB peer-to-peer
+subsystem introduced in NET-2A.
+
+## Identity & NodeID
+
+Each node maintains a persistent secp256k1 identity stored on disk. By default
+`cmd/nhb` writes the key to `<DataDir>/p2p/node_key.json`, creating the directory
+on first run. The public component of this key is hashed with Keccak-256 to
+produce the node's canonical identifier:
+
+```
+nodeID = keccak256(uncompressedPubKey[1:]) // 0x-prefixed, lower-case hex
+```
+
+Loading (or generating) an identity is handled by `p2p.LoadOrCreateIdentity`. The
+helper returns both the private key and derived `NodeID`:
+
+```go
+identityPath := filepath.Join(cfg.DataDir, "p2p", "node_key.json")
+identity, err := p2p.LoadOrCreateIdentity(identityPath)
+if err != nil {
+        log.Fatalf("load node identity: %v", err)
+}
+log.Printf("nodeId=%s", identity.NodeID)
+```
+
+Persisting the identity allows subsequent restarts to present a stable node ID
+and signature key without manual key management.
+
+## Handshake v1
+
+The handshake is an authenticated JSON frame exchanged immediately after a TCP
+connection is established. Both peers transmit the following payload:
+
+| Field | Description |
+| ----- | ----------- |
+| `protoVersion` | Static protocol discriminator (`1`). |
+| `chainId` | Target chain identifier the node belongs to. |
+| `genesisHash` | Hex-encoded canonical genesis hash (32 bytes). |
+| `nodeId` | Sender's 0x-prefixed NodeID derived from its identity key. |
+| `nonce` | 32-byte random challenge encoded as hex. |
+| `clientVersion` | Free-form software/version string exposed via RPC. |
+| `sig` | 65-byte ECDSA signature covering the handshake digest. |
+
+The signature is produced with the sender's node identity over the digest
+outlined in [the security notes](./security.md). Peers reply with a
+`HANDSHAKE_ACK` message type once the frame validates, although the payload is
+the same as the initial `HANDSHAKE` frame.
+
+A minimal illustration of constructing the outbound message is shown below. It
+mirrors the logic in `p2p/handshake.go` and can be used for integration tests or
+other tooling:
+
+```go
+nonce := make([]byte, 32)
+if _, err := rand.Read(nonce); err != nil {
+        log.Fatal(err)
+}
+msg := struct {
+        Proto uint32 `json:"protoVersion"`
+        Chain uint64 `json:"chainId"`
+        Genesis string `json:"genesisHash"`
+        NodeID string `json:"nodeId"`
+        Nonce  string `json:"nonce"`
+        Client string `json:"clientVersion"`
+        Sig    string `json:"sig"`
+}{
+        Proto: 1,
+        Chain: cfg.ChainID,
+        Genesis: hex.EncodeToString(genesisBytes),
+        NodeID: identity.NodeID,
+        Nonce:  hex.EncodeToString(nonce),
+        Client: cfg.ClientVersion,
+}
+digestInput := bytes.Join([][]byte{
+        uint64ToBytes(msg.Chain),
+        genesisBytes,
+        nonce,
+        mustDecodeHex(msg.NodeID),
+}, nil)
+digest := crypto.Keccak256(digestInput)
+signature, err := ethcrypto.Sign(digest, identity.PrivateKey.PrivateKey)
+if err != nil {
+        log.Fatal(err)
+}
+msg.Sig = hex.EncodeToString(signature)
+```
+
+*Helper functions such as `uint64ToBytes` simply encode the integer into an
+8-byte big-endian buffer; the production code uses the same representation.*
+
+### Flow
+
+The handshake flow is intentionally symmetric and short:
+
+1. **Dialing** – initiate or accept a TCP connection.
+2. **Handshaking** – exchange the JSON frames above and validate the digest,
+   chain/genesis compatibility, and nonce replay window. A `HANDSHAKE_ACK`
+   message signals success once verification completes.
+3. **Connected** – both peers register the connection, start the read/write
+   loops, and enable keepalive pings.
+
+Failures at any stage immediately close the socket and increment the peer's
+reputation penalties. Handshake success snapshots the peer metadata for RPC
+exposure.
+
+## State Machine
+
+At a high level the peer lifecycle is:
+
+```
+Dialing  -->  Handshaking  -->  Connected
+   ^            |               |
+   |            v               v
+Reconnect   Reject/Ban      Keepalive
+```
+
+* **Dialing** – initiated either manually (`Connect`) or by the connection
+  manager.
+* **Handshaking** – performs the authenticated handshake exchange and enforces
+  policy (chain, genesis, signature, nonce replay).
+* **Connected** – schedules read/write loops, activates PING/PONG keepalive, and
+  feeds traffic into the application handler.
+
+Peers that violate protocol expectations during any phase are disconnected and
+optionally banned according to the configured reputation policy.

--- a/docs/networking/security.md
+++ b/docs/networking/security.md
@@ -1,0 +1,51 @@
+# Networking Security Notes
+
+The NET-2A handshake introduces a signed challenge to prevent spoofing and
+replay attacks while keeping the exchange lightweight.
+
+## Signed challenge
+
+For each handshake a node signs the digest:
+
+```
+digest = keccak256(
+    bigEndian(chainID) || genesisHash || nonce || remoteNodeID,
+)
+```
+
+* `chainID` is encoded as an 8-byte big-endian integer.
+* `genesisHash` is the raw 32-byte hash of the canonical genesis block.
+* `nonce` is a freshly generated 32-byte random value unique to this handshake.
+* `remoteNodeID` is the sender's advertised NodeID (from the perspective of the
+  verifying peer).
+
+Including the remote NodeID binds the signature to the identity being claimed,
+so any tampering with `nodeId` or swapping in a different identity invalidates
+`SigToPub` recovery. The random nonce ensures the signed material is unique per
+handshake, preventing replay even if the other fields remain constant.
+
+A direct translation of the digest computation is shown below:
+
+```go
+func handshakeDigest(chainID uint64, genesis, nonce []byte, nodeID string) ([]byte, error) {
+        var buf [8]byte
+        binary.BigEndian.PutUint64(buf[:], chainID)
+        idBytes, err := hex.DecodeString(strings.TrimPrefix(nodeID, "0x"))
+        if err != nil {
+                return nil, err
+        }
+        payload := bytes.Join([][]byte{buf[:], genesis, nonce, idBytes}, nil)
+        return ethcrypto.Keccak256(payload), nil
+}
+```
+
+## Replay window
+
+`Server` maintains an in-memory nonce guard that rejects any nonce observed in
+the last ten minutes (`handshakeReplayWindow`). This guard applies to both
+locally generated and remote nonces, providing a coarse replay window until the
+full anti-replay design (NET-2G) lands.
+
+In addition to nonce tracking, peers that fail handshake validation accrue
+reputation penalties and may be temporarily banned depending on the configured
+policy.

--- a/docs/p2p/handshake.md
+++ b/docs/p2p/handshake.md
@@ -1,5 +1,11 @@
 # NHB P2P Handshake
 
+> **Note**
+>
+> The NET-2A handshake is documented in detail under
+> [`docs/networking/overview.md`](../networking/overview.md). The material below
+> captures the earlier NET-1 design and is retained for historical reference.
+
 The NHB peer handshake provides mutual authentication, network compatibility
 checks, and Sybil resistance by binding node identities to funded wallets. All
 connections MUST complete the handshake before any protocol traffic is

--- a/p2p/identity.go
+++ b/p2p/identity.go
@@ -1,0 +1,123 @@
+package p2p
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"nhbchain/crypto"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// Identity encapsulates the persistent node identity material used by the P2P layer.
+type Identity struct {
+	PrivateKey *crypto.PrivateKey
+	NodeID     string
+}
+
+type identityDisk struct {
+	PrivateKey string `json:"privateKey"`
+}
+
+// LoadOrCreateIdentity reads a secp256k1 private key from disk, generating one if absent.
+// The resulting Identity contains the derived NodeID (keccak256 of the uncompressed
+// public key) encoded as a 0x-prefixed hex string.
+func LoadOrCreateIdentity(path string) (*Identity, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("identity path must be provided")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create identity directory: %w", err)
+	}
+
+	if data, err := os.ReadFile(path); err == nil {
+		return decodeIdentity(data)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("read identity file: %w", err)
+	}
+
+	privKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("generate identity key: %w", err)
+	}
+	encoded := identityDisk{PrivateKey: hex.EncodeToString(privKey.Bytes())}
+	payload, err := json.MarshalIndent(&encoded, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode identity: %w", err)
+	}
+	if err := os.WriteFile(path, payload, 0o600); err != nil {
+		return nil, fmt.Errorf("persist identity: %w", err)
+	}
+	return &Identity{PrivateKey: privKey, NodeID: deriveNodeID(privKey)}, nil
+}
+
+func decodeIdentity(data []byte) (*Identity, error) {
+	data = bytesTrimSpace(data)
+	if len(data) == 0 {
+		return nil, fmt.Errorf("identity file empty")
+	}
+	// Accept both raw hex and JSON for forwards compatibility.
+	if data[0] != '{' {
+		keyBytes, err := hex.DecodeString(strings.TrimSpace(string(data)))
+		if err != nil {
+			return nil, fmt.Errorf("decode legacy identity: %w", err)
+		}
+		privKey, err := crypto.PrivateKeyFromBytes(keyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse legacy identity key: %w", err)
+		}
+		return &Identity{PrivateKey: privKey, NodeID: deriveNodeID(privKey)}, nil
+	}
+
+	var stored identityDisk
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return nil, fmt.Errorf("decode identity JSON: %w", err)
+	}
+	raw, err := hex.DecodeString(strings.TrimSpace(stored.PrivateKey))
+	if err != nil {
+		return nil, fmt.Errorf("decode identity key material: %w", err)
+	}
+	privKey, err := crypto.PrivateKeyFromBytes(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse identity key: %w", err)
+	}
+	return &Identity{PrivateKey: privKey, NodeID: deriveNodeID(privKey)}, nil
+}
+
+func deriveNodeID(priv *crypto.PrivateKey) string {
+	if priv == nil {
+		return ""
+	}
+	return deriveNodeIDFromPub(priv.PubKey().PublicKey)
+}
+
+func deriveNodeIDFromPub(pub *ecdsa.PublicKey) string {
+	if pub == nil {
+		return ""
+	}
+	pubBytes := ethcrypto.FromECDSAPub(pub)
+	if len(pubBytes) == 0 {
+		return ""
+	}
+	hash := ethcrypto.Keccak256(pubBytes[1:])
+	return "0x" + hex.EncodeToString(hash)
+}
+
+func bytesTrimSpace(b []byte) []byte {
+	i := 0
+	for i < len(b) && (b[i] == ' ' || b[i] == '\n' || b[i] == '\t' || b[i] == '\r') {
+		i++
+	}
+	j := len(b)
+	for j > i && (b[j-1] == ' ' || b[j-1] == '\n' || b[j-1] == '\t' || b[j-1] == '\r') {
+		j--
+	}
+	return b[i:j]
+}

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -2,19 +2,25 @@ package p2p
 
 import (
 	"encoding/json"
+	"time"
+
 	"nhbchain/core/types"
 )
 
 // Constants for our P2P message types.
 const (
-	MsgTypeTx        byte = 0x01
-	MsgTypeBlock     byte = 0x02
-	MsgTypeGetStatus byte = 0x03
-	MsgTypeStatus    byte = 0x04
-	MsgTypeGetBlocks byte = 0x05
-	MsgTypeBlocks    byte = 0x06
-	MsgTypeProposal  byte = 0x07
-	MsgTypeVote      byte = 0x08
+	MsgTypeTx           byte = 0x01
+	MsgTypeBlock        byte = 0x02
+	MsgTypeGetStatus    byte = 0x03
+	MsgTypeStatus       byte = 0x04
+	MsgTypeGetBlocks    byte = 0x05
+	MsgTypeBlocks       byte = 0x06
+	MsgTypeProposal     byte = 0x07
+	MsgTypeVote         byte = 0x08
+	MsgTypePing         byte = 0x09
+	MsgTypePong         byte = 0x0A
+	MsgTypeHandshake    byte = 0x0B
+	MsgTypeHandshakeAck byte = 0x0C
 )
 
 // StatusPayload is the data sent in a status message.
@@ -30,6 +36,18 @@ type GetBlocksPayload struct {
 // BlocksPayload contains the blocks being sent in response.
 type BlocksPayload struct {
 	Blocks []*types.Block
+}
+
+// PingPayload is exchanged as a lightweight keepalive message.
+type PingPayload struct {
+	Nonce     uint64 `json:"nonce"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+// PongPayload acknowledges receipt of a ping message.
+type PongPayload struct {
+	Nonce     uint64 `json:"nonce"`
+	Timestamp int64  `json:"timestamp"`
 }
 
 // --- Message Creation Helpers ---
@@ -48,4 +66,22 @@ func NewBlockMessage(b *types.Block) (*Message, error) {
 		return nil, err
 	}
 	return &Message{Type: MsgTypeBlock, Payload: payload}, nil
+}
+
+// NewPingMessage builds a ping keepalive message using the provided nonce and timestamp.
+func NewPingMessage(nonce uint64, ts time.Time) (*Message, error) {
+	payload, err := json.Marshal(PingPayload{Nonce: nonce, Timestamp: ts.UnixNano()})
+	if err != nil {
+		return nil, err
+	}
+	return &Message{Type: MsgTypePing, Payload: payload}, nil
+}
+
+// NewPongMessage builds a pong response echoing the supplied nonce.
+func NewPongMessage(nonce uint64, ts time.Time) (*Message, error) {
+	payload, err := json.Marshal(PongPayload{Nonce: nonce, Timestamp: ts.UnixNano()})
+	if err != nil {
+		return nil, err
+	}
+	return &Message{Type: MsgTypePong, Payload: payload}, nil
 }


### PR DESCRIPTION
## Summary
- add a persistent node identity loader and use it for P2P startup
- refactor the handshake to sign node-bound digests, introduce ping/pong keepalive, and refresh tests
- document NET-2A identity and handshake behaviour while exposing the new P2P config knobs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4d87a75f8832d9f40959aee3ceb32