### PR TITLE
potso: add emissions schedule engine

### DIFF
--- a/consensus/potso/emissions/engine.go
+++ b/consensus/potso/emissions/engine.go
@@ -1,0 +1,73 @@
+package emissions
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+type Caps struct {
+	Global *big.Int
+	Epoch  *big.Int
+}
+
+type Engine struct {
+	schedule *Schedule
+	caps     Caps
+}
+
+func NewEngine(schedule *Schedule, caps Caps) (*Engine, error) {
+	if schedule == nil {
+		return nil, errors.New("emissions: schedule required")
+	}
+	if caps.Global != nil && caps.Global.Sign() < 0 {
+		return nil, errors.New("emissions: global cap cannot be negative")
+	}
+	if caps.Epoch != nil && caps.Epoch.Sign() < 0 {
+		return nil, errors.New("emissions: epoch cap cannot be negative")
+	}
+	return &Engine{schedule: schedule, caps: Caps{Global: copyBigInt(caps.Global), Epoch: copyBigInt(caps.Epoch)}}, nil
+}
+
+func copyBigInt(v *big.Int) *big.Int {
+	if v == nil {
+		return nil
+	}
+	return new(big.Int).Set(v)
+}
+
+func (e *Engine) PoolForEpoch(epoch uint64, mintedSoFar *big.Int) (*big.Int, *big.Int, error) {
+	if epoch == 0 {
+		return big.NewInt(0), copyBigInt(e.caps.Global), nil
+	}
+	if mintedSoFar != nil && mintedSoFar.Sign() < 0 {
+		return nil, nil, errors.New("emissions: minted total cannot be negative")
+	}
+	remaining := copyBigInt(e.caps.Global)
+	if remaining != nil {
+		if mintedSoFar != nil {
+			if mintedSoFar.Cmp(remaining) > 0 {
+				return nil, nil, fmt.Errorf("emissions: minted total %s exceeds global cap %s", mintedSoFar.String(), remaining.String())
+			}
+			remaining.Sub(remaining, mintedSoFar)
+		}
+	}
+	scheduled := e.schedule.AmountForEpoch(epoch)
+	pool := new(big.Int).Set(scheduled)
+	if e.caps.Epoch != nil && pool.Cmp(e.caps.Epoch) > 0 {
+		pool.Set(e.caps.Epoch)
+	}
+	if remaining != nil && pool.Cmp(remaining) > 0 {
+		pool.Set(remaining)
+	}
+	if pool.Sign() < 0 {
+		pool.SetInt64(0)
+	}
+	if remaining != nil {
+		remaining.Sub(remaining, pool)
+		if remaining.Sign() < 0 {
+			remaining.SetInt64(0)
+		}
+	}
+	return pool, remaining, nil
+}

--- a/consensus/potso/emissions/engine_test.go
+++ b/consensus/potso/emissions/engine_test.go
@@ -1,0 +1,34 @@
+package emissions
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestEnginePoolForEpoch(t *testing.T) {
+	schedule := &Schedule{entries: []scheduleEntry{{startEpoch: 1, amount: big.NewInt(100)}, {startEpoch: 5, amount: big.NewInt(50)}}}
+	engine, err := NewEngine(schedule, Caps{Global: big.NewInt(180), Epoch: big.NewInt(60)})
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+	pool, remaining, err := engine.PoolForEpoch(1, big.NewInt(0))
+	if err != nil {
+		t.Fatalf("pool epoch1: %v", err)
+	}
+	if pool.Cmp(big.NewInt(60)) != 0 {
+		t.Fatalf("expected epoch cap 60, got %s", pool)
+	}
+	if remaining.Cmp(big.NewInt(120)) != 0 {
+		t.Fatalf("remaining mismatch: %s", remaining)
+	}
+	pool, remaining, err = engine.PoolForEpoch(5, big.NewInt(60))
+	if err != nil {
+		t.Fatalf("pool epoch5: %v", err)
+	}
+	if pool.Cmp(big.NewInt(50)) != 0 {
+		t.Fatalf("expected schedule amount 50, got %s", pool)
+	}
+	if remaining.Cmp(big.NewInt(70)) != 0 {
+		t.Fatalf("remaining mismatch: %s", remaining)
+	}
+}

--- a/consensus/potso/emissions/schedule.go
+++ b/consensus/potso/emissions/schedule.go
@@ -1,0 +1,233 @@
+package emissions
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+const (
+	basisPoints uint32 = 10_000
+)
+
+type Schedule struct {
+	entries []scheduleEntry
+}
+
+type scheduleEntry struct {
+	startEpoch uint64
+	amount     *big.Int
+	decay      *decaySchedule
+}
+
+type decaySchedule struct {
+	mode     decayMode
+	ratioBps uint32
+	duration uint64
+	floor    *big.Int
+}
+
+type decayMode string
+
+const (
+	decayModeNone      decayMode = "none"
+	decayModeGeometric decayMode = "geometric"
+)
+
+type fileSchedule struct {
+	Entries []fileEntry `json:"entries" toml:"entries"`
+}
+
+type fileEntry struct {
+	StartEpoch uint64     `json:"startEpoch" toml:"startEpoch"`
+	Amount     string     `json:"amount" toml:"amount"`
+	Decay      *fileDecay `json:"decay" toml:"decay"`
+}
+
+type fileDecay struct {
+	Mode     string `json:"mode" toml:"mode"`
+	RatioBps uint32 `json:"ratioBps" toml:"ratioBps"`
+	Duration uint64 `json:"durationEpochs" toml:"durationEpochs"`
+	Floor    string `json:"floor" toml:"floor"`
+}
+
+func LoadSchedule(path string) (*Schedule, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("emissions: schedule path required")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("emissions: read schedule: %w", err)
+	}
+	var parsed fileSchedule
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".json":
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&parsed); err != nil {
+			return nil, fmt.Errorf("emissions: decode schedule json: %w", err)
+		}
+	case ".toml", ".tml":
+		meta, err := toml.DecodeReader(bytes.NewReader(data), &parsed)
+		if err != nil {
+			return nil, fmt.Errorf("emissions: decode schedule toml: %w", err)
+		}
+		if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+			return nil, fmt.Errorf("emissions: unknown schedule fields %v", undecoded)
+		}
+	default:
+		return nil, fmt.Errorf("emissions: unsupported schedule format %q", ext)
+	}
+	if len(parsed.Entries) == 0 {
+		return nil, errors.New("emissions: schedule requires at least one entry")
+	}
+	entries := make([]scheduleEntry, len(parsed.Entries))
+	for i := range parsed.Entries {
+		entry := parsed.Entries[i]
+		if entry.StartEpoch == 0 {
+			return nil, fmt.Errorf("emissions: entry %d startEpoch must be greater than zero", i)
+		}
+		amount, ok := new(big.Int).SetString(strings.TrimSpace(entry.Amount), 10)
+		if !ok {
+			return nil, fmt.Errorf("emissions: entry %d amount invalid", i)
+		}
+		if amount.Sign() < 0 {
+			return nil, fmt.Errorf("emissions: entry %d amount cannot be negative", i)
+		}
+		var decay *decaySchedule
+		if entry.Decay != nil {
+			parsedDecay, err := parseDecay(entry.Decay, i)
+			if err != nil {
+				return nil, err
+			}
+			decay = parsedDecay
+		}
+		entries[i] = scheduleEntry{startEpoch: entry.StartEpoch, amount: amount, decay: decay}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].startEpoch < entries[j].startEpoch
+	})
+	for i := 1; i < len(entries); i++ {
+		if entries[i].startEpoch == entries[i-1].startEpoch {
+			return nil, fmt.Errorf("emissions: duplicate startEpoch %d", entries[i].startEpoch)
+		}
+	}
+	return &Schedule{entries: entries}, nil
+}
+
+func parseDecay(spec *fileDecay, index int) (*decaySchedule, error) {
+	mode := decayMode(strings.ToLower(strings.TrimSpace(spec.Mode)))
+	switch mode {
+	case "", decayModeNone:
+		return nil, nil
+	case decayModeGeometric:
+	default:
+		return nil, fmt.Errorf("emissions: entry %d decay mode %q unsupported", index, spec.Mode)
+	}
+	if spec.RatioBps == 0 {
+		return nil, fmt.Errorf("emissions: entry %d decay ratioBps must be greater than zero", index)
+	}
+	if spec.RatioBps > basisPoints {
+		return nil, fmt.Errorf("emissions: entry %d decay ratioBps cannot exceed %d", index, basisPoints)
+	}
+	var floor *big.Int
+	if strings.TrimSpace(spec.Floor) != "" {
+		value, ok := new(big.Int).SetString(strings.TrimSpace(spec.Floor), 10)
+		if !ok {
+			return nil, fmt.Errorf("emissions: entry %d decay floor invalid", index)
+		}
+		if value.Sign() < 0 {
+			return nil, fmt.Errorf("emissions: entry %d decay floor cannot be negative", index)
+		}
+		floor = value
+	}
+	return &decaySchedule{
+		mode:     decayModeGeometric,
+		ratioBps: spec.RatioBps,
+		duration: spec.Duration,
+		floor:    floor,
+	}, nil
+}
+
+func (s *Schedule) AmountForEpoch(epoch uint64) *big.Int {
+	if s == nil || epoch == 0 {
+		return big.NewInt(0)
+	}
+	entry := s.lookup(epoch)
+	if entry == nil {
+		return big.NewInt(0)
+	}
+	amount := new(big.Int).Set(entry.amount)
+	if entry.decay == nil || epoch == entry.startEpoch {
+		return amount
+	}
+	switch entry.decay.mode {
+	case decayModeGeometric:
+		steps := epoch - entry.startEpoch
+		if entry.decay.duration > 0 && steps > entry.decay.duration {
+			steps = entry.decay.duration
+		}
+		result := applyGeometricDecay(amount, entry.decay.ratioBps, steps)
+		if entry.decay.floor != nil && result.Cmp(entry.decay.floor) < 0 {
+			result.Set(entry.decay.floor)
+		}
+		return result
+	default:
+		return amount
+	}
+}
+
+func (s *Schedule) lookup(epoch uint64) *scheduleEntry {
+	if len(s.entries) == 0 {
+		return nil
+	}
+	idx := sort.Search(len(s.entries), func(i int) bool {
+		return s.entries[i].startEpoch > epoch
+	})
+	if idx == 0 {
+		return nil
+	}
+	return &s.entries[idx-1]
+}
+
+func applyGeometricDecay(base *big.Int, ratioBps uint32, steps uint64) *big.Int {
+	if steps == 0 {
+		return new(big.Int).Set(base)
+	}
+	ratio := new(big.Rat).SetFrac(big.NewInt(int64(ratioBps)), big.NewInt(int64(basisPoints)))
+	value := new(big.Rat).SetInt(base)
+	factor := powRat(ratio, steps)
+	value.Mul(value, factor)
+	result := new(big.Int).Quo(value.Num(), value.Denom())
+	if result.Sign() < 0 {
+		result.SetInt64(0)
+	}
+	return result
+}
+
+func powRat(r *big.Rat, exp uint64) *big.Rat {
+	result := new(big.Rat).SetInt64(1)
+	if exp == 0 {
+		return result
+	}
+	base := new(big.Rat).Set(r)
+	for exp > 0 {
+		if exp&1 == 1 {
+			result.Mul(result, base)
+		}
+		exp >>= 1
+		if exp > 0 {
+			base.Mul(base, base)
+		}
+	}
+	return result
+}

--- a/consensus/potso/emissions/schedule_test.go
+++ b/consensus/potso/emissions/schedule_test.go
@@ -1,0 +1,54 @@
+package emissions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadScheduleJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "schedule.json")
+	payload := `{
+  "entries": [
+    {"startEpoch": 1, "amount": "1000000000000000000"},
+    {"startEpoch": 11, "amount": "500000000000000000", "decay": {"mode": "geometric", "ratioBps": 9000, "durationEpochs": 5, "floor": "10000000000000000"}}
+  ]
+}`
+	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write schedule: %v", err)
+	}
+	sched, err := LoadSchedule(path)
+	if err != nil {
+		t.Fatalf("load schedule: %v", err)
+	}
+	if got := sched.AmountForEpoch(0); got.Sign() != 0 {
+		t.Fatalf("epoch 0 expected zero, got %s", got)
+	}
+	if got := sched.AmountForEpoch(1); got.String() != "1000000000000000000" {
+		t.Fatalf("epoch 1 amount mismatch: %s", got)
+	}
+	if got := sched.AmountForEpoch(12); got.String() != "450000000000000000" {
+		t.Fatalf("epoch 12 amount mismatch: %s", got)
+	}
+	// Duration clamps decay to 5 steps, so epoch 30 should equal epoch 16.
+	if got := sched.AmountForEpoch(30); got.String() != "295245000000000000" {
+		t.Fatalf("epoch 30 amount mismatch: %s", got)
+	}
+}
+
+func TestLoadScheduleTOMLRejectUnknown(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "schedule.toml")
+	payload := `[[entries]]
+startEpoch = 1
+amount = "1"
+extra = 1
+`
+	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write schedule: %v", err)
+	}
+	if _, err := LoadSchedule(path); err == nil {
+		t.Fatalf("expected unknown field error")
+	}
+}


### PR DESCRIPTION
## Summary
- add deterministic emission schedule loader supporting JSON/TOML with geometric decay handling
- implement per-epoch emission engine with global/epoch cap enforcement helpers
- cover new logic with unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d5aceafae4832da6d1ae951af03213