### PR TITLE
Add identity claimables and finalize documentation

### DIFF
--- a/core/claimable/claimable.go
+++ b/core/claimable/claimable.go
@@ -51,14 +51,15 @@ var (
 )
 
 type Claimable struct {
-	ID        [32]byte
-	Payer     [20]byte
-	Token     string
-	Amount    *big.Int
-	HashLock  [32]byte
-	Deadline  int64
-	CreatedAt int64
-	Status    ClaimStatus
+	ID            [32]byte
+	Payer         [20]byte
+	Token         string
+	Amount        *big.Int
+	HashLock      [32]byte
+	RecipientHint [32]byte
+	Deadline      int64
+	CreatedAt     int64
+	Status        ClaimStatus
 }
 
 func (c *Claimable) Clone() *Claimable {

--- a/core/events/claimable.go
+++ b/core/events/claimable.go
@@ -16,12 +16,13 @@ const (
 )
 
 type ClaimableCreated struct {
-	ID        [32]byte
-	Payer     [20]byte
-	Token     string
-	Amount    *big.Int
-	Deadline  int64
-	CreatedAt int64
+	ID            [32]byte
+	Payer         [20]byte
+	Token         string
+	Amount        *big.Int
+	RecipientHint [32]byte
+	Deadline      int64
+	CreatedAt     int64
 }
 
 func (ClaimableCreated) EventType() string { return TypeClaimableCreated }
@@ -30,22 +31,24 @@ func (e ClaimableCreated) Event() *types.Event {
 	return &types.Event{
 		Type: TypeClaimableCreated,
 		Attributes: map[string]string{
-			"id":        hex.EncodeToString(e.ID[:]),
-			"payer":     crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
-			"token":     e.Token,
-			"amount":    formatAmount(e.Amount),
-			"deadline":  intToString(e.Deadline),
-			"createdAt": intToString(e.CreatedAt),
+			"id":            hex.EncodeToString(e.ID[:]),
+			"payer":         crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
+			"token":         e.Token,
+			"amount":        formatAmount(e.Amount),
+			"deadline":      intToString(e.Deadline),
+			"createdAt":     intToString(e.CreatedAt),
+			"recipientHint": hex.EncodeToString(e.RecipientHint[:]),
 		},
 	}
 }
 
 type ClaimableClaimed struct {
-	ID     [32]byte
-	Payer  [20]byte
-	Payee  [20]byte
-	Token  string
-	Amount *big.Int
+	ID            [32]byte
+	Payer         [20]byte
+	Payee         [20]byte
+	Token         string
+	Amount        *big.Int
+	RecipientHint [32]byte
 }
 
 func (ClaimableClaimed) EventType() string { return TypeClaimableClaimed }
@@ -54,11 +57,12 @@ func (e ClaimableClaimed) Event() *types.Event {
 	return &types.Event{
 		Type: TypeClaimableClaimed,
 		Attributes: map[string]string{
-			"id":     hex.EncodeToString(e.ID[:]),
-			"payer":  crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
-			"payee":  crypto.NewAddress(crypto.NHBPrefix, e.Payee[:]).String(),
-			"token":  e.Token,
-			"amount": formatAmount(e.Amount),
+			"id":            hex.EncodeToString(e.ID[:]),
+			"payer":         crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
+			"payee":         crypto.NewAddress(crypto.NHBPrefix, e.Payee[:]).String(),
+			"token":         e.Token,
+			"amount":        formatAmount(e.Amount),
+			"recipientHint": hex.EncodeToString(e.RecipientHint[:]),
 		},
 	}
 }

--- a/core/events/identity.go
+++ b/core/events/identity.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	TypeIdentityAliasSet     = "identity.alias.set"
-	TypeIdentityAliasRenamed = "identity.alias.renamed"
+	TypeIdentityAliasSet           = "identity.alias.set"
+	TypeIdentityAliasRenamed       = "identity.alias.renamed"
+	TypeIdentityAliasAvatarUpdated = "identity.alias.avatarUpdated"
 )
 
 // IdentityAliasSet is emitted when an address registers an alias for the first time.
@@ -48,6 +49,28 @@ func (e IdentityAliasRenamed) Event() *types.Event {
 			"old":     e.OldAlias,
 			"new":     e.NewAlias,
 			"address": crypto.NewAddress(crypto.NHBPrefix, e.Address[:]).String(),
+		},
+	}
+}
+
+// IdentityAliasAvatarUpdated is emitted when an alias updates its avatar reference.
+type IdentityAliasAvatarUpdated struct {
+	Alias     string
+	Address   [20]byte
+	AvatarRef string
+}
+
+// EventType implements the Event interface.
+func (IdentityAliasAvatarUpdated) EventType() string { return TypeIdentityAliasAvatarUpdated }
+
+// Event converts the strongly typed event to the generic representation used by subscribers.
+func (e IdentityAliasAvatarUpdated) Event() *types.Event {
+	return &types.Event{
+		Type: TypeIdentityAliasAvatarUpdated,
+		Attributes: map[string]string{
+			"alias":     e.Alias,
+			"address":   crypto.NewAddress(crypto.NHBPrefix, e.Address[:]).String(),
+			"avatarRef": e.AvatarRef,
 		},
 	}
 }

--- a/core/identity/alias.go
+++ b/core/identity/alias.go
@@ -5,19 +5,40 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
 // AliasRecord captures the metadata for a registered alias.
 type AliasRecord struct {
 	Alias     string
-	Address   [20]byte
+	Primary   [20]byte
+	Addresses [][20]byte
+	AvatarRef string
 	CreatedAt int64
 	UpdatedAt int64
 }
 
+func (r *AliasRecord) Clone() *AliasRecord {
+	if r == nil {
+		return nil
+	}
+	clone := *r
+	if len(r.Addresses) > 0 {
+		clone.Addresses = make([][20]byte, len(r.Addresses))
+		copy(clone.Addresses, r.Addresses)
+	}
+	return &clone
+}
+
+func (r *AliasRecord) AliasID() [32]byte {
+	return DeriveAliasID(r.Alias)
+}
+
 const (
-	aliasMinLength = 3
-	aliasMaxLength = 32
+	aliasMinLength    = 3
+	aliasMaxLength    = 32
+	avatarRefMaxBytes = 512
 )
 
 var (
@@ -28,6 +49,11 @@ var (
 	// ErrAliasTaken is returned when the alias is already owned by another
 	// address.
 	ErrAliasTaken = errors.New("identity: alias already registered")
+	// ErrAliasNotFound denotes that the requested alias record does not exist.
+	ErrAliasNotFound = errors.New("identity: alias not found")
+	// ErrInvalidAvatarRef indicates the avatar reference is malformed or
+	// violates policy.
+	ErrInvalidAvatarRef = errors.New("identity: invalid avatar reference")
 )
 
 // NormalizeAlias lowercases and validates the supplied alias.
@@ -42,4 +68,30 @@ func NormalizeAlias(alias string) (string, error) {
 		return "", fmt.Errorf("%w: allowed characters are [a-z0-9._-]", ErrInvalidAlias)
 	}
 	return lower, nil
+}
+
+// DeriveAliasID returns the deterministic 32-byte identifier for the alias.
+func DeriveAliasID(alias string) [32]byte {
+	normalized := strings.ToLower(strings.TrimSpace(alias))
+	hash := ethcrypto.Keccak256([]byte(normalized))
+	var id [32]byte
+	copy(id[:], hash)
+	return id
+}
+
+// NormalizeAvatarRef validates the avatar reference and returns the canonical
+// value if valid. Supported schemes are HTTPS and blob references.
+func NormalizeAvatarRef(ref string) (string, error) {
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return "", ErrInvalidAvatarRef
+	}
+	if len(trimmed) > avatarRefMaxBytes {
+		return "", fmt.Errorf("%w: exceeds %d characters", ErrInvalidAvatarRef, avatarRefMaxBytes)
+	}
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "https://") || strings.HasPrefix(lower, "blob://") {
+		return trimmed, nil
+	}
+	return "", fmt.Errorf("%w: must use https:// or blob:// scheme", ErrInvalidAvatarRef)
 }

--- a/core/identity_integration_test.go
+++ b/core/identity_integration_test.go
@@ -35,10 +35,10 @@ func TestNodeIdentityAliasLifecycle(t *testing.T) {
 		t.Fatalf("set alias: %v", err)
 	}
 	resolved, ok := node.IdentityResolve("frankrocks")
-	if !ok {
+	if !ok || resolved == nil {
 		t.Fatalf("expected alias to resolve")
 	}
-	if resolved != addr {
+	if resolved.Primary != addr {
 		t.Fatalf("resolved address mismatch")
 	}
 	alias, ok := node.IdentityReverse(addr)
@@ -53,7 +53,7 @@ func TestNodeIdentityAliasLifecycle(t *testing.T) {
 		t.Fatalf("old alias should not resolve")
 	}
 	resolved, ok = node.IdentityResolve("frankierocks")
-	if !ok || resolved != addr {
+	if !ok || resolved == nil || resolved.Primary != addr {
 		t.Fatalf("new alias resolution failed")
 	}
 	alias, ok = node.IdentityReverse(addr)

--- a/core/state/claimable_test.go
+++ b/core/state/claimable_test.go
@@ -35,7 +35,7 @@ func TestClaimableCreateAndClaim(t *testing.T) {
 	copy(hashLock[:], hash)
 
 	deadline := int64(500)
-	claim, err := manager.CreateClaimable(payer, "NHB", big.NewInt(100), hashLock, deadline)
+	claim, err := manager.CreateClaimable(payer, "NHB", big.NewInt(100), hashLock, deadline, [32]byte{})
 	if err != nil {
 		t.Fatalf("create claimable: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestClaimableCancelAndExpire(t *testing.T) {
 
 	var hashLock [32]byte
 	deadline := int64(100)
-	claim, err := manager.CreateClaimable(payer, "ZNHB", big.NewInt(200), hashLock, deadline)
+	claim, err := manager.CreateClaimable(payer, "ZNHB", big.NewInt(200), hashLock, deadline, [32]byte{})
 	if err != nil {
 		t.Fatalf("create claimable: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestClaimableCancelAndExpire(t *testing.T) {
 	// Expire path
 	fundAccount(t, manager, payer, 500, 1000) // replenish NHB for second claimable
 	deadlineExpire := int64(50)
-	second, err := manager.CreateClaimable(payer, "NHB", big.NewInt(300), hashLock, deadlineExpire)
+	second, err := manager.CreateClaimable(payer, "NHB", big.NewInt(300), hashLock, deadlineExpire, [32]byte{})
 	if err != nil {
 		t.Fatalf("create second claimable: %v", err)
 	}

--- a/docs/identity/audit.md
+++ b/docs/identity/audit.md
@@ -1,0 +1,37 @@
+# Identity Audit & Compliance
+
+Identity operations on NHBChain are intentionally observable so that custodians, gateways, and regulators can reconstruct user journeys without accessing raw PII. This note describes the emitted event streams, retention guidance, and recommended review procedures.
+
+## Event Streams
+
+| Event | Purpose | Payload Highlights |
+| --- | --- | --- |
+| `identity.alias.set` | First-time alias registration. | `alias`, `address` |
+| `identity.alias.renamed` | Alias string changed for an existing owner. | `old`, `new`, `address` |
+| `identity.alias.avatarUpdated` | Avatar reference updated. | `alias`, `address`, `avatarRef` |
+| `claimable.created` | Pay-by-email claimable funded. | `id`, `payer`, `token`, `amount`, `recipientHint`, `deadline` |
+| `claimable.claimed` | Claimable settled to a recipient. | `id`, `payer`, `payee`, `token`, `amount`, `recipientHint` |
+| `claimable.cancelled` / `claimable.expired` | Funds returned to the payer. | `id`, `payer`, `token`, `amount` |
+
+All events are appended to the node state log and exposed via:
+
+* JSON-RPC `events_stream` (see Observability docs) – suited for real-time ingestion.
+* Block logs – every committed block includes emitted events in execution order.
+* Gateway webhooks – operators can relay selected events to merchants or compliance tooling.
+
+## Retention & Access
+
+* **Node state** – full nodes implicitly retain the entire event log; archival nodes should keep at least 18 months to satisfy typical KYC/AML retention windows.
+* **Gateway logs** – store email verification records for 18 months. Hashes only; purge on DSAR unless subject to legal hold.
+* **Wallet telemetry** – avoid storing raw emails. Persist claimable IDs, hint hashes, and timestamps instead.
+* **Access control** – production RPC endpoints require bearer tokens. Restrict webhook URLs to trusted systems and sign payloads (HMAC SHA-256 recommended).
+
+## Regulator Guidance
+
+* **PII minimisation** – on-chain data excludes plaintext email; regulators inspecting the chain see only salted hashes and alias metadata.
+* **Lawful disclosure** – when compelled, operators can map salted hashes back to email addresses using gateway logs. Document the salt rotation schedule to prove uniqueness.
+* **Abuse monitoring** – maintain dashboards tracking alias registrations per IP, verification retries, and claim velocity per payer. Alert on anomalies (e.g., >20 failed verifications/hour from one IP, bursts of high-value claims sharing the same hint).
+* **Incident response** – if an alias is compromised, governance can freeze or reassign by submitting a governance proposal. Wallets should surface alias `UpdatedAt` and event history to end users.
+* **Audit trails** – retain the RPC request metadata (caller IP, authenticated user) for identity mutations. Pair with event logs to reconstruct end-to-end changes.
+
+For more operational controls see [identity-security-compliance.md](./identity-security-compliance.md) and the platform observability runbooks.

--- a/docs/identity/avatars.md
+++ b/docs/identity/avatars.md
@@ -29,7 +29,7 @@ strings (`avatarRef`) and retrieved via HTTPS or on-chain blob storage.
 
 1. Owner uploads media via [`POST /identity/avatars/upload`](./identity-gateway.md#post-identityavatarsupload).
 2. Gateway returns canonical `avatarRef` (HTTPS URL or `blob://` reference) after validation.
-3. Owner signs `identity_setAvatar(alias, avatarRef, sig)` to update on-chain record.
+3. Owner calls `identity_setAvatar(ownerAddr, avatarRef)` over authenticated RPC to update the on-chain record.
 4. Event `identity.alias.avatarUpdated` notifies subscribers to refresh caches.
 
 ## Recommended Client Behavior
@@ -37,6 +37,11 @@ strings (`avatarRef`) and retrieved via HTTPS or on-chain blob storage.
 * Fallback to generated identicon (e.g., BLAKE3 aliasId hashed to color palette) when no avatar set.
 * Preload avatars when scanning QR codes or directory listings.
 * Display moderation badges for avatars flagged by governance (future field `avatarFlag`).
+
+## RPC & CLI Exposure
+
+* JSON-RPC: `identity_setAvatar(addressBech32, avatarRef)` (authenticated).
+* CLI: `nhb-cli id set-avatar --addr nhb1... --avatar https://cdn/...`.
 
 ## Security Notes
 

--- a/docs/identity/identity-api.md
+++ b/docs/identity/identity-api.md
@@ -1,434 +1,211 @@
 # Identity JSON-RPC Reference
 
-> Endpoint: `POST /rpc` (same port as core node RPC) • Namespace: `identity_*`
+> Endpoint: `POST /rpc` (same port as the core node RPC) • Namespace: `identity_*`
 
-The identity module exposes deterministic JSON-RPC methods for registering aliases, managing linked addresses, configuring
-avatars, and handling claimables. All write operations require an owner signature following the NHBChain EIP-191-style scheme
-described below.
+The identity module exposes JSON-RPC endpoints for registering aliases, updating
+avatar references, resolving alias metadata, and managing pay-by-email
+claimables. This guide documents the request/response schemas, authentication
+requirements, and sample payloads for each method.
 
-## Authentication & Signature Scheme
+## Authentication
 
-* **Scheme:** EIP-191 (`\x19NHB Signed Message:\n${len}|payload`), hashed with keccak256 prior to secp256k1 signing.
-* **Payload format:** `${method}|${paramsHash}|${chainId}|${nonce}|${expiry}`.
-  * `paramsHash` = keccak256 of canonical JSON-serialized params (sorted keys, no whitespace).
-  * `nonce` sourced from `identity_get(aliasOrId).version + 1` or monotonic wallet counter.
-  * `expiry` = unix timestamp (seconds) after which the signature is invalid.
-* **Verification:** Nodes recompute the payload and recover the signer. The recovered address must match the alias owner.
+* **Bearer token** – Mutating methods require the `Authorization: Bearer <token>`
+  header. The token is configured in the node's RPC server (`rpc.authToken`).
+  Requests without the header (or with a mismatched token) return HTTP 401.
+* **Public reads** – `identity_resolve` and `identity_reverse` do not require
+  authentication and may be used by wallets or public gateways to look up alias
+  data.
+* **Idempotency** – The node enforces idempotent semantics for
+  `identity_createClaimable` and `identity_claim`. Clients may retry safely when
+  receiving network errors.
 
-Example signing payload for `identity_registerAlias`:
+## Common Error Shapes
 
-```
-method = "identity_registerAlias"
-params = {"alias":"frankrocks","ownerBech32":"nhb1...","primaryAddr":"nhb1..."}
-paramsHash = keccak256("{\"alias\":\"frankrocks\",\"ownerBech32\":\"nhb1...\"}")
-chainId = 187001
-nonce = 7
-expiry = 1718131261
-payload = "identity_registerAlias|0x4fb6...|187001|7|1718131261"
-```
+Errors follow the JSON-RPC 2.0 structure `{code, message, data}`. Identity
+handlers reuse standard node error codes:
 
-Wallets should display the decoded payload before signing. Include `expiry` that matches UX expectations (typically 5 minutes).
-
-### Common Error Codes
-
-| Code | Message | Description | Suggested Remediation |
+| HTTP Status | `code` | `message` | Typical Cause |
 | --- | --- | --- | --- |
-| `IDN-001` | `name_taken` | Alias reserved or already registered. | Prompt user to pick another alias or appeal via governance. |
-| `IDN-002` | `invalid_alias` | Alias fails normalization or policy checks. | Sanitize input, enforce length/charset before submission. |
-| `IDN-003` | `not_owner` | Caller signature does not match alias owner. | Re-authenticate with owner key or transfer ownership. |
-| `IDN-004` | `bad_signature` | Signature fails verification. | Recompute payload, ensure nonce/expiry correct. |
-| `IDN-005` | `address_not_linked` | Address not currently linked to alias. | Fetch alias details, link address first. |
-| `IDN-006` | `claim_expired` | Claimable expired before claim. | Instruct payer to recreate claimable. |
-| `IDN-007` | `alias_not_found` | Alias or ID cannot be resolved. | Prompt user to register alias or check spelling. |
-| `IDN-008` | `replay_detected` | Nonce already used or signature expired. | Generate new nonce/expiry and re-sign. |
-| `IDN-009` | `gateway_required` | Operation requires off-chain verification (e.g., email binding). | Complete verification via gateway. |
-
-All errors include `{code, message, data}` fields; `data` may contain contextual hints (`{"aliasId":"0x.."}`).
+| `400` | `-32602` | `invalid_params` | Invalid Bech32 address, alias format, or malformed payload. |
+| `401` | `-32000` | `missing Authorization header` (or similar) | Missing/incorrect bearer token. |
+| `403` | `-32060` | `forbidden` | Claimable access errors (payer/payee mismatch). |
+| `404` | `-32602` | `alias not found` / `not_found` | Alias or claimable does not exist. |
+| `409` | `-32061` | `conflict` | Claimable deadline exceeded, already claimed, or invalid preimage. |
+| `500` | `-32001` | `internal_error` | Unexpected server error (check `data`). |
 
 ---
 
 ## Method Reference
 
-Each method below includes parameters, return schema, and request/response examples. Replace `NODE_RPC_URL` with your node
-endpoint. All examples use JSON-RPC 2.0.
+Each method uses JSON-RPC 2.0. Examples below omit the surrounding HTTP headers
+for brevity.
 
-### `identity_registerAlias`
+### `identity_setAlias`
 
-Registers a new alias and sets the initial primary address.
+Registers or updates the alias controlled by an address. Re-registering with a
+new alias automatically emits rename events and updates timestamps.
 
 **Parameters**
 
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `alias` | string | ✓ | Desired alias (normalized client-side). |
-| `ownerBech32` | string | ✓ | Owner account that signs subsequent mutations. |
-| `sig` | string | ✓ | Hex-encoded signature per scheme above. |
+Positional array with two items:
+
+1. `address` (`string`) – Bech32-encoded owner address (`nhb1...`).
+2. `alias` (`string`) – Desired alias. The node normalises to lower-case and
+   validates length/charset.
 
 **Returns**
 
 ```json
-{
-  "aliasId": "0x5e2c...",
-  "alias": "frankrocks",
-  "owner": "nhb1...",
-  "primaryAddr": "nhb1...",
-  "createdAt": 1718131200
-}
+{"ok": true}
 ```
 
 **Example Request**
 
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
-
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "identity_registerAlias",
-  "params": ["frankrocks", "nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgpxxx", "0xSIG"]
-}
-```
-
-**Example Error Response**
-
 ```json
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "error": {
-    "code": -32001,
-    "message": "identity error",
-    "data": {"code": "IDN-001", "message": "name_taken"}
-  }
-}
-```
-
-### `identity_addAddress`
-
-Links a new Bech32 address to an alias.
-
-**Parameters**
-
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `aliasOrId` | string | ✓ | Alias string or hex aliasId. |
-| `addressBech32` | string | ✓ | Address to link. |
-| `sig` | string | ✓ | Owner signature. |
-
-**Returns**
-
-```json
-{"ok": true, "addresses": ["nhb1...", "nhb1alt..."]}
-```
-
-**Request Example**
-
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
-
-{
-  "jsonrpc": "2.0",
-  "id": 11,
-  "method": "identity_addAddress",
-  "params": ["frankrocks", "nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y", "0xSIG"]
-}
-```
-
-### `identity_removeAddress`
-
-Removes a linked address. Cannot remove the current primary address; set a new primary first.
-
-**Parameters**: same as `identity_addAddress`.
-
-**Returns**
-
-```json
-{"ok": true, "addresses": ["nhb1..."]}
-```
-
-**Request Example**
-
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
-
-{
-  "jsonrpc": "2.0",
-  "id": 12,
-  "method": "identity_removeAddress",
-  "params": ["frankrocks", "nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y", "0xSIG"]
-}
-```
-
-### `identity_setPrimary`
-
-Sets the primary payout address.
-
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `aliasOrId` | string | ✓ | Alias or aliasId. |
-| `addressBech32` | string | ✓ | Address that must already be linked. |
-| `sig` | string | ✓ | Owner signature. |
-
-**Returns**
-
-```json
-{"ok": true, "primaryAddr": "nhb1..."}
-```
-
-If the address is not linked, the method fails with `IDN-005`.
-
-**Request Example**
-
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
-
-{
-  "jsonrpc": "2.0",
-  "id": 13,
-  "method": "identity_setPrimary",
-  "params": ["frankrocks", "nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y", "0xSIG"]
+  "method": "identity_setAlias",
+  "params": [
+    "nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgp9p6hd",
+    "frankrocks"
+  ]
 }
 ```
 
 ### `identity_setAvatar`
 
-Updates the avatar reference. Accepts HTTPS URL or on-chain blob reference (`blob://{cid}`).
+Updates the avatar reference for the alias owned by the address. Accepts HTTPS
+URLs or `blob://` references that have been provisioned by the identity gateway.
 
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `aliasOrId` | string | ✓ | Alias or aliasId. |
-| `avatarUrlOrBlobRef` | string | ✓ | Avatar reference per [Avatar spec](./avatars.md). |
-| `sig` | string | ✓ | Owner signature. |
+**Parameters**
 
-**Returns**: `{ "ok": true, "avatarRef": "https://..." }`
-
-**Request Example**
-
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
-
-{
-  "jsonrpc": "2.0",
-  "id": 14,
-  "method": "identity_setAvatar",
-  "params": ["frankrocks", "https://cdn.nhb/avatars/frankrocks.png", "0xSIG"]
-}
-```
-
-### `identity_rename`
-
-Renames an alias without changing `aliasId`.
-
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `aliasId` | string | ✓ | Hex aliasId (canonical). |
-| `newAlias` | string | ✓ | New alias candidate. |
-| `sig` | string | ✓ | Owner signature. |
-
-**Returns**: `{ "ok": true, "alias": "frankr0cks" }`
-
-**Request Example**
-
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
-
-{
-  "jsonrpc": "2.0",
-  "id": 15,
-  "method": "identity_rename",
-  "params": ["0x5e2c...", "frankr0cks", "0xSIG"]
-}
-```
-
-### `identity_get`
-
-Fetches the full alias record.
-
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `aliasOrId` | string | ✓ | Alias or aliasId. |
-
-**Returns**
-
-```json
-{
-  "aliasId": "0x5e2c...",
-  "alias": "frankrocks",
-  "owner": "nhb1...",
-  "primaryAddr": "nhb1...",
-  "addresses": ["nhb1...", "nhb1alt..."],
-  "avatarRef": "https://cdn.nhb/id/frankrocks.png",
-  "createdAt": 1718131200,
-  "updatedAt": 1718132200,
-  "version": 4
-}
-```
-
-**Request Example**
-
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
-
-{
-  "jsonrpc": "2.0",
-  "id": 16,
-  "method": "identity_get",
-  "params": ["frankrocks"]
-}
-```
-
-### `identity_resolve`
-
-Resolves an alias to linked addresses.
-
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `nameOrAlias` | string | ✓ | Alias string (with or without leading `@`). |
-
-**Returns**
-
-```json
-{
-  "aliasId": "0x5e2c...",
-  "alias": "frankrocks",
-  "primary": "nhb1...",
-  "addresses": ["nhb1...", "nhb1alt..."],
-  "avatarRef": "https://cdn.nhb/id/frankrocks.png",
-  "createdAt": 1718131200
-}
-```
-
-**Request Example**
-
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
-
-{
-  "jsonrpc": "2.0",
-  "id": 21,
-  "method": "identity_resolve",
-  "params": ["frankrocks"]
-}
-```
-
-### `identity_reverseResolve`
-
-Reverse-lookup of alias by address.
-
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `addressBech32` | string | ✓ | Address to resolve. |
-
-**Returns**: `{ "alias": "frankrocks", "aliasId": "0x5e2c..." }`
-
-**Request Example**
-
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
-
-{
-  "jsonrpc": "2.0",
-  "id": 22,
-  "method": "identity_reverseResolve",
-  "params": ["nhb1alt4vrc6j9j9r4w0l5z7p3yyd86x8k6qfsu8y"]
-}
-```
-
-### `identity_createClaimable`
-
-Creates a claimable escrow for an unresolved alias or email hash.
-
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `recipientAliasOrEmailHash` | string | ✓ | Alias string/aliasId or salted email hash (hex). |
-| `token` | string | ✓ | Token denom (e.g., `NHB`, `ZNHB`). |
-| `amount` | string | ✓ | Decimal string. |
-| `expiry` | integer | ✓ | Unix timestamp expiry. |
-| `payerSig` | string | ✓ | Signature from payer address authorizing hold. |
-
-**Returns**
-
-```json
-{
-  "claimId": "0x92fd...",
-  "expiresAt": 1718137200
-}
-```
-
-**Request Example**
-
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
-
-{
-  "jsonrpc": "2.0",
-  "id": 42,
-  "method": "identity_createClaimable",
-  "params": ["0x5e2c...", "NHB", "10.00", 1718736000, "0xPAYER_SIG"]
-}
-```
-
-### `identity_claim`
-
-Claims an existing claimable once alias/email resolves.
-
-| Name | Type | Required | Description |
-| --- | --- | --- | --- |
-| `claimId` | string | ✓ | Claimable identifier. |
-| `recipientSig` | string | ✓ | Signature from alias owner proving control. |
+1. `address` (`string`) – Owner address.
+2. `avatarRef` (`string`) – HTTPS or `blob://` reference.
 
 **Returns**
 
 ```json
 {
   "ok": true,
-  "settledTx": "0xabc123...",
-  "amount": "10.0",
-  "token": "NHB",
-  "to": "nhb1primary..."
+  "alias": "frankrocks",
+  "aliasId": "0x5e2c...",
+  "avatarRef": "https://cdn.nhb/avatars/frank.png",
+  "updatedAt": 1718132211
 }
 ```
 
-On success, the claimable is removed and the escrow vault transfers funds to the alias primary address.
+### `identity_resolve`
 
-**Request Example**
+Fetches the latest metadata for an alias. Public and cache-friendly.
 
-```http
-POST NODE_RPC_URL
-Content-Type: application/json
+**Parameters**
 
+* `alias` (`string`) – Alias to resolve. Case-insensitive; the node applies
+  canonical normalisation.
+
+**Returns**
+
+```json
 {
-  "jsonrpc": "2.0",
-  "id": 43,
-  "method": "identity_claim",
-  "params": ["0x92fd...", "0xRECIP_SIG"]
+  "alias": "frankrocks",
+  "aliasId": "0x5e2c...",
+  "primary": "nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgp9p6hd",
+  "addresses": [
+    "nhb1qyqszqgpqyqszqgpqyqszqgpqyqszqgp9p6hd"
+  ],
+  "avatarRef": "https://cdn.nhb/avatars/frank.png",
+  "createdAt": 1718131200,
+  "updatedAt": 1718132211
 }
 ```
+
+### `identity_reverse`
+
+Reverse lookup for an address. Returns the alias string and deterministic
+`aliasId` derived from the alias.
+
+**Parameters**
+
+* `address` (`string`) – Bech32 address to reverse lookup.
+
+**Returns**
+
+```json
+{
+  "alias": "frankrocks",
+  "aliasId": "0x5e2c..."
+}
+```
+
+### `identity_createClaimable`
+
+Escrows funds for a recipient identified by an alias or salted email hash.
+Clients **must** send a single JSON object as the first positional parameter.
+
+**Request Object**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `payer` | string | ✓ | Bech32 address funding the claimable. |
+| `recipient` | string | ✓ | 32-byte hex salted email hash or alias string. |
+| `token` | string | ✓ | `NHB` or `ZNHB`. Case-insensitive. |
+| `amount` | string | ✓ | Decimal string amount (in token base units). |
+| `deadline` | int | ✓ | Unix timestamp (seconds) when the claim expires. Must be in the future. |
+
+**Returns**
+
+```json
+{
+  "claimId": "0x92fd...",
+  "recipientHint": "0x3a4b...",
+  "token": "NHB",
+  "amount": "25",
+  "expiresAt": 1718822400,
+  "createdAt": 1718736000
+}
+```
+
+### `identity_claim`
+
+Releases a claimable to the verified recipient. Requires the preimage supplied
+by the identity gateway or derived from the alias ID.
+
+**Request Object**
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `claimId` | string | ✓ | Hex-encoded claimable ID returned by `identity_createClaimable`. |
+| `payee` | string | ✓ | Bech32 address receiving the funds. |
+| `preimage` | string | ✓ | 32-byte hex string matching the stored `recipientHint`. |
+
+**Returns**
+
+```json
+{
+  "ok": true,
+  "token": "NHB",
+  "amount": "25"
+}
+```
+
+On replay or duplicate submissions the method still returns `{ "ok": true }`
+without transferring additional funds.
 
 ---
 
-## Batch & Pagination Guidance
+## CLI Helpers
 
-* JSON-RPC batch requests are supported; include nonces/expiries per call.
-* `identity_get` and `identity_resolve` support future pagination of addresses via optional `offset`, `limit` params (reserved).
+The `nhb-cli` binary wraps the RPCs above:
 
-## Monitoring & Events
+| Command | Description |
+| --- | --- |
+| `nhb-cli id set-alias --addr <bech32> --alias <name>` | Calls `identity_setAlias`. |
+| `nhb-cli id set-avatar --addr <bech32> --avatar <ref>` | Calls `identity_setAvatar`. |
+| `nhb-cli id resolve --alias <name>` | Calls `identity_resolve`. |
+| `nhb-cli id reverse --addr <bech32>` | Calls `identity_reverse`. |
+| `nhb-cli id create-claimable ...` | Calls `identity_createClaimable`. |
+| `nhb-cli id claim ...` | Calls `identity_claim`. |
 
-Consumers can subscribe to `identity.*` events via `eth_subscribe` (`logs`) and filter by topic (`identity.alias.registered`,
-`identity.claimable.created`). Each event log encodes `aliasId`, addresses, and metadata hashes. Use this for audit trails.
-
-## Related Documents
-
-* [Identity Concepts](./identity.md)
-* [Identity Gateway REST API](./identity-gateway.md)
-* [CLI Usage](./identity-cli.md)
+Refer to the CLI help output (`nhb-cli id --help`) for full flag listings and
+examples.

--- a/docs/identity/pay-by-email.md
+++ b/docs/identity/pay-by-email.md
@@ -1,0 +1,140 @@
+# Pay-by-Email Claimables
+
+Pay-by-email extends NHBChain payments to recipients that have not yet claimed an alias. Funds are held in a lightweight on-chain claimable until the recipient verifies their email address and presents the shared secret returned by the identity gateway. This document covers the verification flow, JSON-RPC/CLI usage, webhook notifications, and abuse controls.
+
+## Verification Flow
+
+1. **Initiate verification** – the sender (or wallet on their behalf) calls the identity gateway `POST /identity/email/register` endpoint with the raw email address and optional alias hint. The gateway normalises (`lower + NFKC`), salts, and HMAC-hashes the address before queuing an out-of-band code.
+2. **Recipient verifies** – the recipient follows the emailed link and submits the one-time code via `POST /identity/email/verify`. Success returns the salted `emailHash` that is safe to share with wallets and nodes.
+3. **Wallet stores secret** – wallets persist the returned hash locally. This 32-byte value becomes the claim preimage supplied during `identity_claim`.
+4. **Optional alias binding** – once the recipient registers an alias they may opt-in to bind the verified hash to their alias for directory lookups (see `identity_setAlias` + gateway bind APIs).
+
+The node never sees raw email addresses. All on-chain state references the 32-byte salted hash only.
+
+## Creating Claimables
+
+Use the authenticated JSON-RPC method `identity_createClaimable` to escrow funds for a hashed recipient.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 41,
+  "method": "identity_createClaimable",
+  "params": [
+    {
+      "payer": "nhb1payer...",
+      "recipient": "0x3a4b...",    // salted email hash
+      "token": "NHB",
+      "amount": "25",
+      "deadline": 1718822400
+    }
+  ]
+}
+```
+
+**Response**
+
+```json
+{
+  "claimId": "0x92fd...",
+  "recipientHint": "0x3a4b...",
+  "token": "NHB",
+  "amount": "25",
+  "expiresAt": 1718822400,
+  "createdAt": 1718736000
+}
+```
+
+CLI equivalent:
+
+```
+nhb-cli id create-claimable \
+  --payer nhb1payer... \
+  --recipient 0x3a4b... \
+  --token NHB \
+  --amount 25 \
+  --deadline 1718822400
+```
+
+### Recipient Hint
+
+`recipient` must be either:
+
+* A salted email hash returned by the gateway (32-byte hex string), or
+* An alias string – the node derives the aliasId and uses it as the hint. This is useful when paying aliases that are registered but unresolved for a linked address.
+
+Internally the node stores the 32-byte hint alongside the keccak hash used for the claim lock. The preimage supplied during claim must match this hint exactly.
+
+## Claiming Funds
+
+Recipients call the authenticated `identity_claim` RPC once they control the email hash.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "identity_claim",
+  "params": [
+    {
+      "claimId": "0x92fd...",
+      "payee": "nhb1recipient...",
+      "preimage": "0x3a4b..."
+    }
+  ]
+}
+```
+
+**Response**
+
+```json
+{
+  "ok": true,
+  "token": "NHB",
+  "amount": "25"
+}
+```
+
+CLI equivalent:
+
+```
+nhb-cli id claim \
+  --id 0x92fd... \
+  --payee nhb1recipient... \
+  --preimage 0x3a4b...
+```
+
+On success the node debits the claimable vault and credits the `payee`. Replays are idempotent and return `{ "ok": true }` without double-paying.
+
+## Webhook Notifications
+
+Gateway operators typically subscribe to node events to drive webhooks. Relevant event types:
+
+* `claimable.created` – includes `id`, `payer`, `token`, `amount`, `recipientHint`, `deadline`.
+* `claimable.claimed` – includes `id`, `payer`, `payee`, `token`, `amount`, `recipientHint`.
+* `claimable.expired` / `claimable.cancelled` – emitted when funds return to the payer.
+
+Suggested webhook payload for a successful claim:
+
+```json
+{
+  "event": "identity.claimable.claimed",
+  "id": "0x92fd...",
+  "payee": "nhb1recipient...",
+  "token": "NHB",
+  "amount": "25",
+  "recipientHint": "0x3a4b...",
+  "claimedAt": 1718740000
+}
+```
+
+Include an HMAC signature header so merchants can verify authenticity.
+
+## Abuse Handling & Limits
+
+* **TTL** – `deadline` must be in the future; once reached the payer can reclaim funds. Default wallet UX sets 7–14 days.
+* **Rate limits** – gateway enforces per-IP and per-email attempt caps (5/hour default). Node RPCs inherit standard bearer-token throttles.
+* **Anomaly detection** – monitor claim events for abnormal velocity by hint or payer. Flag repeated failures, mismatched preimages, or rapidly reused hints.
+* **PII minimisation** – only salted hashes leave the gateway. Wallet logs should redact raw emails and hints whenever possible.
+* **Idempotency** – clients may safely retry create/claim calls; the node returns stable results if nothing changes.
+
+For a deeper look at alias records and avatar usage, see [identity.md](./identity.md) and [avatars.md](./avatars.md).

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -312,10 +312,16 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handleLoyaltyUserQR(w, r, req)
 	case "identity_setAlias":
 		s.handleIdentitySetAlias(w, r, req)
+	case "identity_setAvatar":
+		s.handleIdentitySetAvatar(w, r, req)
 	case "identity_resolve":
 		s.handleIdentityResolve(w, r, req)
 	case "identity_reverse":
 		s.handleIdentityReverse(w, r, req)
+	case "identity_createClaimable":
+		s.handleIdentityCreateClaimable(w, r, req)
+	case "identity_claim":
+		s.handleIdentityClaim(w, r, req)
 	case "claimable_create":
 		s.handleClaimableCreate(w, r, req)
 	case "claimable_claim":

--- a/rpc/identity_handlers.go
+++ b/rpc/identity_handlers.go
@@ -1,9 +1,13 @@
 package rpc
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
 	"nhbchain/core/identity"
 	"nhbchain/crypto"
@@ -14,11 +18,55 @@ type identitySetAliasResult struct {
 }
 
 type identityResolveResult struct {
-	Address string `json:"addressBech32"`
+	Alias     string   `json:"alias"`
+	AliasID   string   `json:"aliasId"`
+	Primary   string   `json:"primary"`
+	Addresses []string `json:"addresses"`
+	AvatarRef string   `json:"avatarRef,omitempty"`
+	CreatedAt int64    `json:"createdAt"`
+	UpdatedAt int64    `json:"updatedAt"`
 }
 
 type identityReverseResult struct {
-	Alias string `json:"alias"`
+	Alias   string `json:"alias"`
+	AliasID string `json:"aliasId"`
+}
+
+type identitySetAvatarResult struct {
+	OK        bool   `json:"ok"`
+	Alias     string `json:"alias"`
+	AliasID   string `json:"aliasId"`
+	AvatarRef string `json:"avatarRef"`
+	UpdatedAt int64  `json:"updatedAt"`
+}
+
+type identityCreateClaimableParams struct {
+	Payer     string `json:"payer"`
+	Recipient string `json:"recipient"`
+	Token     string `json:"token"`
+	Amount    string `json:"amount"`
+	Deadline  int64  `json:"deadline"`
+}
+
+type identityCreateClaimableResult struct {
+	ClaimID       string `json:"claimId"`
+	RecipientHint string `json:"recipientHint"`
+	Token         string `json:"token"`
+	Amount        string `json:"amount"`
+	ExpiresAt     int64  `json:"expiresAt"`
+	CreatedAt     int64  `json:"createdAt"`
+}
+
+type identityClaimParams struct {
+	ClaimID  string `json:"claimId"`
+	Payee    string `json:"payee"`
+	Preimage string `json:"preimage"`
+}
+
+type identityClaimResult struct {
+	OK     bool   `json:"ok"`
+	Token  string `json:"token"`
+	Amount string `json:"amount"`
 }
 
 func (s *Server) handleIdentitySetAlias(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
@@ -58,6 +106,56 @@ func (s *Server) handleIdentitySetAlias(w http.ResponseWriter, r *http.Request, 
 	writeResult(w, req.ID, identitySetAliasResult{OK: true})
 }
 
+func (s *Server) handleIdentitySetAvatar(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 2 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected address and avatarRef parameters", nil)
+		return
+	}
+	var addressParam, avatarParam string
+	if err := json.Unmarshal(req.Params[0], &addressParam); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid address parameter", err.Error())
+		return
+	}
+	if err := json.Unmarshal(req.Params[1], &avatarParam); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid avatar parameter", err.Error())
+		return
+	}
+	addr, err := decodeBech32(addressParam)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid address", err.Error())
+		return
+	}
+	normalizedAvatar, err := identity.NormalizeAvatarRef(avatarParam)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid avatarRef", err.Error())
+		return
+	}
+	record, err := s.node.IdentitySetAvatar(addr, normalizedAvatar)
+	if err != nil {
+		switch {
+		case errors.Is(err, identity.ErrAliasNotFound):
+			writeError(w, http.StatusNotFound, req.ID, codeInvalidParams, "alias not registered", addressParam)
+		case errors.Is(err, identity.ErrInvalidAvatarRef):
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid avatarRef", err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "failed to set avatar", err.Error())
+		}
+		return
+	}
+	aliasID := record.AliasID()
+	writeResult(w, req.ID, identitySetAvatarResult{
+		OK:        true,
+		Alias:     record.Alias,
+		AliasID:   "0x" + hex.EncodeToString(aliasID[:]),
+		AvatarRef: record.AvatarRef,
+		UpdatedAt: record.UpdatedAt,
+	})
+}
+
 func (s *Server) handleIdentityResolve(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
 	if len(req.Params) != 1 {
 		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "alias parameter required", nil)
@@ -73,13 +171,154 @@ func (s *Server) handleIdentityResolve(w http.ResponseWriter, _ *http.Request, r
 		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid alias", err.Error())
 		return
 	}
-	addr, ok := s.node.IdentityResolve(normalized)
-	if !ok {
+	record, ok := s.node.IdentityResolve(normalized)
+	if !ok || record == nil {
 		writeError(w, http.StatusNotFound, req.ID, codeInvalidParams, "alias not found", normalized)
 		return
 	}
-	bech32 := crypto.NewAddress(crypto.NHBPrefix, addr[:]).String()
-	writeResult(w, req.ID, identityResolveResult{Address: bech32})
+	primary := crypto.NewAddress(crypto.NHBPrefix, record.Primary[:]).String()
+	addresses := make([]string, 0, len(record.Addresses))
+	for _, addr := range record.Addresses {
+		addresses = append(addresses, crypto.NewAddress(crypto.NHBPrefix, addr[:]).String())
+	}
+	aliasID := record.AliasID()
+	result := identityResolveResult{
+		Alias:     record.Alias,
+		AliasID:   "0x" + hex.EncodeToString(aliasID[:]),
+		Primary:   primary,
+		Addresses: addresses,
+		CreatedAt: record.CreatedAt,
+		UpdatedAt: record.UpdatedAt,
+	}
+	if record.AvatarRef != "" {
+		result.AvatarRef = record.AvatarRef
+	}
+	writeResult(w, req.ID, result)
+}
+
+func (s *Server) handleIdentityCreateClaimable(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", "exactly one parameter object expected")
+		return
+	}
+	var params identityCreateClaimableParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	payer, err := parseBech32Address(params.Payer)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	token := strings.ToUpper(strings.TrimSpace(params.Token))
+	if token != "NHB" && token != "ZNHB" {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", "token must be NHB or ZNHB")
+		return
+	}
+	amount, err := parsePositiveBigInt(params.Amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	hint, err := parseRecipientHint(params.Recipient)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	now := time.Now().Unix()
+	if params.Deadline < now-deadlineSkewSeconds {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", "deadline must be in the future")
+		return
+	}
+	record, err := s.node.IdentityCreateClaimable(payer, token, amount, hint, params.Deadline)
+	if err != nil {
+		writeClaimableError(w, req.ID, err)
+		return
+	}
+	amountStr := "0"
+	if record.Amount != nil {
+		amountStr = record.Amount.String()
+	}
+	writeResult(w, req.ID, identityCreateClaimableResult{
+		ClaimID:       formatClaimableID(record.ID),
+		RecipientHint: "0x" + hex.EncodeToString(record.RecipientHint[:]),
+		Token:         record.Token,
+		Amount:        amountStr,
+		ExpiresAt:     record.Deadline,
+		CreatedAt:     record.CreatedAt,
+	})
+}
+
+func (s *Server) handleIdentityClaim(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", "exactly one parameter object expected")
+		return
+	}
+	var params identityClaimParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	id, err := parseClaimableID(params.ClaimID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	payee, err := parseBech32Address(params.Payee)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	preimage, err := parseHexBytes(params.Preimage)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeClaimableInvalidParams, "invalid_params", err.Error())
+		return
+	}
+	record, err := s.node.IdentityClaim(id, preimage, payee)
+	if err != nil {
+		writeClaimableError(w, req.ID, err)
+		return
+	}
+	amountStr := "0"
+	token := ""
+	if record != nil {
+		token = record.Token
+		if record.Amount != nil {
+			amountStr = record.Amount.String()
+		}
+	}
+	writeResult(w, req.ID, identityClaimResult{OK: true, Token: token, Amount: amountStr})
+}
+
+func parseRecipientHint(value string) ([32]byte, error) {
+	var out [32]byte
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return out, fmt.Errorf("recipient required")
+	}
+	cleaned := strings.TrimPrefix(strings.TrimPrefix(trimmed, "0x"), "0X")
+	if len(cleaned) == 64 {
+		decoded, err := hex.DecodeString(cleaned)
+		if err != nil {
+			return out, err
+		}
+		copy(out[:], decoded)
+		return out, nil
+	}
+	normalized, err := identity.NormalizeAlias(trimmed)
+	if err != nil {
+		return out, fmt.Errorf("recipient must be alias or 32-byte hash")
+	}
+	return identity.DeriveAliasID(normalized), nil
 }
 
 func (s *Server) handleIdentityReverse(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
@@ -102,5 +341,6 @@ func (s *Server) handleIdentityReverse(w http.ResponseWriter, _ *http.Request, r
 		writeError(w, http.StatusNotFound, req.ID, codeInvalidParams, "address has no alias", addressParam)
 		return
 	}
-	writeResult(w, req.ID, identityReverseResult{Alias: alias})
+	aliasID := identity.DeriveAliasID(alias)
+	writeResult(w, req.ID, identityReverseResult{Alias: alias, AliasID: "0x" + hex.EncodeToString(aliasID[:])})
 }


### PR DESCRIPTION
## Summary
- extend identity state, node logic, and RPC handlers to support recipient-hinted claimables, avatar updates, and richer alias records
- update CLI tooling and add comprehensive documentation covering identity RPCs, pay-by-email flows, avatars, and audit guidance
- add targeted unit and integration tests for the identity manager and handlers, including avatar update coverage

## Testing
- `GOTOOLCHAIN=local go test ./core/state`
- `GOTOOLCHAIN=local go test ./core`
- `GOTOOLCHAIN=local go test ./rpc`
- `GOTOOLCHAIN=local go test ./cmd/...`
- `GOTOOLCHAIN=local go test ./core/claimable`
- `GOTOOLCHAIN=local go test ./core/events`
- `GOTOOLCHAIN=local go test ./core/identity`


------
https://chatgpt.com/codex/tasks/task_e_68d5cef072c0832dbf32bed141331739