### PR TITLE
Add POTSO determinism E2E and fuzz tests

### DIFF
--- a/tests/e2e/potso_task3_test.go
+++ b/tests/e2e/potso_task3_test.go
@@ -1,0 +1,565 @@
+package e2e
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"testing"
+
+	"nhbchain/consensus/potso/evidence"
+	"nhbchain/consensus/potso/penalty"
+	"nhbchain/consensus/potso/rewards"
+	statebank "nhbchain/state/bank"
+	statepotso "nhbchain/state/potso"
+	"nhbchain/storage"
+)
+
+type operationPlan struct {
+	Evidence evidence.Evidence
+	Hash     [32]byte
+	Attempts []attemptPlan
+}
+
+type attemptPlan struct {
+	ReceivedAt int64
+	Context    penalty.Context
+}
+
+type epochPlan struct {
+	Number        uint64
+	Pool          *big.Int
+	NodeAAttempts []int
+	NodeBAttempts []int
+	NodeAOrder    []int
+	NodeBOrder    []int
+}
+
+type weightSeed struct {
+	Base    *big.Int
+	Current *big.Int
+}
+
+type opInstance struct {
+	Operation int
+	Attempt   int
+}
+
+type scenarioPlan struct {
+	Floor         *big.Int
+	Ceiling       *big.Int
+	Participants  [][20]byte
+	Initial       map[[20]byte]weightSeed
+	Operations    []operationPlan
+	Epochs        []epochPlan
+	NodeASequence []opInstance
+	NodeBSequence []opInstance
+}
+
+type pipelineSnapshot struct {
+	Weights    map[string]string            `json:"weights"`
+	Rewards    map[string]map[string]string `json:"rewards"`
+	Totals     map[string]string            `json:"totals"`
+	Dust       string                       `json:"dust"`
+	Deliveries map[string]deliverySnapshot  `json:"deliveries"`
+}
+
+type deliverySnapshot struct {
+	Address string `json:"address"`
+	Amount  string `json:"amount"`
+}
+
+type deliveryRecord struct {
+	Epoch    uint64
+	Address  string
+	Amount   string
+	Attempts int
+}
+
+type pipelineNode struct {
+	name         string
+	db           storage.Database
+	ledger       *statepotso.Ledger
+	penalty      *penalty.Engine
+	rewards      *rewards.Ledger
+	rounding     *rewards.RoundingBucket
+	exporter     *mockExporter
+	participants [][20]byte
+	totals       map[uint64]*big.Int
+	epochDust    map[uint64]*big.Int
+	records      map[[32]byte]*evidence.Record
+}
+
+type mockExporter struct {
+	deliveries   map[string]deliveryRecord
+	hadDuplicate bool
+}
+
+func TestPotsoTask3Determinism(t *testing.T) {
+	seeds := []int64{42, 1337, 9001}
+	updateGolden := os.Getenv("UPDATE_POTSO_GOLDEN") == "1"
+
+	for _, seed := range seeds {
+		plan, err := buildScenarioPlan(seed)
+		if err != nil {
+			t.Fatalf("seed %d: build plan: %v", seed, err)
+		}
+		nodeA, err := newPipelineNode("nodeA", plan)
+		if err != nil {
+			t.Fatalf("seed %d: nodeA init: %v", seed, err)
+		}
+		defer nodeA.close()
+		snapshotA, err := executePlan(nodeA, plan, plan.NodeASequence, func(ep epochPlan) []int { return ep.NodeAAttempts }, func(ep epochPlan) []int { return ep.NodeAOrder })
+		if err != nil {
+			t.Fatalf("seed %d: execute nodeA: %v", seed, err)
+		}
+		nodeB, err := newPipelineNode("nodeB", plan)
+		if err != nil {
+			t.Fatalf("seed %d: nodeB init: %v", seed, err)
+		}
+		defer nodeB.close()
+		snapshotB, err := executePlan(nodeB, plan, plan.NodeBSequence, func(ep epochPlan) []int { return ep.NodeBAttempts }, func(ep epochPlan) []int { return ep.NodeBOrder })
+		if err != nil {
+			t.Fatalf("seed %d: execute nodeB: %v", seed, err)
+		}
+		if !reflect.DeepEqual(snapshotA, snapshotB) {
+			aJSON, _ := json.Marshal(snapshotA)
+			bJSON, _ := json.Marshal(snapshotB)
+			t.Fatalf("seed %d: node snapshots diverged\nA=%s\nB=%s", seed, string(aJSON), string(bJSON))
+		}
+		if !nodeA.exporter.hadDuplicate && !nodeB.exporter.hadDuplicate {
+			t.Fatalf("seed %d: expected duplicate deliveries to be exercised", seed)
+		}
+		if err := compareWithGolden(seed, snapshotA, updateGolden); err != nil {
+			t.Fatalf("seed %d: %v", seed, err)
+		}
+	}
+}
+
+func buildScenarioPlan(seed int64) (scenarioPlan, error) {
+	rng := rand.New(rand.NewSource(seed))
+	participantCount := 4 + rng.Intn(3)
+	participants := make([][20]byte, participantCount)
+	seen := make(map[[20]byte]struct{}, participantCount)
+	for i := range participants {
+		var addr [20]byte
+		for {
+			for j := range addr {
+				addr[j] = byte(rng.Intn(256))
+			}
+			if _, ok := seen[addr]; !ok {
+				seen[addr] = struct{}{}
+				break
+			}
+		}
+		participants[i] = addr
+	}
+	floor := big.NewInt(int64(100 + rng.Intn(50)))
+	ceil := big.NewInt(int64(700 + rng.Intn(500)))
+	if ceil.Cmp(floor) <= 0 {
+		ceil = new(big.Int).Add(floor, big.NewInt(100))
+	}
+	initial := make(map[[20]byte]weightSeed, len(participants))
+	for _, addr := range participants {
+		base := big.NewInt(int64(500 + rng.Intn(400)))
+		current := new(big.Int).Sub(base, big.NewInt(int64(rng.Intn(150))))
+		if current.Cmp(floor) < 0 {
+			current = new(big.Int).Set(floor)
+		}
+		initial[addr] = weightSeed{Base: base, Current: current}
+	}
+	evidenceTypes := []evidence.Type{evidence.TypeDowntime, evidence.TypeEquivocation, evidence.TypeInvalidBlockProposal}
+	const baseTimestamp = int64(1_700_000_000)
+	opCount := 6 + rng.Intn(4)
+	operations := make([]operationPlan, opCount)
+	for i := 0; i < opCount; i++ {
+		typ := evidenceTypes[rng.Intn(len(evidenceTypes))]
+		offender := participants[rng.Intn(len(participants))]
+		heights := make([]uint64, 1+rng.Intn(3))
+		baseHeight := uint64(50 + rng.Intn(200))
+		for j := range heights {
+			heights[j] = baseHeight + uint64(rng.Intn(30))
+		}
+		details := make([]byte, 4)
+		for j := range details {
+			details[j] = byte(rng.Intn(256))
+		}
+		reporter := participants[rng.Intn(len(participants))]
+		evidence := evidence.Evidence{
+			Type:        typ,
+			Offender:    offender,
+			Heights:     heights,
+			Details:     append([]byte(nil), details...),
+			Reporter:    reporter,
+			ReporterSig: []byte{byte(i), byte(i + 1), byte(i + 2)},
+			Timestamp:   baseTimestamp + int64(rng.Intn(7200)),
+		}
+		hash, err := evidence.CanonicalHash()
+		if err != nil {
+			return scenarioPlan{}, err
+		}
+		attemptCount := 1 + rng.Intn(3)
+		attempts := make([]attemptPlan, attemptCount)
+		ctx := penalty.Context{
+			BlockHeight:  uint64(100 + rng.Intn(900)),
+			MissedEpochs: uint64(rng.Intn(4)),
+		}
+		if rng.Intn(4) == 0 {
+			ctx.BaseWeightOverride = big.NewInt(int64(400 + rng.Intn(200)))
+		}
+		for j := range attempts {
+			attempts[j] = attemptPlan{
+				ReceivedAt: baseTimestamp + int64(rng.Intn(7200)) + int64(j*5),
+				Context:    ctx,
+			}
+		}
+		operations[i] = operationPlan{Evidence: evidence, Hash: hash, Attempts: attempts}
+	}
+	duplicate := false
+	for _, op := range operations {
+		if len(op.Attempts) > 1 {
+			duplicate = true
+			break
+		}
+	}
+	if !duplicate {
+		op := &operations[0]
+		if len(op.Attempts) > 0 {
+			op.Attempts = append(op.Attempts, op.Attempts[0])
+		} else {
+			op.Attempts = []attemptPlan{{ReceivedAt: baseTimestamp + 10, Context: penalty.Context{BlockHeight: 10}}}
+		}
+	}
+	epochCount := 3
+	epochs := make([]epochPlan, epochCount)
+	for i := 0; i < epochCount; i++ {
+		pool := big.NewInt(int64(2000 + rng.Intn(2000)))
+		attemptsA := make([]int, len(participants))
+		attemptsB := make([]int, len(participants))
+		orderA := make([]int, len(participants))
+		orderB := make([]int, len(participants))
+		for j := range participants {
+			attemptsA[j] = 1 + rng.Intn(3)
+			attemptsB[j] = 1 + rng.Intn(3)
+			orderA[j] = j
+			orderB[j] = j
+		}
+		if attemptsA[0] < 2 {
+			attemptsA[0] = 2
+		}
+		if attemptsB[0] < 2 {
+			attemptsB[0] = 2
+		}
+		shuffle := rand.New(rand.NewSource(seed + int64(i)*97 + 12345))
+		shuffle.Shuffle(len(orderB), func(a, b int) { orderB[a], orderB[b] = orderB[b], orderB[a] })
+		epochs[i] = epochPlan{
+			Number:        uint64(i + 1),
+			Pool:          pool,
+			NodeAAttempts: attemptsA,
+			NodeBAttempts: attemptsB,
+			NodeAOrder:    append([]int(nil), orderA...),
+			NodeBOrder:    append([]int(nil), orderB...),
+		}
+	}
+	instances := make([]opInstance, 0)
+	for i, op := range operations {
+		for j := range op.Attempts {
+			instances = append(instances, opInstance{Operation: i, Attempt: j})
+		}
+	}
+	nodeA := append([]opInstance(nil), instances...)
+	sort.Slice(nodeA, func(i, j int) bool {
+		ai := operations[nodeA[i].Operation].Attempts[nodeA[i].Attempt].ReceivedAt
+		aj := operations[nodeA[j].Operation].Attempts[nodeA[j].Attempt].ReceivedAt
+		if ai == aj {
+			return nodeA[i].Operation < nodeA[j].Operation
+		}
+		return ai < aj
+	})
+	nodeB := append([]opInstance(nil), instances...)
+	shuffleOps := rand.New(rand.NewSource(seed ^ 0x517cc1b727220a95))
+	shuffleOps.Shuffle(len(nodeB), func(i, j int) { nodeB[i], nodeB[j] = nodeB[j], nodeB[i] })
+	return scenarioPlan{
+		Floor:         floor,
+		Ceiling:       ceil,
+		Participants:  participants,
+		Initial:       initial,
+		Operations:    operations,
+		Epochs:        epochs,
+		NodeASequence: nodeA,
+		NodeBSequence: nodeB,
+	}, nil
+}
+
+func newPipelineNode(name string, plan scenarioPlan) (*pipelineNode, error) {
+	db := storage.NewMemDB()
+	ledger, err := statepotso.NewLedger(plan.Floor, plan.Ceiling)
+	if err != nil {
+		return nil, fmt.Errorf("ledger: %w", err)
+	}
+	for addr, seed := range plan.Initial {
+		if _, err := ledger.Set(addr, seed.Base, seed.Current); err != nil {
+			return nil, fmt.Errorf("ledger seed: %w", err)
+		}
+	}
+	catalog, err := penalty.BuildCatalog(penalty.DefaultConfig())
+	if err != nil {
+		return nil, fmt.Errorf("catalog: %w", err)
+	}
+	engine := penalty.NewEngine(catalog, ledger, statebank.NewNoopSlasher(false))
+	node := &pipelineNode{
+		name:         name,
+		db:           db,
+		ledger:       ledger,
+		penalty:      engine,
+		rewards:      rewards.NewLedger(db),
+		rounding:     rewards.NewRoundingBucket(),
+		exporter:     newMockExporter(),
+		participants: append([][20]byte(nil), plan.Participants...),
+		totals:       make(map[uint64]*big.Int),
+		epochDust:    make(map[uint64]*big.Int),
+		records:      make(map[[32]byte]*evidence.Record),
+	}
+	return node, nil
+}
+
+func (n *pipelineNode) ingest(op operationPlan, attempt attemptPlan) error {
+	if _, exists := n.records[op.Hash]; exists {
+		return nil
+	}
+	record := &evidence.Record{Hash: op.Hash, Evidence: op.Evidence.Clone(), ReceivedAt: attempt.ReceivedAt}
+	n.records[op.Hash] = record
+	res, err := n.penalty.Apply(record, attempt.Context)
+	if err != nil {
+		return fmt.Errorf("penalty apply: %w", err)
+	}
+	if res == nil {
+		return fmt.Errorf("penalty result nil")
+	}
+	return nil
+}
+
+func (n *pipelineNode) settleEpoch(plan epochPlan, attempts []int, order []int) error {
+	weights := make([]rewards.WeightEntry, len(n.participants))
+	for i, addr := range n.participants {
+		entry := n.ledger.Entry(addr)
+		weights[i] = rewards.WeightEntry{Address: addr, Weight: entry.Value}
+	}
+	carry := n.rounding.Balance()
+	dist, err := rewards.SplitRewards(plan.Pool, weights, n.rounding)
+	if err != nil {
+		return fmt.Errorf("split rewards: %w", err)
+	}
+	allowance := new(big.Int).Add(plan.Pool, carry)
+	if dist.TotalAssigned.Cmp(allowance) > 0 {
+		return fmt.Errorf("assigned %s exceeds allowance %s", dist.TotalAssigned, allowance)
+	}
+	entries := make([]*rewards.RewardEntry, len(dist.Shares))
+	for i, share := range dist.Shares {
+		entries[i] = &rewards.RewardEntry{
+			Epoch:    plan.Number,
+			Address:  share.Address,
+			Amount:   new(big.Int).Set(share.Amount),
+			Currency: "ZNHB",
+		}
+		entries[i].Checksum = rewards.EntryChecksum(plan.Number, share.Address, share.Amount)
+	}
+	if err := n.rewards.PutBatch(entries); err != nil {
+		return fmt.Errorf("rewards ledger: %w", err)
+	}
+	n.totals[plan.Number] = new(big.Int).Set(dist.TotalAssigned)
+	n.epochDust[plan.Number] = new(big.Int).Set(dist.Dust)
+	if err := n.exporter.Deliver(entries, order, attempts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (n *pipelineNode) snapshot() (pipelineSnapshot, error) {
+	weights := make(map[string]string, len(n.participants))
+	for _, addr := range n.participants {
+		entry := n.ledger.Entry(addr)
+		weights[hex.EncodeToString(addr[:])] = entry.Value.String()
+	}
+	rewardsMap := map[string]map[string]string{}
+	entries, _, err := n.rewards.List(rewards.RewardFilter{})
+	if err != nil {
+		return pipelineSnapshot{}, fmt.Errorf("list rewards: %w", err)
+	}
+	for _, entry := range entries {
+		epochKey := fmt.Sprintf("%d", entry.Epoch)
+		bucket, ok := rewardsMap[epochKey]
+		if !ok {
+			bucket = map[string]string{}
+			rewardsMap[epochKey] = bucket
+		}
+		amount := "0"
+		if entry.Amount != nil {
+			amount = entry.Amount.String()
+		}
+		bucket[hex.EncodeToString(entry.Address[:])] = amount
+	}
+	totals := make(map[string]string, len(n.totals))
+	for epoch, total := range n.totals {
+		totals[fmt.Sprintf("%d", epoch)] = total.String()
+	}
+	snapshot := pipelineSnapshot{
+		Weights:    weights,
+		Rewards:    rewardsMap,
+		Totals:     totals,
+		Dust:       n.rounding.Balance().String(),
+		Deliveries: n.exporter.snapshot(),
+	}
+	return snapshot, nil
+}
+
+func (n *pipelineNode) close() {
+	if n == nil || n.db == nil {
+		return
+	}
+	n.db.Close()
+}
+
+func executePlan(node *pipelineNode, plan scenarioPlan, sequence []opInstance, attemptSel func(epochPlan) []int, orderSel func(epochPlan) []int) (pipelineSnapshot, error) {
+	for _, inst := range sequence {
+		op := plan.Operations[inst.Operation]
+		if inst.Attempt >= len(op.Attempts) {
+			return pipelineSnapshot{}, fmt.Errorf("invalid attempt index")
+		}
+		if err := node.ingest(op, op.Attempts[inst.Attempt]); err != nil {
+			return pipelineSnapshot{}, err
+		}
+	}
+	for _, epoch := range plan.Epochs {
+		attempts := append([]int(nil), attemptSel(epoch)...)
+		order := append([]int(nil), orderSel(epoch)...)
+		if len(order) != len(node.participants) {
+			return pipelineSnapshot{}, fmt.Errorf("invalid order length")
+		}
+		if err := node.settleEpoch(epoch, attempts, order); err != nil {
+			return pipelineSnapshot{}, err
+		}
+	}
+	return node.snapshot()
+}
+
+func newMockExporter() *mockExporter {
+	return &mockExporter{deliveries: map[string]deliveryRecord{}}
+}
+
+func (m *mockExporter) Deliver(entries []*rewards.RewardEntry, order []int, attempts []int) error {
+	for _, idx := range order {
+		if idx < 0 || idx >= len(entries) {
+			return fmt.Errorf("invalid delivery order index %d", idx)
+		}
+		entry := entries[idx]
+		count := 1
+		if idx < len(attempts) && attempts[idx] > 0 {
+			count = attempts[idx]
+		}
+		if count > 1 {
+			m.hadDuplicate = true
+		}
+		for i := 0; i < count; i++ {
+			if err := m.record(entry); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (m *mockExporter) record(entry *rewards.RewardEntry) error {
+	if entry == nil {
+		return fmt.Errorf("nil reward entry")
+	}
+	checksum := entry.Checksum
+	if checksum == "" {
+		checksum = rewards.EntryChecksum(entry.Epoch, entry.Address, entry.Amount)
+	}
+	addr := hex.EncodeToString(entry.Address[:])
+	amount := "0"
+	if entry.Amount != nil {
+		amount = entry.Amount.String()
+	}
+	rec, ok := m.deliveries[checksum]
+	if ok {
+		if rec.Amount != amount || rec.Address != addr {
+			return fmt.Errorf("inconsistent delivery for %s", checksum)
+		}
+	} else {
+		rec = deliveryRecord{Epoch: entry.Epoch, Address: addr, Amount: amount}
+	}
+	rec.Attempts++
+	m.deliveries[checksum] = rec
+	return nil
+}
+
+func (m *mockExporter) snapshot() map[string]deliverySnapshot {
+	out := make(map[string]deliverySnapshot, len(m.deliveries))
+	for checksum, rec := range m.deliveries {
+		out[checksum] = deliverySnapshot{Address: rec.Address, Amount: rec.Amount}
+	}
+	return out
+}
+
+func compareWithGolden(seed int64, snapshot pipelineSnapshot, update bool) error {
+	path, err := goldenFilePath(seed)
+	if err != nil {
+		return err
+	}
+	if update {
+		if err := writeGolden(path, snapshot); err != nil {
+			return fmt.Errorf("write golden: %w", err)
+		}
+		return nil
+	}
+	expected, err := readGolden(path)
+	if err != nil {
+		return fmt.Errorf("read golden: %w", err)
+	}
+	if !reflect.DeepEqual(expected, snapshot) {
+		expectedJSON, _ := json.MarshalIndent(expected, "", "  ")
+		actualJSON, _ := json.MarshalIndent(snapshot, "", "  ")
+		return fmt.Errorf("snapshot mismatch\nexpected:\n%s\nactual:\n%s", string(expectedJSON), string(actualJSON))
+	}
+	return nil
+}
+
+func goldenFilePath(seed int64) (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime caller lookup failed")
+	}
+	base := filepath.Join(filepath.Dir(filepath.Dir(file)), "golden", "potso")
+	return filepath.Join(base, fmt.Sprintf("seed_%04d.json", seed)), nil
+}
+
+func writeGolden(path string, snapshot pipelineSnapshot) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func readGolden(path string) (pipelineSnapshot, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return pipelineSnapshot{}, err
+	}
+	var snapshot pipelineSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return pipelineSnapshot{}, err
+	}
+	return snapshot, nil
+}

--- a/tests/fuzz/potso_evidence_fuzz.go
+++ b/tests/fuzz/potso_evidence_fuzz.go
@@ -1,0 +1,160 @@
+package fuzz
+
+import (
+	"encoding/binary"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"nhbchain/consensus/potso/evidence"
+	"nhbchain/consensus/potso/penalty"
+	"nhbchain/consensus/potso/rewards"
+	statebank "nhbchain/state/bank"
+	statepotso "nhbchain/state/potso"
+	"nhbchain/storage"
+)
+
+func FuzzPotsoEvidencePipeline(f *testing.F) {
+	f.Add([]byte{0x01, 0x02, 0x03, 0x04, 0x05})
+	f.Add([]byte{0x10, 0x42, 0xAA, 0xBB, 0xCC, 0xDD})
+	f.Fuzz(func(t *testing.T, payload []byte) {
+		if len(payload) == 0 {
+			payload = []byte{0}
+		}
+		seed := int64(binary.LittleEndian.Uint64(padPayload(payload)))
+		rng := rand.New(rand.NewSource(seed))
+		db := storage.NewMemDB()
+		defer db.Close()
+		floor := big.NewInt(100)
+		ceil := big.NewInt(5000)
+		ledger, err := statepotso.NewLedger(floor, ceil)
+		if err != nil {
+			t.Fatalf("ledger init: %v", err)
+		}
+		participants := make([][20]byte, 4)
+		for i := range participants {
+			for j := range participants[i] {
+				participants[i][j] = byte(rng.Intn(256))
+			}
+			base := big.NewInt(1000 + int64(rng.Intn(2000)))
+			current := new(big.Int).Sub(base, big.NewInt(int64(rng.Intn(400))))
+			if current.Cmp(floor) < 0 {
+				current = new(big.Int).Set(floor)
+			}
+			if _, err := ledger.Set(participants[i], base, current); err != nil {
+				t.Fatalf("seed ledger: %v", err)
+			}
+		}
+		catalog, err := penalty.BuildCatalog(penalty.DefaultConfig())
+		if err != nil {
+			t.Fatalf("catalog init: %v", err)
+		}
+		engine := penalty.NewEngine(catalog, ledger, statebank.NewNoopSlasher(false))
+		store := evidence.NewStore(db)
+		bucket := rewards.NewRoundingBucket()
+		rewardLedger := rewards.NewLedger(db)
+		evidenceTypes := []evidence.Type{evidence.TypeDowntime, evidence.TypeEquivocation, evidence.TypeInvalidBlockProposal}
+		accepted := make(map[[32]byte]struct{})
+		const baseTimestamp = int64(1_700_000_000)
+		for offset := 0; offset < len(payload); offset += 6 {
+			chunk := payload[offset:]
+			selector := chunk[0]
+			typ := evidenceTypes[int(selector)%len(evidenceTypes)]
+			offender := participants[int(selector)%len(participants)]
+			reporter := participants[int(chunk[len(chunk)-1])%len(participants)]
+			heights := make([]uint64, 1+int(selector%3))
+			heightSeed := uint64(10 + int(selector%23))
+			for i := range heights {
+				idx := (offset + i + 1) % len(payload)
+				heights[i] = heightSeed + uint64(payload[idx]%31)
+			}
+			details := []byte{selector, byte(len(heights)), payload[offset%len(payload)]}
+			ev := evidence.Evidence{
+				Type:        typ,
+				Offender:    offender,
+				Heights:     heights,
+				Details:     append([]byte(nil), details...),
+				Reporter:    reporter,
+				ReporterSig: []byte{selector, byte(offset)},
+				Timestamp:   baseTimestamp + int64(offset),
+			}
+			hash, err := ev.CanonicalHash()
+			if err != nil {
+				t.Fatalf("canonical hash: %v", err)
+			}
+			record, fresh, err := store.Put(hash, ev, baseTimestamp+int64(offset))
+			if err != nil {
+				t.Fatalf("store put: %v", err)
+			}
+			if !fresh {
+				if _, ok := accepted[hash]; !ok {
+					t.Fatalf("duplicate returned before acceptance")
+				}
+				continue
+			}
+			accepted[hash] = struct{}{}
+			ctx := penalty.Context{
+				BlockHeight:  uint64(100 + offset),
+				MissedEpochs: uint64(selector % 4),
+			}
+			if selector%5 == 0 {
+				ctx.BaseWeightOverride = big.NewInt(800 + int64(selector%7)*50)
+			}
+			if _, err := engine.Apply(record, ctx); err != nil {
+				t.Fatalf("penalty apply: %v", err)
+			}
+		}
+		weights := make([]rewards.WeightEntry, len(participants))
+		for i, addr := range participants {
+			entry := ledger.Entry(addr)
+			weights[i] = rewards.WeightEntry{Address: addr, Weight: entry.Value}
+		}
+		pools := []*big.Int{big.NewInt(6000), big.NewInt(4500)}
+		for epoch := range pools {
+			dist, err := rewards.SplitRewards(pools[epoch], weights, bucket)
+			if err != nil {
+				t.Fatalf("split rewards: %v", err)
+			}
+			if dist.TotalAssigned.Cmp(pools[epoch]) > 0 {
+				t.Fatalf("epoch %d over-mint: assigned=%s pool=%s", epoch, dist.TotalAssigned, pools[epoch])
+			}
+			entries := make([]*rewards.RewardEntry, len(dist.Shares))
+			for i, share := range dist.Shares {
+				entries[i] = &rewards.RewardEntry{
+					Epoch:   uint64(epoch + 1),
+					Address: share.Address,
+					Amount:  new(big.Int).Set(share.Amount),
+				}
+				if entries[i].Amount.Sign() < 0 {
+					t.Fatalf("negative reward amount")
+				}
+				entries[i].Checksum = rewards.EntryChecksum(uint64(epoch+1), share.Address, share.Amount)
+			}
+			if err := rewardLedger.PutBatch(entries); err != nil {
+				t.Fatalf("ledger put batch: %v", err)
+			}
+		}
+		if bucket.Balance().Sign() < 0 {
+			t.Fatalf("bucket balance negative")
+		}
+		// ensure ledger outputs are retrievable and non-negative
+		for _, addr := range participants {
+			entry := ledger.Entry(addr)
+			if entry.Value.Sign() < 0 {
+				t.Fatalf("negative ledger weight")
+			}
+		}
+	})
+}
+
+func padPayload(payload []byte) []byte {
+	if len(payload) >= 8 {
+		return payload[:8]
+	}
+	padded := make([]byte, 8)
+	copy(padded, payload)
+	for i := len(payload); i < 8; i++ {
+		padded[i] = byte(i * 31)
+	}
+	return padded
+}

--- a/tests/golden/potso/seed_0042.json
+++ b/tests/golden/potso/seed_0042.json
@@ -1,0 +1,116 @@
+{
+  "deliveries": {
+    "02918ca26b4f59facc273f757b8fc62120d7d9b0676cf95c3d5642e35d6b10ee": {
+      "address": "f0f04f163aae13883ff8270f930b76611b692ab1",
+      "amount": "475"
+    },
+    "0fd30977059b2f227684b8a6a563f9d4af9656398d6db1937bdf3fa5ab3bd5a6": {
+      "address": "537d67fa1ed71a2b22ce166733b7d73ccf10a20e",
+      "amount": "460"
+    },
+    "129dc4c785b9c6ba5c91eddca93a394b61c1a0674dbdcbc299a315cf87721975": {
+      "address": "16c45b102ddae75b278e8ef302edca36c71c1b4b",
+      "amount": "565"
+    },
+    "268c82b04ad2eb6f45c7155dfab6495eda34cc60f1a3bc72a202a2818af3af8f": {
+      "address": "a2b3a0b787a8301c5fded376f7a070f5d89f66bf",
+      "amount": "475"
+    },
+    "2f23964f6257dfd9320eb17b9d4403b40b1a18d3ffecd5de63c4026d5261dc7f": {
+      "address": "a2b3a0b787a8301c5fded376f7a070f5d89f66bf",
+      "amount": "316"
+    },
+    "359f312d4f91ac1f50205d6b0d74c03dab8ae8ace3d9e240d875802c4ebb21c4": {
+      "address": "f0f04f163aae13883ff8270f930b76611b692ab1",
+      "amount": "940"
+    },
+    "393f031ef4dca6c64171e454b3bb7b43f36adc5a7d8c9753b4a746be185edcd0": {
+      "address": "4b843edf61a58870d3f96fe7dc8c6d0479af10aa",
+      "amount": "123"
+    },
+    "3cfaae3c61101d46d1b99ef92a134e2478e04c960528f11c627e4192ef7b0526": {
+      "address": "16c45b102ddae75b278e8ef302edca36c71c1b4b",
+      "amount": "745"
+    },
+    "66d82c559ab06c7321e7c628a0c559b8e07118f5ef5f92f1b69da0fe76d5bdcc": {
+      "address": "eb60e88088826c4da71ab0b5bf60cc92690a5f08",
+      "amount": "180"
+    },
+    "6f0b4f148d837967d65c6b8648b3233881b90f616c45e2f2ccd9ac58eb955e7b": {
+      "address": "f0f04f163aae13883ff8270f930b76611b692ab1",
+      "amount": "626"
+    },
+    "a4eb3f85f250bdcb147bc793c7a282b27e071e74ea3966288ec7f62438241af5": {
+      "address": "4b843edf61a58870d3f96fe7dc8c6d0479af10aa",
+      "amount": "185"
+    },
+    "b73e043166c1d528bc58c41c3afe3ce209bd6b68fdeb041c4966bc47c0e72261": {
+      "address": "537d67fa1ed71a2b22ce166733b7d73ccf10a20e",
+      "amount": "909"
+    },
+    "bcb702f38a78922bb636e541b727c0fa617cc8c8a5b9e4098349a2100e4db5e0": {
+      "address": "16c45b102ddae75b278e8ef302edca36c71c1b4b",
+      "amount": "1118"
+    },
+    "bf678c03e0d3ccc39011173990966d05606a53b24087f58c1536ff53c753824f": {
+      "address": "eb60e88088826c4da71ab0b5bf60cc92690a5f08",
+      "amount": "356"
+    },
+    "d9b4420f9ef9a9805c155e3be2858d513e0d420cf6d277fabddd3e49e3a41bb9": {
+      "address": "4b843edf61a58870d3f96fe7dc8c6d0479af10aa",
+      "amount": "94"
+    },
+    "defd8590eed75da3379d801332cc5a8b240552f58f2382096e4c29279791d6f4": {
+      "address": "537d67fa1ed71a2b22ce166733b7d73ccf10a20e",
+      "amount": "606"
+    },
+    "df8eec4003208123857a8e077608be9e46c0831fd026a930eb9ad6a8d545acf1": {
+      "address": "eb60e88088826c4da71ab0b5bf60cc92690a5f08",
+      "amount": "237"
+    },
+    "ea7741554c81f6be9225e4c7df0c537b81cb52e1db7cbafdd709e1992dd16185": {
+      "address": "a2b3a0b787a8301c5fded376f7a070f5d89f66bf",
+      "amount": "240"
+    }
+  },
+  "dust": "3",
+  "rewards": {
+    "1": {
+      "16c45b102ddae75b278e8ef302edca36c71c1b4b": "1118",
+      "4b843edf61a58870d3f96fe7dc8c6d0479af10aa": "185",
+      "537d67fa1ed71a2b22ce166733b7d73ccf10a20e": "909",
+      "a2b3a0b787a8301c5fded376f7a070f5d89f66bf": "475",
+      "eb60e88088826c4da71ab0b5bf60cc92690a5f08": "356",
+      "f0f04f163aae13883ff8270f930b76611b692ab1": "940"
+    },
+    "2": {
+      "16c45b102ddae75b278e8ef302edca36c71c1b4b": "745",
+      "4b843edf61a58870d3f96fe7dc8c6d0479af10aa": "123",
+      "537d67fa1ed71a2b22ce166733b7d73ccf10a20e": "606",
+      "a2b3a0b787a8301c5fded376f7a070f5d89f66bf": "316",
+      "eb60e88088826c4da71ab0b5bf60cc92690a5f08": "237",
+      "f0f04f163aae13883ff8270f930b76611b692ab1": "626"
+    },
+    "3": {
+      "16c45b102ddae75b278e8ef302edca36c71c1b4b": "565",
+      "4b843edf61a58870d3f96fe7dc8c6d0479af10aa": "94",
+      "537d67fa1ed71a2b22ce166733b7d73ccf10a20e": "460",
+      "a2b3a0b787a8301c5fded376f7a070f5d89f66bf": "240",
+      "eb60e88088826c4da71ab0b5bf60cc92690a5f08": "180",
+      "f0f04f163aae13883ff8270f930b76611b692ab1": "475"
+    }
+  },
+  "totals": {
+    "1": "3983",
+    "2": "2653",
+    "3": "2014"
+  },
+  "weights": {
+    "16c45b102ddae75b278e8ef302edca36c71c1b4b": "734",
+    "4b843edf61a58870d3f96fe7dc8c6d0479af10aa": "122",
+    "537d67fa1ed71a2b22ce166733b7d73ccf10a20e": "597",
+    "a2b3a0b787a8301c5fded376f7a070f5d89f66bf": "312",
+    "eb60e88088826c4da71ab0b5bf60cc92690a5f08": "234",
+    "f0f04f163aae13883ff8270f930b76611b692ab1": "617"
+  }
+}

--- a/tests/golden/potso/seed_1337.json
+++ b/tests/golden/potso/seed_1337.json
@@ -1,0 +1,100 @@
+{
+  "deliveries": {
+    "0bd640184a2bb66da9bedac0118c68514699290af3266c244f917bf1b5b03089": {
+      "address": "6122ceebf1b46e844f45f86e2dd0d5c708bf2af7",
+      "amount": "902"
+    },
+    "1f6fce17ef155be1b5e99bf419a225a94e4902e18037f70b8d0c7a7aa6591ece": {
+      "address": "c6874b346c5e31b7b5da627f27f44a777ab77844",
+      "amount": "247"
+    },
+    "476eac81cf0c7156020ef35cff66eac5a4417de3fe2429aa884326ee09c5c219": {
+      "address": "fc21f6ed8312e9bdd625a70a490933d53903be38",
+      "amount": "172"
+    },
+    "52f775b7df4a04fc29eec30bf15768076248eb02d3494f673a306c234ee6aba4": {
+      "address": "53e02a61d82147172ae994e8c327143c0434495a",
+      "amount": "650"
+    },
+    "61beb53e16017923fc782ee5e48d0a517180671b183099ef1c1ef56ec827fbba": {
+      "address": "c6874b346c5e31b7b5da627f27f44a777ab77844",
+      "amount": "305"
+    },
+    "7ffb993193138f347e09db8fddac3d8d7e09b578da9620123b15819cfc9c07b5": {
+      "address": "c6874b346c5e31b7b5da627f27f44a777ab77844",
+      "amount": "383"
+    },
+    "96fc6ad33570f496320f608f9c815fa0ef22249a7f5837f6e174316cecae1310": {
+      "address": "fc21f6ed8312e9bdd625a70a490933d53903be38",
+      "amount": "213"
+    },
+    "a4f416c6558aca420bf94986fa51e4f5768cc2da0ad3c62dc7c00de326fae0d0": {
+      "address": "6122ceebf1b46e844f45f86e2dd0d5c708bf2af7",
+      "amount": "1116"
+    },
+    "af5f1e3549b33b68e39128f32d26bcb017bbc101dd49083d17b0d2d2cbce3b4e": {
+      "address": "d9d2ee494797c5d696c88233e8a31897b62eb15e",
+      "amount": "550"
+    },
+    "c6f03825a0a9c4e4e49179917a404f62eb332daa29887bb1be4c37ba87b66826": {
+      "address": "53e02a61d82147172ae994e8c327143c0434495a",
+      "amount": "815"
+    },
+    "cd256bf8af9fa84f3fd36ee72d51cb14b17bde1fc6b9b51abda3aef61a86815a": {
+      "address": "d9d2ee494797c5d696c88233e8a31897b62eb15e",
+      "amount": "853"
+    },
+    "d2d70201d1f6df6ab11396a1f0179b6967dc7585e3aab029774f57b61d5f78e0": {
+      "address": "53e02a61d82147172ae994e8c327143c0434495a",
+      "amount": "526"
+    },
+    "d4adde9b17045cc5790dbb4865ead31268e6d23d637aa1923e5af04e7d90e00a": {
+      "address": "fc21f6ed8312e9bdd625a70a490933d53903be38",
+      "amount": "267"
+    },
+    "e7e53ab18f1019b9d4736aedc1855c131cbace489cf3f112e966ae43d71d727f": {
+      "address": "d9d2ee494797c5d696c88233e8a31897b62eb15e",
+      "amount": "681"
+    },
+    "e8428b153b9d8afa33f1dbbd99e1f7c29b944d9e79a0f6056f8e8dd8e7bcaa9b": {
+      "address": "6122ceebf1b46e844f45f86e2dd0d5c708bf2af7",
+      "amount": "1400"
+    }
+  },
+  "dust": "2",
+  "rewards": {
+    "1": {
+      "53e02a61d82147172ae994e8c327143c0434495a": "815",
+      "6122ceebf1b46e844f45f86e2dd0d5c708bf2af7": "1400",
+      "c6874b346c5e31b7b5da627f27f44a777ab77844": "383",
+      "d9d2ee494797c5d696c88233e8a31897b62eb15e": "853",
+      "fc21f6ed8312e9bdd625a70a490933d53903be38": "267"
+    },
+    "2": {
+      "53e02a61d82147172ae994e8c327143c0434495a": "650",
+      "6122ceebf1b46e844f45f86e2dd0d5c708bf2af7": "1116",
+      "c6874b346c5e31b7b5da627f27f44a777ab77844": "305",
+      "d9d2ee494797c5d696c88233e8a31897b62eb15e": "681",
+      "fc21f6ed8312e9bdd625a70a490933d53903be38": "213"
+    },
+    "3": {
+      "53e02a61d82147172ae994e8c327143c0434495a": "526",
+      "6122ceebf1b46e844f45f86e2dd0d5c708bf2af7": "902",
+      "c6874b346c5e31b7b5da627f27f44a777ab77844": "247",
+      "d9d2ee494797c5d696c88233e8a31897b62eb15e": "550",
+      "fc21f6ed8312e9bdd625a70a490933d53903be38": "172"
+    }
+  },
+  "totals": {
+    "1": "3718",
+    "2": "2965",
+    "3": "2397"
+  },
+  "weights": {
+    "53e02a61d82147172ae994e8c327143c0434495a": "430",
+    "6122ceebf1b46e844f45f86e2dd0d5c708bf2af7": "738",
+    "c6874b346c5e31b7b5da627f27f44a777ab77844": "202",
+    "d9d2ee494797c5d696c88233e8a31897b62eb15e": "450",
+    "fc21f6ed8312e9bdd625a70a490933d53903be38": "141"
+  }
+}

--- a/tests/golden/potso/seed_9001.json
+++ b/tests/golden/potso/seed_9001.json
@@ -1,0 +1,100 @@
+{
+  "deliveries": {
+    "05e321438a3af6c11b6e1ff198acfca61a4f29a3b885d132d182dee2338f85e0": {
+      "address": "f3482072bce7a5b4b855d65bad1e063b47908e5b",
+      "amount": "594"
+    },
+    "18d09e95673ccbfc6efd4d25e45af901fea373de657514f39381fa0e13fd699f": {
+      "address": "f3482072bce7a5b4b855d65bad1e063b47908e5b",
+      "amount": "575"
+    },
+    "1ac1444891cbca1aaf6eb9e18a45e6ee218737151d865742fc5a39844a7eef07": {
+      "address": "e2ef00cfe80fb2b57b9a03b5885ebb56adfa516c",
+      "amount": "230"
+    },
+    "1d116bdbf6c809647db5a602191165a511e5d53617a1b467b3a0aa6c58007a90": {
+      "address": "3d3b61e722026f350b425608d5d2a2eb7199366d",
+      "amount": "717"
+    },
+    "29a9c8ee041e8652416fcbcf9cd6f8dfa28cbf656bce48d9dd0ca9642494b4af": {
+      "address": "2d50fc467ba4cdcc8a123c82607a2ef8d059f6b6",
+      "amount": "804"
+    },
+    "4190b412e2b332d593d1490618a19da510419b7bc1327debadceab69a0ffdd99": {
+      "address": "3d3b61e722026f350b425608d5d2a2eb7199366d",
+      "amount": "1150"
+    },
+    "44d089ab6f2332b5d842736025fa32aa0bbf0dc42027f40261d9820ff0fcab4c": {
+      "address": "91f654f9efd612341f30395bec159b573d78ba37",
+      "amount": "799"
+    },
+    "54864521ec62ed4ce9824174c10df94b359bc31e6a4e24bfc2638597dad33860": {
+      "address": "91f654f9efd612341f30395bec159b573d78ba37",
+      "amount": "483"
+    },
+    "65508574c18f8cca7638d385daf06b345348310525b4fe13e027188d00d8a8de": {
+      "address": "e2ef00cfe80fb2b57b9a03b5885ebb56adfa516c",
+      "amount": "238"
+    },
+    "6d71fa644568ea3d65e432f883486c6d1d790b7247fba773f3b3819e85ac32ad": {
+      "address": "2d50fc467ba4cdcc8a123c82607a2ef8d059f6b6",
+      "amount": "778"
+    },
+    "89bdd7e8fad84b341f58f0f0dd29cca9f21fd272362be774675819fecfdb03cc": {
+      "address": "3d3b61e722026f350b425608d5d2a2eb7199366d",
+      "amount": "1187"
+    },
+    "d44d378d13e828b49ef234ab79f10734bf7d36f987c8f356c0e80cc50b1b1851": {
+      "address": "e2ef00cfe80fb2b57b9a03b5885ebb56adfa516c",
+      "amount": "144"
+    },
+    "d5170094d74935748b64ac1e918c910b1e8d413381716c39b95590d21e43b135": {
+      "address": "f3482072bce7a5b4b855d65bad1e063b47908e5b",
+      "amount": "359"
+    },
+    "d8314b33de54212947a486e839816a00e31206230b31125f45d3af95c446b424": {
+      "address": "91f654f9efd612341f30395bec159b573d78ba37",
+      "amount": "774"
+    },
+    "e94b71484e1f5f679a94b40b809ba7623bac47f6937828ffb0fda6d47830382e": {
+      "address": "2d50fc467ba4cdcc8a123c82607a2ef8d059f6b6",
+      "amount": "486"
+    }
+  },
+  "dust": "2",
+  "rewards": {
+    "1": {
+      "2d50fc467ba4cdcc8a123c82607a2ef8d059f6b6": "804",
+      "3d3b61e722026f350b425608d5d2a2eb7199366d": "1187",
+      "91f654f9efd612341f30395bec159b573d78ba37": "799",
+      "e2ef00cfe80fb2b57b9a03b5885ebb56adfa516c": "238",
+      "f3482072bce7a5b4b855d65bad1e063b47908e5b": "594"
+    },
+    "2": {
+      "2d50fc467ba4cdcc8a123c82607a2ef8d059f6b6": "778",
+      "3d3b61e722026f350b425608d5d2a2eb7199366d": "1150",
+      "91f654f9efd612341f30395bec159b573d78ba37": "774",
+      "e2ef00cfe80fb2b57b9a03b5885ebb56adfa516c": "230",
+      "f3482072bce7a5b4b855d65bad1e063b47908e5b": "575"
+    },
+    "3": {
+      "2d50fc467ba4cdcc8a123c82607a2ef8d059f6b6": "486",
+      "3d3b61e722026f350b425608d5d2a2eb7199366d": "717",
+      "91f654f9efd612341f30395bec159b573d78ba37": "483",
+      "e2ef00cfe80fb2b57b9a03b5885ebb56adfa516c": "144",
+      "f3482072bce7a5b4b855d65bad1e063b47908e5b": "359"
+    }
+  },
+  "totals": {
+    "1": "3622",
+    "2": "3507",
+    "3": "2189"
+  },
+  "weights": {
+    "2d50fc467ba4cdcc8a123c82607a2ef8d059f6b6": "499",
+    "3d3b61e722026f350b425608d5d2a2eb7199366d": "737",
+    "91f654f9efd612341f30395bec159b573d78ba37": "496",
+    "e2ef00cfe80fb2b57b9a03b5885ebb56adfa516c": "148",
+    "f3482072bce7a5b4b855d65bad1e063b47908e5b": "369"
+  }
+}


### PR DESCRIPTION
## Summary
- add orchestrated POTSO Task 3 determinism test harness with multi-node replay chaos and golden snapshots
- add fuzz coverage for POTSO evidence, penalty, and reward pipeline invariants
- check in deterministic golden ledgers for seeds 42, 1337, and 9001

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5b860cae8832d900e062e7953d613