### PR TITLE
Add POTSO observability metrics, dashboards, and alerts

### DIFF
--- a/core/events/potso_alert.go
+++ b/core/events/potso_alert.go
@@ -1,0 +1,25 @@
+package events
+
+import "nhbchain/core/types"
+
+const (
+	TypePotsoAlertInvariantViolation = "potso.alert.invariant_violation"
+)
+
+type PotsoInvariantViolation struct {
+	Kind    string
+	Details string
+}
+
+func (PotsoInvariantViolation) EventType() string { return TypePotsoAlertInvariantViolation }
+
+func (a PotsoInvariantViolation) Event() *types.Event {
+	attrs := map[string]string{}
+	if a.Kind != "" {
+		attrs["kind"] = a.Kind
+	}
+	if a.Details != "" {
+		attrs["details"] = a.Details
+	}
+	return &types.Event{Type: TypePotsoAlertInvariantViolation, Attributes: attrs}
+}

--- a/docs/potso/emissions.md
+++ b/docs/potso/emissions.md
@@ -1,0 +1,103 @@
+# POTSO Emissions Observability
+
+The POTSO emissions dashboards give operations, treasury, and integrations
+teams real-time insight into reward budgets, evidence processing, and webhook
+health. Each dashboard is backed by Prometheus metrics exposed by the node and
+can be imported directly into Grafana using the JSON exports stored in
+`observability/grafana/dashboards/`.
+
+## Dashboards
+
+### POTSO Overview
+
+* **Evidence Acceptance Rate** – `potso_evidence_accepted_total{type}` plotted
+  as a per-second rate to confirm reporters are submitting records at the
+  expected cadence. Sudden spikes or a single type dominating the graph should
+  trigger abuse investigations.
+* **Penalty Application Rate** – mirrors `potso_penalty_applied_total{type}`.
+  This should roughly track the evidence rate. Divergence indicates penalty
+  workers are lagging or rejecting submissions.
+* **Active Epoch Pool** – the `potso_epoch_pool` gauge confirms treasury
+  funding is sufficient for the current epoch.
+* **Webhook Failures** – derived from
+  `increase(potso_webhook_failures_total{destination}[1h])` to quickly identify
+  unhealthy delivery targets.
+* **Rounding Dust by Epoch** – the running total of
+  `potso_rounding_dust{epoch}` to catch rounding regressions.
+
+### POTSO Emissions & Caps
+
+* **Reward Emissions by Epoch** – view `potso_rewards_sum{epoch}` to verify the
+  expected emission curve.
+* **Emission Pool vs Remaining Budget** – overlays the live
+  `potso_epoch_pool` against the sum of `potso_rewards_sum`. When the remaining
+  budget drops below 10% the `POTSOEmissionCapApproach` alert fires.
+* **Rounding Dust Share** – calculates the proportion of dust relative to the
+  pool to ensure the carry-over invariant stays below operational thresholds.
+* **Penalty Pressure** – 15 minute increases of `potso_penalty_applied_total`
+  by type show whether penalty workers are saturated.
+
+### POTSO Rewards Pipeline
+
+* **Evidence Intake vs Penalties** – compares the 5 minute rate of evidence and
+  penalties to highlight backlog risk.
+* **Rewards vs Dust** – overlays per-epoch reward sums and rounding dust so
+  finance can confirm totals before publishing exports.
+* **Webhook Failure Rate** – tracks `rate(potso_webhook_failures_total[5m])` per
+  destination to reveal SLO breaches.
+* **Latest Reward Snapshot** – table view combining the latest reward total and
+  dust for each epoch. Use this to cross-check ledger exports prior to
+  settlement runs.
+
+## Alert Playbooks
+
+### POTSOEvidenceSpike & POTSOEvidenceDelta
+
+* **Trigger** – Evidence acceptance rate exceeds 10/sec for 5 minutes or more
+  than 300 submissions land in 10 minutes.
+* **Response** – Page the incident commander in #potso-ops. Verify reporter
+  addresses against the allow list and inspect the fraud heuristics service.
+  If legitimate, scale penalty workers. If abusive, temporarily block the
+  reporter and coordinate with governance to apply penalties.
+
+### POTSOFailedWebhookDelivery
+
+* **Trigger** – More than five webhook failures accumulate within five
+  minutes.
+* **Response** – Notify the integrations on-call engineer. Check dispatcher
+  logs for HTTP status codes, confirm downstream endpoints are reachable, and
+  pause retries if a partner is degraded to avoid flooding.
+
+### POTSOIdempotencyConflicts
+
+* **Trigger** – Any delivery labelled `destination="duplicate"` fails within
+  a 10 minute window.
+* **Response** – Escalate to the webhook consumer immediately. Confirm the
+  consumer is using the `deliveryId` as an idempotency key and that caches are
+  cleared. Rebuild the retry queue once the consumer acknowledges the fix.
+
+### POTSOEmissionCapApproach
+
+* **Trigger** – Remaining budget falls below 10% of the active epoch pool for
+  10 minutes.
+* **Response** – Page treasury operations. Audit recent reward configuration
+  changes, confirm treasury replenishment transfers are on schedule, and be
+  ready to halt reward settlements if the cap is about to breach.
+
+### POTSORoundingDustExceedsThreshold
+
+* **Trigger** – Rounding dust exceeds one token on any epoch for 10 minutes.
+* **Response** – Notify finance. Validate reward weight inputs, recalculate the
+  affected epochs, and confirm dust is rolling into the next pool as expected.
+  If dust is not draining, escalate to the core engineering lead.
+
+### POTSOCapInvariantBreach
+
+* **Trigger** – The sum of `potso_rewards_sum` exceeds `potso_epoch_pool`.
+* **Response** – Treat as a sev-0. Emit `potso.alert.invariant_violation` with
+  the breach details, stop payout processing, and page both treasury and core
+  engineering. Roll back the epoch or patch the reward config before resuming
+  settlements.
+
+Keeping these dashboards and playbooks up to date ensures emission invariants
+remain intact and incidents can be remediated quickly.

--- a/docs/potso/rewards-integration.md
+++ b/docs/potso/rewards-integration.md
@@ -145,6 +145,23 @@ Additional headers:
 * When handling ready events use the supplied export URLs and checksum to
   download and verify the ledger slice.
 
+### Webhook SLOs & Alert Thresholds
+
+The node exports `potso_webhook_failures_total{destination}` to measure
+delivery health. Operations enforce the following service levels:
+
+* **Availability SLO:** Successful deliveries ≥ 99.5% over 30 minutes. Alerts
+  fire when more than five failures accumulate in five minutes.
+* **Idempotency Guard:** Any failure labelled `destination="duplicate"`
+  indicates replay protection issues and pages integrations immediately.
+* **Latency Watch:** Downstream consumers should acknowledge requests within
+  five seconds. Repeated 5xx or timeout responses will be visible as failure
+  spikes on the Grafana dashboards.
+
+During incidents reference the POTSO Rewards Pipeline dashboard for per-target
+failure rates and follow the alert playbooks outlined in
+`docs/potso/emissions.md`.
+
 ### Signature Verification Example
 
 ```go

--- a/observability/alerts/alert_rules.yaml
+++ b/observability/alerts/alert_rules.yaml
@@ -1,0 +1,81 @@
+groups:
+  - name: potso-alerts
+    interval: 30s
+    rules:
+      - alert: POTSOEvidenceSpike
+        expr: sum(rate(potso_evidence_accepted_total[5m])) > 10
+        for: 5m
+        labels:
+          severity: warning
+          team: potso
+        annotations:
+          summary: "Evidence submissions surging"
+          description: |
+            Accepted evidence rate is {{ $value | printf "%.2f" }} per second averaged over 5 minutes.
+            Investigate reporters for coordinated abuse or underlying fraud detection drift.
+      - alert: POTSOEvidenceDelta
+        expr: sum(increase(potso_evidence_accepted_total[10m])) > 300
+        for: 0m
+        labels:
+          severity: critical
+          team: potso
+        annotations:
+          summary: "Evidence intake spike"
+          description: |
+            More than 300 evidence records accepted in the last 10 minutes.
+            Validate reporter lists and confirm penalty pipeline is keeping pace.
+      - alert: POTSOFailedWebhookDelivery
+        expr: sum(increase(potso_webhook_failures_total[5m])) > 5
+        for: 5m
+        labels:
+          severity: warning
+          team: potso-integrations
+        annotations:
+          summary: "Webhook delivery errors"
+          description: |
+            POTSO reward webhooks have {{ $value | printf "%.0f" }} failed deliveries in 5 minutes.
+            Check dispatcher logs and downstream webhook endpoints.
+      - alert: POTSOIdempotencyConflicts
+        expr: sum(increase(potso_webhook_failures_total{destination="duplicate"}[10m])) > 0
+        for: 0m
+        labels:
+          severity: critical
+          team: potso-integrations
+        annotations:
+          summary: "Idempotency conflict detected"
+          description: |
+            Duplicate webhook deliveries are being rejected by downstream services.
+            Ensure replay protection headers are honoured and queues are drained safely.
+      - alert: POTSOEmissionCapApproach
+        expr: (potso_epoch_pool - sum(potso_rewards_sum)) < 0.1 * potso_epoch_pool
+        for: 10m
+        labels:
+          severity: critical
+          team: potso
+        annotations:
+          summary: "Emission pool nearing cap"
+          description: |
+            Remaining epoch emission budget is below 10%% of the configured pool.
+            Confirm emission targets, treasury replenishment schedules, and consider slowing payouts.
+      - alert: POTSORoundingDustExceedsThreshold
+        expr: max(potso_rounding_dust) > 1
+        for: 10m
+        labels:
+          severity: warning
+          team: potso
+        annotations:
+          summary: "Reward rounding dust accumulating"
+          description: |
+            Rounding dust has exceeded 1 token on at least one epoch.
+            Check reward splits and confirm rounding mitigation is still active.
+      - alert: POTSOCapInvariantBreach
+        expr: sum(potso_rewards_sum) > potso_epoch_pool
+        for: 0m
+        labels:
+          severity: critical
+          team: potso
+        annotations:
+          summary: "Emission invariant breached"
+          description: |
+            Rewards distributed {{ $value | printf "%.2f" }} exceed the active epoch pool.
+            Broadcast potso.alert.invariant_violation, halt payouts, and page treasury operators immediately.

--- a/observability/grafana/dashboards/potso-emissions-and-caps.json
+++ b/observability/grafana/dashboards/potso-emissions-and-caps.json
@@ -1,0 +1,153 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0"},
+    {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0"},
+    {"type": "panel", "id": "timeseries", "name": "Time series", "version": "1.0.0"},
+    {"type": "panel", "id": "stat", "name": "Stat", "version": "1.0.0"}
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "mappings": [], "unit": "token"},
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"expr": "sum(potso_rewards_sum) by (epoch)", "legendFormat": "epoch {{epoch}}", "refId": "A"}
+      ],
+      "title": "Reward Emissions by Epoch",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "mappings": [], "unit": "token"},
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "potso_epoch_pool",
+          "legendFormat": "pool",
+          "refId": "A"
+        },
+        {
+          "expr": "potso_epoch_pool - sum(potso_rewards_sum)",
+          "legendFormat": "remaining",
+          "refId": "B"
+        }
+      ],
+      "title": "Emission Pool vs Remaining Budget",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "thresholds"}, "decimals": 2, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "#1F60C4", "value": null}, {"color": "#EAB839", "value": 0.2}, {"color": "#E24D42", "value": 0.5}]}, "unit": "percent"},
+        "overrides": []
+      },
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 9},
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "text": {"valueSize": 24},
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "clamp_min((sum(potso_rounding_dust) / ignoring(epoch) potso_epoch_pool), 0)",
+          "legendFormat": "dust",
+          "refId": "A"
+        }
+      ],
+      "title": "Rounding Dust Share",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "mappings": [], "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 16, "x": 8, "y": 9},
+      "id": 4,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "expr": "sum(increase(potso_penalty_applied_total[15m])) by (type)",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Penalty Pressure (15m)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["potso", "emissions"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "${DS_PROMETHEUS}"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-12h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "POTSO Emissions & Caps",
+  "uid": "potso-emissions",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/grafana/dashboards/potso-overview.json
+++ b/observability/grafana/dashboards/potso-overview.json
@@ -1,0 +1,225 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0"},
+    {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0"},
+    {"type": "panel", "id": "timeseries", "name": "Time series", "version": "1.0.0"},
+    {"type": "panel", "id": "stat", "name": "Stat", "version": "1.0.0"}
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "legend": {"calcs": ["max"], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(potso_evidence_accepted_total{type!\=""}[5m])) by (type)",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Evidence Acceptance Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "options": {
+        "legend": {"calcs": ["max"], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(potso_penalty_applied_total{type!\=""}[5m])) by (type)",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Penalty Application Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "token"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 10},
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "text": {},
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "potso_epoch_pool",
+          "legendFormat": "pool",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Epoch Pool",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 8, "x": 8, "y": 10},
+      "id": 4,
+      "options": {
+        "legend": {"calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(potso_webhook_failures_total{destination!\=""}[1h])) by (destination)",
+          "legendFormat": "{{destination}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Webhook Failures (1h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 8, "x": 16, "y": 10},
+      "id": 5,
+      "options": {
+        "legend": {"calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      },
+      "targets": [
+        {
+          "expr": "sum(potso_rounding_dust) by (epoch)",
+          "legendFormat": "epoch {{epoch}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Rounding Dust by Epoch",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["potso"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "${DS_PROMETHEUS}"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "POTSO Overview",
+  "uid": "potso-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/grafana/dashboards/potso-rewards-pipeline.json
+++ b/observability/grafana/dashboards/potso-rewards-pipeline.json
@@ -1,0 +1,169 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0"},
+    {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0"},
+    {"type": "panel", "id": "timeseries", "name": "Time series", "version": "1.0.0"},
+    {"type": "panel", "id": "table", "name": "Table", "version": "1.0.0"}
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "mappings": [], "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"expr": "sum(rate(potso_evidence_accepted_total[5m])) by (type)", "legendFormat": "accepted {{type}}", "refId": "A"},
+        {"expr": "sum(rate(potso_penalty_applied_total[5m])) by (type)", "legendFormat": "penalty {{type}}", "refId": "B"}
+      ],
+      "title": "Evidence Intake vs Penalties",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "mappings": [], "unit": "token"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "options": {"legend": {"calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom"}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {"expr": "sum(potso_rewards_sum) by (epoch)", "legendFormat": "epoch {{epoch}}", "refId": "A"},
+        {"expr": "sum(potso_rounding_dust) by (epoch)", "legendFormat": "dust {{epoch}}", "refId": "B"}
+      ],
+      "title": "Rewards vs Dust",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 10, "x": 0, "y": 9},
+      "id": 3,
+      "options": {
+        "legend": {"calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      },
+      "targets": [
+        {"expr": "sum(rate(potso_webhook_failures_total[5m])) by (destination)", "legendFormat": "{{destination}}", "refId": "A"}
+      ],
+      "title": "Webhook Failure Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]},
+          "unit": "token"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 14, "x": 10, "y": 9},
+      "id": 4,
+      "options": {
+        "footer": {"enable": false},
+        "frameIndex": 0,
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "expr": "label_replace(sum(potso_rewards_sum) by (epoch), \"epoch\", \"$1\", \"epoch\", \"(.*)\")",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "expr": "label_replace(sum(potso_rounding_dust) by (epoch), \"epoch\", \"$1\", \"epoch\", \"(.*)\")",
+          "format": "table",
+          "instant": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Latest Reward Snapshot",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "fields": {
+              "Value": ["Value", "Value"],
+              "epoch": ["epoch", "epoch"]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value": "rewards",
+              "Value 1": "rounding_dust"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["potso", "rewards"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "${DS_PROMETHEUS}"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "Datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "POTSO Rewards Pipeline",
+  "uid": "potso-rewards",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/metrics/potso.go
+++ b/observability/metrics/potso.go
@@ -1,0 +1,145 @@
+package metrics
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type PotsoMetrics struct {
+	evidenceAccepted *prometheus.CounterVec
+	penaltyApplied   *prometheus.CounterVec
+	epochPool        prometheus.Gauge
+	rewardsSum       *prometheus.GaugeVec
+	webhookFailures  *prometheus.CounterVec
+	roundingDust     *prometheus.GaugeVec
+}
+
+var (
+	potsoOnce     sync.Once
+	potsoRegistry *PotsoMetrics
+)
+
+func Potso() *PotsoMetrics {
+	potsoOnce.Do(func() {
+		potsoRegistry = &PotsoMetrics{
+			evidenceAccepted: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "potso_evidence_accepted_total",
+				Help: "Count of accepted evidence submissions by type.",
+			}, []string{"type"}),
+			penaltyApplied: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "potso_penalty_applied_total",
+				Help: "Count of penalty executions applied by type.",
+			}, []string{"type"}),
+			epochPool: prometheus.NewGauge(prometheus.GaugeOpts{
+				Name: "potso_epoch_pool",
+				Help: "Current token pool available for the active epoch.",
+			}),
+			rewardsSum: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Name: "potso_rewards_sum",
+				Help: "Total reward emissions per epoch.",
+			}, []string{"epoch"}),
+			webhookFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "potso_webhook_failures_total",
+				Help: "Number of failed webhook delivery attempts by destination.",
+			}, []string{"destination"}),
+			roundingDust: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Name: "potso_rounding_dust",
+				Help: "Cumulative rounding remainder recorded per epoch.",
+			}, []string{"epoch"}),
+		}
+		prometheus.MustRegister(
+			potsoRegistry.evidenceAccepted,
+			potsoRegistry.penaltyApplied,
+			potsoRegistry.epochPool,
+			potsoRegistry.rewardsSum,
+			potsoRegistry.webhookFailures,
+			potsoRegistry.roundingDust,
+		)
+	})
+	return potsoRegistry
+}
+
+func (m *PotsoMetrics) ObserveEvidenceAccepted(kind string) {
+	if m == nil {
+		return
+	}
+	if kind == "" {
+		kind = "unknown"
+	}
+	m.evidenceAccepted.WithLabelValues(kind).Inc()
+}
+
+func (m *PotsoMetrics) ObservePenaltyApplied(kind string) {
+	if m == nil {
+		return
+	}
+	if kind == "" {
+		kind = "unknown"
+	}
+	m.penaltyApplied.WithLabelValues(kind).Inc()
+}
+
+func (m *PotsoMetrics) SetEpochPool(amount float64) {
+	if m == nil {
+		return
+	}
+	m.epochPool.Set(amount)
+}
+
+func (m *PotsoMetrics) ObserveRewardsSum(epoch uint64, amount float64) {
+	if m == nil {
+		return
+	}
+	label := fmt.Sprintf("%d", epoch)
+	m.rewardsSum.WithLabelValues(label).Set(amount)
+}
+
+func (m *PotsoMetrics) ObserveRoundingDust(epoch uint64, dust float64) {
+	if m == nil {
+		return
+	}
+	label := fmt.Sprintf("%d", epoch)
+	m.roundingDust.WithLabelValues(label).Set(dust)
+}
+
+func (m *PotsoMetrics) IncWebhookFailure(destination string) {
+	if m == nil {
+		return
+	}
+	if destination == "" {
+		destination = "unknown"
+	}
+	m.webhookFailures.WithLabelValues(destination).Inc()
+}
+
+func (m *PotsoMetrics) InitRewardEpoch(epoch uint64) {
+	if m == nil {
+		return
+	}
+	label := fmt.Sprintf("%d", epoch)
+	m.rewardsSum.WithLabelValues(label).Add(0)
+	m.roundingDust.WithLabelValues(label).Set(0)
+}
+
+func (m *PotsoMetrics) InitEvidenceType(kind string) {
+	if m == nil {
+		return
+	}
+	if kind == "" {
+		kind = "unknown"
+	}
+	m.evidenceAccepted.WithLabelValues(kind).Add(0)
+	m.penaltyApplied.WithLabelValues(kind).Add(0)
+}
+
+func (m *PotsoMetrics) InitWebhookDestination(destination string) {
+	if m == nil {
+		return
+	}
+	if destination == "" {
+		destination = "unknown"
+	}
+	m.webhookFailures.WithLabelValues(destination).Add(0)
+}


### PR DESCRIPTION
## Summary
- add Prometheus instrumentation helpers for POTSO evidence, penalties, rewards, and webhook health
- publish Grafana dashboards and alertmanager rules for emissions monitoring and anomaly detection
- document dashboards, alert playbooks, and webhook SLO thresholds for operations teams

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d5b550f60c832d97bfe38fa87a091b