### PR TITLE
Implement PEX gossip with TTL and echo suppression

### DIFF
--- a/docs/networking/overview.md
+++ b/docs/networking/overview.md
@@ -133,6 +133,28 @@ Reconnect   Reject/Ban      Keepalive
 Peers that violate protocol expectations during any phase are disconnected and
 optionally banned according to the configured reputation policy.
 
+## Discovery Lifecycle
+
+Peer discovery progresses through a short pipeline before settling into the
+steady gossip mesh:
+
+```
+Seed Bootstrapping --> Authenticated Handshake --> PEX Gossip --> Steady-State Mesh
+        ^                                                      |
+        |------------------------------------------------------|
+```
+
+1. **Seed Bootstrapping** – the node dials the configured seed list and any
+   persisted peers from the peerstore, establishing an initial foothold.
+2. **Authenticated Handshake** – successful handshakes elevate peers into the
+   active set and record their addresses with fresh timestamps.
+3. **PEX Gossip** – connected peers exchange `PEX_REQUEST`/`PEX_ADDRESSES`
+   messages to learn about additional endpoints while enforcing the address
+   TTL window and deduplication rules.
+4. **Steady-State Mesh** – the connection manager maintains target counts by
+   recycling aged peers, periodically requesting PEX samples to replenish the
+   dial queue as nodes churn.
+
 ## Peerstore
 
 The NET-2B release introduces a durable peerstore backed by LevelDB. Every

--- a/docs/networking/pex.md
+++ b/docs/networking/pex.md
@@ -1,0 +1,72 @@
+# Peer Exchange (PEX)
+
+The NET-2D release introduces address gossip so that nodes can discover peers
+beyond the configured seeds. Peer Exchange (PEX) reuses the authenticated TCP
+transport and adds two lightweight message types: `PEX_REQUEST` and
+`PEX_ADDRESSES`.
+
+## Message Schemas
+
+### `PEX_REQUEST`
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `limit` | `int` | Upper bound on the number of addresses requested. Values are capped at `32`. |
+| `token` | `string` | Echo-suppression token supplied by the requester and reflected in the response. Empty values are replaced with a random 128-bit hex string. |
+
+### `PEX_ADDRESSES`
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `token` | `string` | Echo token copied from the request. Peers drop frames that reuse a previously seen token. |
+| `addresses[].addr` | `string` | Dialable `host:port` endpoint observed for the peer. |
+| `addresses[].nodeID` | `string` | 0x-prefixed, normalized NodeID associated with the address. |
+| `addresses[].lastSeen` | `time.Time` | Wall-clock timestamp (UTC) when the sender last confirmed the address. |
+
+## Selection, Deduplication & TTL
+
+When answering a `PEX_REQUEST` the responder walks its address book and applies
+the following filters in order:
+
+1. **Identity Deduplication** – the address book is keyed by `nodeID`, so a
+   peer can appear at most once in a response even if it was observed at multiple
+   endpoints. New observations replace the stored address.
+2. **Sanity Filtering** – the responder never returns its own identity, the
+   requester, or currently banned peers. Invalid `host:port` values are skipped
+   during ingestion.
+3. **TTL Window** – entries older than 60 minutes are expired. The check is a
+   simple `now - lastSeen > 60m` comparison performed whenever the address book
+   is pruned. Fresh observations reset the timestamp.
+4. **Limit Enforcement** – after filtering, the responder shuffles the working
+   set and truncates it to the caller's requested `limit` (defaulting to `32`).
+
+All addresses learned through PEX are persisted to the peerstore with
+`lastSeen` timestamps so the dialer can queue them even if the node restarts.
+
+## Echo Suppression
+
+Echo suppression prevents infinite gossip loops when peers request addresses
+from each other in quick succession. Each request carries a caller-supplied
+`token` that is mirrored back in the `PEX_ADDRESSES` response. The responder
+records the token and ignores any subsequent `PEX_ADDRESSES` frames from that
+peer that reuse the same token.
+
+The following diagrams illustrate a typical interaction:
+
+```
+A ---- PEX_REQUEST(token=t1) ----> B
+B ---- PEX_ADDRESSES(token=t1, {C}) --> A
+
+# Later, B receives an address gossip from C with token=t2 and forwards it.
+B ---- PEX_REQUEST(token=t2) ----> C
+C ---- PEX_ADDRESSES(token=t2, {D}) --> B
+B ---- PEX_ADDRESSES(token=t2, {D}) --> A  (allowed, new token)
+
+# Echo suppression example when a response loops back.
+A ---- PEX_REQUEST(token=t3) ----> B
+B ---- PEX_ADDRESSES(token=t3, {C}) --> A
+A ---- PEX_ADDRESSES(token=t3, {C}) --> B  (dropped: token already seen)
+```
+
+Tokens expire alongside address entries (60 minutes). Old tokens are pruned so
+genuine updates are accepted after the window elapses.

--- a/p2p/messages.go
+++ b/p2p/messages.go
@@ -1,0 +1,22 @@
+package p2p
+
+import "time"
+
+// PexRequestPayload asks a peer for recently seen addresses.
+type PexRequestPayload struct {
+	Limit int    `json:"limit"`
+	Token string `json:"token"`
+}
+
+// PexAddress captures a gossipable peer endpoint.
+type PexAddress struct {
+	Addr     string    `json:"addr"`
+	NodeID   string    `json:"nodeID"`
+	LastSeen time.Time `json:"lastSeen"`
+}
+
+// PexAddressesPayload contains the set of addresses returned for a request.
+type PexAddressesPayload struct {
+	Token     string       `json:"token"`
+	Addresses []PexAddress `json:"addresses"`
+}

--- a/p2p/pex.go
+++ b/p2p/pex.go
@@ -1,10 +1,295 @@
 package p2p
 
 import (
+	crand "crypto/rand"
+	"encoding/hex"
 	"fmt"
+	"math/rand"
 	"net"
 	"strings"
+	"sync"
+	"time"
 )
+
+const (
+	pexAddressTTL  = 60 * time.Minute
+	pexResponseMax = 32
+)
+
+type pexEntry struct {
+	Addr     string
+	NodeID   string
+	LastSeen time.Time
+}
+
+type sentToken struct {
+	token string
+	seen  time.Time
+}
+
+type pexPeer interface {
+	ID() string
+	Enqueue(*Message) error
+}
+
+type pexManager struct {
+	server *Server
+
+	ttl  time.Duration
+	max  int
+	mu   sync.Mutex
+	book map[string]*pexEntry
+
+	seenTokens map[string]time.Time
+	sentTokens map[string]sentToken
+}
+
+func newPexManager(server *Server) *pexManager {
+	mgr := &pexManager{
+		server:     server,
+		ttl:        pexAddressTTL,
+		max:        pexResponseMax,
+		book:       make(map[string]*pexEntry),
+		seenTokens: make(map[string]time.Time),
+		sentTokens: make(map[string]sentToken),
+	}
+	now := mgr.now()
+	for _, seed := range server.seeds {
+		if seed.NodeID == "" || seed.Address == "" {
+			continue
+		}
+		mgr.book[normalizeHex(seed.NodeID)] = &pexEntry{Addr: strings.TrimSpace(seed.Address), NodeID: normalizeHex(seed.NodeID), LastSeen: now}
+	}
+	return mgr
+}
+
+func (m *pexManager) now() time.Time {
+	if m.server != nil && m.server.now != nil {
+		return m.server.now()
+	}
+	return time.Now()
+}
+
+func (m *pexManager) pruneLocked(now time.Time) {
+	ttl := m.ttl
+	if ttl <= 0 {
+		return
+	}
+	for nodeID, entry := range m.book {
+		if now.Sub(entry.LastSeen) > ttl {
+			delete(m.book, nodeID)
+		}
+	}
+	for token, ts := range m.seenTokens {
+		if now.Sub(ts) > ttl {
+			delete(m.seenTokens, token)
+		}
+	}
+	for peerID, sent := range m.sentTokens {
+		if now.Sub(sent.seen) > ttl {
+			delete(m.sentTokens, peerID)
+		}
+	}
+}
+
+func (m *pexManager) generateToken() string {
+	var buf [16]byte
+	if _, err := crand.Read(buf[:]); err != nil {
+		return fmt.Sprintf("%d", m.now().UnixNano())
+	}
+	return hex.EncodeToString(buf[:])
+}
+
+func (m *pexManager) recordPeer(nodeID, addr string, seen time.Time) {
+	nodeID = normalizeHex(nodeID)
+	addr = strings.TrimSpace(addr)
+	if nodeID == "" || addr == "" {
+		return
+	}
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		return
+	}
+	now := m.now()
+	if seen.IsZero() {
+		seen = now
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pruneLocked(now)
+	entry := m.book[nodeID]
+	if entry == nil {
+		m.book[nodeID] = &pexEntry{Addr: addr, NodeID: nodeID, LastSeen: seen}
+		return
+	}
+	if seen.After(entry.LastSeen) {
+		entry.LastSeen = seen
+	}
+	if entry.Addr != addr {
+		entry.Addr = addr
+	}
+}
+
+func (m *pexManager) handleRequest(peer pexPeer, req PexRequestPayload) error {
+	if m == nil || peer == nil {
+		return nil
+	}
+	token := strings.TrimSpace(req.Token)
+	if token == "" {
+		token = m.generateToken()
+	}
+	now := m.now()
+	limit := req.Limit
+	if limit <= 0 || limit > m.max {
+		limit = m.max
+	}
+	localID := ""
+	if m.server != nil {
+		localID = normalizeHex(m.server.nodeID)
+	}
+	peerID := normalizeHex(peer.ID())
+
+	m.mu.Lock()
+	m.pruneLocked(now)
+	addrs := make([]PexAddress, 0, limit)
+	for _, entry := range m.book {
+		if entry == nil {
+			continue
+		}
+		if entry.NodeID == "" || entry.Addr == "" {
+			continue
+		}
+		if entry.NodeID == peerID || (localID != "" && entry.NodeID == localID) {
+			continue
+		}
+		if m.server != nil && m.server.isBanned(entry.NodeID) {
+			continue
+		}
+		if now.Sub(entry.LastSeen) > m.ttl {
+			continue
+		}
+		addrs = append(addrs, PexAddress{Addr: entry.Addr, NodeID: entry.NodeID, LastSeen: entry.LastSeen})
+	}
+	if len(addrs) > 1 {
+		rand.Shuffle(len(addrs), func(i, j int) {
+			addrs[i], addrs[j] = addrs[j], addrs[i]
+		})
+	}
+	if len(addrs) > limit {
+		addrs = addrs[:limit]
+	}
+	m.seenTokens[token] = now
+	m.sentTokens[peer.ID()] = sentToken{token: token, seen: now}
+	m.mu.Unlock()
+
+	payload := PexAddressesPayload{Token: token, Addresses: addrs}
+	msg, err := NewPexAddressesMessage(payload)
+	if err != nil {
+		return err
+	}
+	return peer.Enqueue(msg)
+}
+
+func (m *pexManager) handleAddresses(peer pexPeer, payload PexAddressesPayload) {
+	if m == nil || peer == nil {
+		return
+	}
+	now := m.now()
+	token := strings.TrimSpace(payload.Token)
+	localID := ""
+	if m.server != nil {
+		localID = normalizeHex(m.server.nodeID)
+	}
+	peerID := normalizeHex(peer.ID())
+
+	m.mu.Lock()
+	m.pruneLocked(now)
+	if token != "" {
+		if sent, ok := m.sentTokens[peer.ID()]; ok && sent.token == token {
+			delete(m.sentTokens, peer.ID())
+			m.mu.Unlock()
+			return
+		}
+		if seen, ok := m.seenTokens[token]; ok && now.Sub(seen) <= m.ttl {
+			m.mu.Unlock()
+			return
+		}
+		m.seenTokens[token] = now
+	}
+
+	newEntries := make([]pexEntry, 0, len(payload.Addresses))
+	for _, addr := range payload.Addresses {
+		nodeID := normalizeHex(addr.NodeID)
+		endpoint := strings.TrimSpace(addr.Addr)
+		if nodeID == "" || endpoint == "" {
+			continue
+		}
+		if _, _, err := net.SplitHostPort(endpoint); err != nil {
+			continue
+		}
+		if localID != "" && nodeID == localID {
+			continue
+		}
+		if m.server != nil && m.server.isBanned(nodeID) {
+			continue
+		}
+		if nodeID == peerID {
+			continue
+		}
+		lastSeen := addr.LastSeen
+		if lastSeen.IsZero() {
+			lastSeen = now
+		}
+		if now.Sub(lastSeen) > m.ttl {
+			continue
+		}
+		entry := m.book[nodeID]
+		if entry == nil {
+			entry = &pexEntry{NodeID: nodeID, Addr: endpoint, LastSeen: lastSeen}
+			m.book[nodeID] = entry
+			newEntries = append(newEntries, *entry)
+			continue
+		}
+		updated := false
+		if lastSeen.After(entry.LastSeen) {
+			entry.LastSeen = lastSeen
+			updated = true
+		}
+		if entry.Addr != endpoint {
+			entry.Addr = endpoint
+			updated = true
+		}
+		if updated {
+			newEntries = append(newEntries, *entry)
+		}
+	}
+	m.mu.Unlock()
+
+	if len(newEntries) == 0 {
+		return
+	}
+	for _, entry := range newEntries {
+		m.persist(entry)
+	}
+}
+
+func (m *pexManager) forgetPeer(id string) {
+	if m == nil || id == "" {
+		return
+	}
+	m.mu.Lock()
+	delete(m.sentTokens, id)
+	m.mu.Unlock()
+}
+
+func (m *pexManager) persist(entry pexEntry) {
+	if m.server == nil || m.server.peerstore == nil {
+		return
+	}
+	rec := PeerstoreEntry{Addr: entry.Addr, NodeID: entry.NodeID, LastSeen: entry.LastSeen}
+	if err := m.server.peerstore.Put(rec); err != nil {
+		fmt.Printf("persist learned peer %s: %v\n", entry.NodeID, err)
+	}
+}
 
 type seedEndpoint struct {
 	NodeID  string
@@ -29,16 +314,17 @@ func parseSeedList(values []string) []seedEndpoint {
 			fmt.Printf("Ignoring seed %q: empty node ID\n", trimmed)
 			continue
 		}
-		if _, _, err := net.SplitHostPort(strings.TrimSpace(addrPart)); err != nil {
+		addr := strings.TrimSpace(addrPart)
+		if _, _, err := net.SplitHostPort(addr); err != nil {
 			fmt.Printf("Ignoring seed %q: invalid address: %v\n", trimmed, err)
 			continue
 		}
-		key := node + "@" + strings.TrimSpace(addrPart)
+		key := node + "@" + addr
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
-		seeds = append(seeds, seedEndpoint{NodeID: node, Address: strings.TrimSpace(addrPart)})
+		seeds = append(seeds, seedEndpoint{NodeID: node, Address: addr})
 	}
 	return seeds
 }

--- a/p2p/pex_test.go
+++ b/p2p/pex_test.go
@@ -1,0 +1,102 @@
+package p2p
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+type mockPexPeer struct {
+	id   string
+	sent []*Message
+}
+
+func (m *mockPexPeer) ID() string {
+	return m.id
+}
+
+func (m *mockPexPeer) Enqueue(msg *Message) error {
+	m.sent = append(m.sent, msg)
+	return nil
+}
+
+func TestPexRequestDedupesByNode(t *testing.T) {
+	now := time.Now()
+	server := &Server{nodeID: "0xaaaa", now: func() time.Time { return now }}
+	mgr := newPexManager(server)
+
+	mgr.recordPeer("0xdead", "10.0.0.2:26656", now.Add(-time.Minute))
+	mgr.recordPeer("0xdead", "10.0.0.3:26656", now)
+
+	peer := &mockPexPeer{id: "0xbeef"}
+	if err := mgr.handleRequest(peer, PexRequestPayload{Limit: 8, Token: "tok"}); err != nil {
+		t.Fatalf("handleRequest failed: %v", err)
+	}
+	if len(peer.sent) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(peer.sent))
+	}
+
+	var payload PexAddressesPayload
+	if err := json.Unmarshal(peer.sent[0].Payload, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if len(payload.Addresses) != 1 {
+		t.Fatalf("expected 1 address, got %d", len(payload.Addresses))
+	}
+	got := payload.Addresses[0]
+	if got.NodeID != "0xdead" {
+		t.Fatalf("unexpected node id: %s", got.NodeID)
+	}
+	if got.Addr != "10.0.0.3:26656" {
+		t.Fatalf("expected latest addr, got %s", got.Addr)
+	}
+}
+
+func TestPexRequestFiltersExpired(t *testing.T) {
+	now := time.Now()
+	server := &Server{nodeID: "0xaaaa", now: func() time.Time { return now }}
+	mgr := newPexManager(server)
+
+	mgr.recordPeer("0xdead", "10.0.0.2:26656", now.Add(-2*pexAddressTTL))
+
+	peer := &mockPexPeer{id: "0xbeef"}
+	if err := mgr.handleRequest(peer, PexRequestPayload{Limit: 8, Token: "tok"}); err != nil {
+		t.Fatalf("handleRequest failed: %v", err)
+	}
+	if len(peer.sent) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(peer.sent))
+	}
+
+	var payload PexAddressesPayload
+	if err := json.Unmarshal(peer.sent[0].Payload, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if len(payload.Addresses) != 0 {
+		t.Fatalf("expected no addresses, got %d", len(payload.Addresses))
+	}
+}
+
+func TestPexEchoSuppressionPreventsLoop(t *testing.T) {
+	now := time.Now()
+	server := &Server{nodeID: "0xaaaa", now: func() time.Time { return now }}
+	mgr := newPexManager(server)
+
+	mgr.recordPeer("0xdead", "10.0.0.2:26656", now)
+
+	peer := &mockPexPeer{id: "0xbeef"}
+	if err := mgr.handleRequest(peer, PexRequestPayload{Limit: 8, Token: "loop"}); err != nil {
+		t.Fatalf("handleRequest failed: %v", err)
+	}
+
+	mgr.handleAddresses(peer, PexAddressesPayload{
+		Token:     "loop",
+		Addresses: []PexAddress{{NodeID: "0xfeed", Addr: "10.1.0.5:26656", LastSeen: now}},
+	})
+
+	mgr.mu.Lock()
+	_, exists := mgr.book["0xfeed"]
+	mgr.mu.Unlock()
+	if exists {
+		t.Fatalf("echo suppression failed: looped address stored")
+	}
+}

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -21,6 +21,8 @@ const (
 	MsgTypePong         byte = 0x0A
 	MsgTypeHandshake    byte = 0x0B
 	MsgTypeHandshakeAck byte = 0x0C
+	MsgTypePexRequest   byte = 0x0D
+	MsgTypePexAddresses byte = 0x0E
 )
 
 // StatusPayload is the data sent in a status message.
@@ -84,4 +86,22 @@ func NewPongMessage(nonce uint64, ts time.Time) (*Message, error) {
 		return nil, err
 	}
 	return &Message{Type: MsgTypePong, Payload: payload}, nil
+}
+
+// NewPexRequestMessage builds a peer exchange request using the provided limit and token.
+func NewPexRequestMessage(limit int, token string) (*Message, error) {
+	payload, err := json.Marshal(PexRequestPayload{Limit: limit, Token: token})
+	if err != nil {
+		return nil, err
+	}
+	return &Message{Type: MsgTypePexRequest, Payload: payload}, nil
+}
+
+// NewPexAddressesMessage builds a peer exchange response message.
+func NewPexAddressesMessage(payload PexAddressesPayload) (*Message, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &Message{Type: MsgTypePexAddresses, Payload: data}, nil
 }


### PR DESCRIPTION
## Summary
- add peer exchange message types and manager to deduplicate addresses with TTL and echo suppression tokens
- integrate the server and peer loops to service PEX requests and persist learned peers
- document the PEX protocol and extend the networking overview with the discovery lifecycle

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d54f24506c832d9411e3ca6e2837a5