### PR TITLE
Fix PEX address propagation and stabilize mesh test

### DIFF
--- a/docs/networking/overview.md
+++ b/docs/networking/overview.md
@@ -155,6 +155,29 @@ Seed Bootstrapping --> Authenticated Handshake --> PEX Gossip --> Steady-State M
    recycling aged peers, periodically requesting PEX samples to replenish the
    dial queue as nodes churn.
 
+### Steady-State Mini Mesh (NET-2H)
+
+The NET-2H milestone validates the discovery loop by forming a three-node mesh
+anchored by a seed and exercising peer exchange. The healthy nodes maintain
+bidirectional links while a fourth node advertising the wrong chain is rejected
+during the handshake. The steady-state topology is illustrated below:
+
+```mermaid
+graph LR
+    SeedN1[Seed N1]
+    N2[Node N2]
+    N3[Node N3]
+    Wrong[Node N4\nWrong Chain]
+
+    SeedN1 <--> N2
+    SeedN1 <--> N3
+    N2 <--> N3
+    Wrong -.-> SeedN1
+```
+
+Dashed edges represent rejected handshakes. Successful connections participate
+in the authenticated mesh, enabling PEX gossip and keepalive traffic.
+
 ## Peerstore
 
 The NET-2B release introduces a durable peerstore backed by LevelDB. Every

--- a/docs/networking/security.md
+++ b/docs/networking/security.md
@@ -46,6 +46,54 @@ the last ten minutes (`handshakeReplayWindow`). This guard applies to both
 locally generated and remote nonces, providing a coarse replay window until the
 full anti-replay design (NET-2G) lands.
 
+### Nonce guard internals
+
+The guard is implemented by `nonceGuard` (`p2p/nonce.go`). Each nonce is stored
+in an LRU list keyed by the raw hex string. When `Remember` is invoked:
+
+1. Entries older than the configured window are pruned from the tail of the list
+   (default: 10 minutes).
+2. If the nonce already exists it is treated as a replay and rejected.
+3. Otherwise a new record `{nonce, seenAt}` is inserted at the head of the list.
+
+The structure is effectively bounded by the number of handshakes observed within
+the ten minute window. Even at 1,000 handshakes per minute this amounts to ~10k
+entries, easily handled in memory. Operators can reduce the window with
+`P2P.HandshakeReplayWindow` once that configuration surface lands; until then the
+default offers conservative protection without noticeable memory pressure.
+
 In addition to nonce tracking, peers that fail handshake validation accrue
 reputation penalties and may be temporarily banned depending on the configured
 policy.
+
+## Ban reasons & operator guidance
+
+| Event | Trigger | Default action | Operator notes |
+| ----- | ------- | -------------- | -------------- |
+| Handshake violation | Chain/genesis mismatch, signature failure, nonce replay | Immediate ban for `PeerBanDuration` (15m default) and peerstore entry marked via `RecordViolation`. | Verify the remote `nodeId` and published chain parameters before unbanning. Persistent mismatches usually indicate misconfiguration or an attempted Sybil. |
+| Invalid message rate | >50% invalid messages within 5-frame window (`invalidRateThresholdPerc`) | Disconnect and ban if repeated; log `Protocol violation from <id>` with reason. | Inspect application logs for malformed payloads. If caused by a buggy release, roll back before whitelisting the peer. |
+| Per-peer rate limit | Message throughput exceeds configured `RateMsgsPerSec` | Disconnect, optionally ban if reputation drops below `BanScore`. | Increase per-peer rate limits only if the remote is a trusted bulk publisher. Otherwise the throttle prevents spam amplification. |
+| Global rate cap | Aggregate throughput exceeds `RateMsgsPerSec * MaxPeers` | Connection dropped (`global rate cap exceeded`) without banning. | Typically symptomatic of DDoS attempts. Raise global caps cautiously and monitor CPU load. |
+| Manual ban (`peerstore.SetBan`) | Operator action via tooling | Persisted until expiry. | Use to quarantine peers for investigative or legal reasons. Document ban rationale for future audits. |
+
+All bans honour the configured `PeerBanDuration` unless overridden by the
+peerstore entry. Persistent peers are re-dialled automatically once the ban
+expires.
+
+## Security event log taxonomy
+
+Operational logs form the primary audit trail for network policy decisions. The
+table below summarises the high-signal log messages emitted by the P2P layer:
+
+| Log snippet | Source | Meaning |
+| ----------- | ------ | ------- |
+| `Inbound connection from <addr> rejected: <err>` | `server.handleInbound` | Handshake failed. `err` contains specifics (chain mismatch, signature, timeout). |
+| `Protocol violation from <id>: <err> (score X)` | `handleProtocolViolation` | Peer sent malformed or unauthorized messages. Reputation adjusted accordingly. |
+| `Peer <id> exceeded rate limit (score X)` | `handleRateLimit` | Per-peer message rate exceeded allowance; connection dropped and potentially banned. |
+| `Dropping message from <id> due to global rate cap` | `handleRateLimit` (global) | The server hit its aggregate throughput budget and disconnected the peer without banning. |
+| `Peer <id> disconnected and banned: <reason>` | `removePeer` | Final disposition when a peer crosses the ban threshold. Includes the rationale recorded in reputation/peerstore. |
+| `Record handshake violation <id>: <err>` / `record handshake ban` | `markHandshakeViolation` | Persistence layer acknowledgement that the peer was banned for handshake faults. |
+
+Collect these messages alongside RPC access logs to produce a full audit trail.
+For production deployments forward them to a SIEM or long-term log store so that
+investigations can correlate P2P events with application-level symptoms.

--- a/p2p/handshake_test.go
+++ b/p2p/handshake_test.go
@@ -17,6 +17,8 @@ func TestHandshakeVerifySuccess(t *testing.T) {
 	local := NewServer(handler, mustKey(t), baseConfig(genesis))
 	remote := NewServer(handler, mustKey(t), baseConfig(genesis))
 
+	remote.addListenAddress("127.0.0.1:34567")
+
 	packet, err := remote.buildHandshake()
 	if err != nil {
 		t.Fatalf("build handshake: %v", err)
@@ -36,6 +38,12 @@ func TestHandshakeVerifySuccess(t *testing.T) {
 	}
 	if packet.nodeID != remote.nodeID {
 		t.Fatalf("expected nodeID %s got %s", remote.nodeID, packet.nodeID)
+	}
+	if len(packet.ListenAddrs) == 0 || packet.ListenAddrs[0] != "127.0.0.1:34567" {
+		t.Fatalf("expected listen address to be sanitized, got %v", packet.ListenAddrs)
+	}
+	if len(packet.addrs) != len(packet.ListenAddrs) {
+		t.Fatalf("expected cached listen addrs to mirror payload")
 	}
 }
 

--- a/p2p/integration/mesh_test.go
+++ b/p2p/integration/mesh_test.go
@@ -1,0 +1,284 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	"nhbchain/crypto"
+	"nhbchain/p2p"
+)
+
+type meshHandler struct{}
+
+func (meshHandler) HandleMessage(msg *p2p.Message) error { return nil }
+
+type testNode struct {
+	server *p2p.Server
+	store  *p2p.Peerstore
+}
+
+func TestMiniMeshIntegration(t *testing.T) {
+	genesis := bytes.Repeat([]byte{0xAB}, 32)
+
+	base := p2p.ServerConfig{
+		ChainID:          777,
+		GenesisHash:      genesis,
+		ClientVersion:    "mesh/test",
+		MaxPeers:         8,
+		MaxInbound:       8,
+		MaxOutbound:      8,
+		MinPeers:         3,
+		OutboundPeers:    3,
+		MaxMessageBytes:  1 << 16,
+		RateMsgsPerSec:   64,
+		RateBurst:        128,
+		HandshakeTimeout: time.Second,
+		DialBackoff:      50 * time.Millisecond,
+		MaxDialBackoff:   500 * time.Millisecond,
+		EnablePEX:        true,
+	}
+
+	key1 := mustKey(t)
+	key2 := mustKey(t)
+	key3 := mustKey(t)
+
+	id1 := nodeIDFromKey(key1)
+	id2 := nodeIDFromKey(key2)
+	id3 := nodeIDFromKey(key3)
+
+	n1Cfg := base
+	n1Cfg.ListenAddress = "127.0.0.1:37651"
+	n1Cfg.Seeds = []string{
+		fmt.Sprintf("%s@%s", id2, "127.0.0.1:37652"),
+		fmt.Sprintf("%s@%s", id3, "127.0.0.1:37653"),
+	}
+	n1 := newServerWithKey(t, "n1", n1Cfg, key1)
+
+	n2Cfg := base
+	n2Cfg.ListenAddress = "127.0.0.1:37652"
+	n2Cfg.ClientVersion = "mesh/test-n2"
+	n2Cfg.Seeds = []string{fmt.Sprintf("%s@%s", id1, n1Cfg.ListenAddress)}
+	n2 := newServerWithKey(t, "n2", n2Cfg, key2)
+
+	n3Cfg := base
+	n3Cfg.ListenAddress = "127.0.0.1:37653"
+	n3Cfg.ClientVersion = "mesh/test-n3"
+	n3Cfg.Seeds = []string{fmt.Sprintf("%s@%s", id1, n1Cfg.ListenAddress)}
+	n3 := newServerWithKey(t, "n3", n3Cfg, key3)
+
+	startServer(t, "n1", n1)
+	waitForListen(t, n1.server, n1Cfg.ListenAddress)
+	startServer(t, "n2", n2)
+	waitForListen(t, n2.server, n2Cfg.ListenAddress)
+	startServer(t, "n3", n3)
+	waitForListen(t, n3.server, n3Cfg.ListenAddress)
+
+	waitForPeer(t, n1.server, n2.server.NodeID())
+	waitForPeer(t, n1.server, n3.server.NodeID())
+	waitForPeer(t, n2.server, n1.server.NodeID())
+	waitForPeer(t, n3.server, n1.server.NodeID())
+
+	discoverPeerViaPEX(t, n2, n3.server.NodeID())
+	discoverPeerViaPEX(t, n3, n2.server.NodeID())
+
+	waitForNetPeer(t, n2.server, n3.server.NodeID())
+	waitForNetPeer(t, n3.server, n2.server.NodeID())
+
+	wrongCfg := base
+	wrongCfg.ListenAddress = "127.0.0.1:37654"
+	wrongCfg.ClientVersion = "mesh/test-wrong"
+	wrongCfg.ChainID = base.ChainID + 1
+	wrongKey := mustKey(t)
+	wrong := newServerWithKey(t, "wrong", wrongCfg, wrongKey)
+	t.Cleanup(func() {
+		if wrong.store != nil {
+			_ = wrong.store.Close()
+		}
+	})
+
+	if err := wrong.server.Connect(n1Cfg.ListenAddress); err == nil || !containsChainMismatch(err) {
+		t.Fatalf("expected chain mismatch during handshake, got %v", err)
+	}
+
+	ensureNoPeer(t, n1.server, wrong.server.NodeID())
+}
+
+func newServer(t *testing.T, name string, cfg p2p.ServerConfig) *testNode {
+	t.Helper()
+	key, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return newServerWithKey(t, name, cfg, key)
+}
+
+func newServerWithKey(t *testing.T, name string, cfg p2p.ServerConfig, key *crypto.PrivateKey) *testNode {
+	t.Helper()
+	server := p2p.NewServer(meshHandler{}, key, cfg)
+	dir := t.TempDir()
+	store, err := p2p.NewPeerstore(filepath.Join(dir, name+"-peers.db"), 20*time.Millisecond, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("peerstore: %v", err)
+	}
+	server.SetPeerstore(store)
+	return &testNode{server: server, store: store}
+}
+
+func startServer(t *testing.T, name string, node *testNode) *testNode {
+	t.Helper()
+	if node == nil {
+		t.Fatalf("startServer: node %s is nil", name)
+	}
+	go func() {
+		if err := node.server.Start(); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			t.Logf("server %s stopped: %v", name, err)
+		}
+	}()
+	return node
+}
+
+func waitForListen(t *testing.T, server *p2p.Server, expect string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	target := strings.ToLower(expect)
+	for time.Now().Before(deadline) {
+		addrs := server.ListenAddresses()
+		for _, addr := range addrs {
+			if strings.ToLower(addr) == target {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("server failed to bind %s", expect)
+}
+
+func waitForPeer(t *testing.T, server *p2p.Server, nodeID string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	target := strings.ToLower(strings.TrimSpace(nodeID))
+	for time.Now().Before(deadline) {
+		if hasPeer(server, target) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for peer %s", nodeID)
+}
+
+func waitForNetPeer(t *testing.T, server *p2p.Server, nodeID string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	target := strings.ToLower(strings.TrimSpace(nodeID))
+	for time.Now().Before(deadline) {
+		infos := server.NetPeers()
+		for _, info := range infos {
+			if strings.ToLower(strings.TrimSpace(info.NodeID)) == target && strings.EqualFold(info.State, "connected") {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("net_info missing connected peer %s", nodeID)
+}
+
+func ensureNoPeer(t *testing.T, server *p2p.Server, nodeID string) {
+	t.Helper()
+	peers := server.SnapshotPeers()
+	target := strings.ToLower(strings.TrimSpace(nodeID))
+	for _, peer := range peers {
+		if strings.ToLower(strings.TrimSpace(peer.NodeID)) == target {
+			t.Fatalf("unexpected peer %s registered", nodeID)
+		}
+	}
+}
+
+func hasPeer(server *p2p.Server, target string) bool {
+	for _, peer := range server.SnapshotPeers() {
+		if strings.ToLower(strings.TrimSpace(peer.NodeID)) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func containsChainMismatch(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "chain ID mismatch")
+}
+
+func discoverPeerViaPEX(t *testing.T, node *testNode, targetID string) {
+	t.Helper()
+	requestPEXSample(t, node, targetID)
+	if err := node.server.DialPeer(targetID); err != nil {
+		t.Fatalf("dialing discovered peer %s failed: %v", targetID, err)
+	}
+	waitForPeer(t, node.server, targetID)
+}
+
+func requestPEXSample(t *testing.T, node *testNode, targetID string) {
+	t.Helper()
+	if node == nil || node.server == nil {
+		t.Fatalf("requestPEXSample: node missing server")
+	}
+	tokenBase := fmt.Sprintf("mesh-%s", node.server.NodeID())
+	deadline := time.Now().Add(10 * time.Second)
+	normalized := strings.ToLower(strings.TrimSpace(targetID))
+	for time.Now().Before(deadline) {
+		if hasPeerstoreEntry(node.store, normalized) {
+			return
+		}
+		msg, err := p2p.NewPexRequestMessage(32, fmt.Sprintf("%s-%d", tokenBase, time.Now().UnixNano()))
+		if err == nil {
+			_ = node.server.Broadcast(msg)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if !hasPeerstoreEntry(node.store, normalized) {
+		t.Fatalf("peerstore missing PEX entry for %s", targetID)
+	}
+}
+
+func mustKey(t *testing.T) *crypto.PrivateKey {
+	t.Helper()
+	key, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return key
+}
+
+func nodeIDFromKey(key *crypto.PrivateKey) string {
+	if key == nil {
+		return ""
+	}
+	pub := &key.PrivateKey.PublicKey
+	pubBytes := ethcrypto.FromECDSAPub(pub)
+	if len(pubBytes) == 0 {
+		return ""
+	}
+	hash := ethcrypto.Keccak256(pubBytes[1:])
+	return "0x" + hex.EncodeToString(hash)
+}
+
+func hasPeerstoreEntry(store *p2p.Peerstore, target string) bool {
+	if store == nil {
+		return false
+	}
+	entries := store.Snapshot()
+	for _, entry := range entries {
+		if strings.ToLower(strings.TrimSpace(entry.NodeID)) == target {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- include sanitized listen addresses in the handshake and persist them for PEX and the peerstore
- update the handshake test suite to cover the advertised listen address metadata
- finish the mini mesh integration test and document the mini-mesh runbook, steady-state diagram, and security guidance

## Testing
- go test ./... -race

------
https://chatgpt.com/codex/tasks/task_e_68d5795a297c832d98cae365e3acc423