### PR TITLE
Add observability, ops playbooks, and SDK docs

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,89 @@
+# Example Applications
+
+This guide shows how to run the NHB Chain example applications against the public testnet. Each project demonstrates authentication, idempotency, and tracing best practices from the SDKs.
+
+## Prerequisites
+
+- Node.js 18+ and Go 1.21+
+- Docker and Docker Compose
+- NHB Chain API credentials with least-privilege scopes for the relevant product areas
+- Access to the testnet RPC endpoint (`https://rpc.testnet.nhbchain.xyz`)
+
+## Repository Layout
+
+- `examples/merchant-js`: browser checkout flow using the JS SDK
+- `examples/escrow-js`: custodial escrow workflow with automated release
+- `examples/swap-js`: token swap integration demonstrating idempotent order placement
+- `examples/merchant-go`: backend service for merchant settlement
+- `examples/escrow-go`: escrow orchestration microservice
+- `examples/swap-go`: Go-based swap engine with Prometheus metrics
+
+## Environment Setup
+
+1. Clone the repository and install dependencies:
+
+   ```bash
+   git clone https://github.com/nhbchain/examples.git
+   cd examples
+   npm install && go mod tidy
+   ```
+
+2. Copy the sample environment file and configure secrets:
+
+   ```bash
+   cp .env.example .env
+   # Set NHB_API_KEY, NHB_API_SECRET, NHB_ENV=testnet
+   ```
+
+3. Start shared services (Redis, Postgres, mock webhooks):
+
+   ```bash
+   docker compose up -d
+   ```
+
+## Running the JavaScript Apps
+
+```bash
+cd examples/merchant-js
+npm run dev
+```
+
+- Visit `http://localhost:3000` for the merchant checkout demo.
+- Use the provided test cards; the app calls the RPC with HMAC auth and logs trace IDs to the console.
+
+For the escrow and swap apps, run `npm run start` in their respective directories. Each app exports Prometheus metrics at `http://localhost:9464/metrics`.
+
+## Running the Go Apps
+
+```bash
+cd examples/merchant-go
+NHB_API_KEY=... NHB_API_SECRET=... go run ./cmd/server
+```
+
+- Health endpoint: `GET /healthz`
+- Metrics endpoint: `GET /metrics`
+- Structured logs are emitted to stdout in JSON format.
+
+For automated tests:
+
+```bash
+go test ./...
+```
+
+## Observability Hooks
+
+- All apps emit traces via OpenTelemetry; configure the OTLP endpoint with `OTEL_EXPORTER_OTLP_ENDPOINT`.
+- Logs include redaction utilities to avoid leaking secrets.
+- Alerts can be simulated by running the `scripts/fire-alerts.sh` script to raise sample PagerDuty events.
+
+## Troubleshooting
+
+- Verify API credentials with `curl https://rpc.testnet.nhbchain.xyz/healthz`.
+- If HMAC verification fails, ensure system clocks are in sync (use `chronyd` or `ntpd`).
+- For persistent errors, capture trace IDs from logs and inspect in Grafana Tempo.
+
+## Next Steps
+
+- Deploy the examples to staging to validate CI/CD pipelines.
+- Integrate dashboards from `/docs/ops/observability.md` to monitor sample traffic.
+- Contribute improvements back via pull requests following the standard review checklist.

--- a/docs/ops/observability.md
+++ b/docs/ops/observability.md
@@ -1,0 +1,80 @@
+# Observability Stack
+
+This document describes how the NHB Chain observability stack is deployed, how data flows through the system, and how to operate the dashboards and alerts that keep the network healthy.
+
+## Metrics
+
+### Collection
+- **Prometheus** scrapes the `/metrics` endpoint on every validator, RPC node, and oracle service.
+- Exporters: `prometheus-node-exporter` for host-level stats, custom NHB Chain exporters for consensus and RPC metrics.
+- Metrics are labeled with `cluster`, `role`, `shard`, and `env` to enable granular dashboards.
+
+### Key Metrics & Thresholds
+- **Consensus health**: `nhb_consensus_finality_lag_seconds` should remain < 15s; alert at 30s.
+- **RPC latency**: `nhb_rpc_request_duration_seconds` 95th percentile < 500ms; alert at 1s.
+- **Block production**: `nhb_validator_blocks_signed_total` should increase every epoch; alert if flat for > 2 epochs.
+- **Oracle freshness**: `nhb_oracle_update_age_seconds` < 60s; alert at 120s.
+
+### Dashboards
+- **Network Overview**: per-cluster latency, throughput, and finality trends.
+- **Validator Drill-down**: CPU, memory, disk I/O, and consensus participation for each validator.
+- **RPC Performance**: request throughput, error rates, cache hit ratio, HMAC auth failures.
+- **Oracle Health**: feed latency, signer distribution, on-chain submission success.
+
+## Tracing
+
+### Instrumentation
+- Services emit OpenTelemetry traces with span attributes for `request_id`, `client_id`, and `txn_hash`.
+- RPC nodes propagate distributed trace context across internal microservices via W3C Trace Context headers.
+- Sample rate defaults to 10% for production, 100% for staging to aid debugging.
+
+### Export & Storage
+- **OTLP/HTTP** exporter ships traces to Tempo, retained for 72 hours.
+- Derived metrics for trace errors feed into Prometheus via the spanmetrics connector.
+- Sensitive values (`account_number`, `auth_token`) must be redacted before spans are exported.
+
+### Dashboards & Usage
+- Use Grafana Explore with the Tempo data source to follow requests across RPC, consensus, and storage services.
+- Trace exemplars are linked from latency panels in the RPC dashboard.
+
+## Structured Logging
+
+### Format & Routing
+- Logs are JSON with fields `timestamp`, `severity`, `service`, `env`, `request_id`, and `message`.
+- PII is hashed or dropped at the source. Access tokens and HMAC secrets are never logged.
+- Fluent Bit forwards logs to Loki with retention of 14 days.
+
+### Searching & Alerts
+- LogQL dashboards surface error spikes, failed signature verifications, and oracle stale data messages.
+- Critical log patterns (e.g., `validator_missed_signature`, `kms_rotation_failed`) generate alerts routed through Alertmanager.
+
+## Alerting
+
+### Routing
+- Alertmanager routes incidents by severity:
+  - **P1**: paging SRE on-call via PagerDuty and #sre-alerts.
+  - **P2**: notify ops triage channel and create Jira ticket.
+  - **P3**: email weekly digest to platform team.
+- Alerts include RACI contacts and runbook links.
+
+### Policy Highlights
+- **Finality lag**: triggered when lag > 30s for 3 consecutive intervals.
+- **RPC failure rate**: triggered at > 2% error rate over 10 minutes.
+- **Oracle stale data**: triggered when data age > 2 minutes.
+- **Validator downtime**: triggered when heartbeat missing for 3 epochs.
+
+## Operations
+
+### Access Control
+- Use least-privilege Prometheus and Grafana API tokens scoped per environment.
+- Rotate tokens quarterly or immediately after staff changes.
+
+### Incident Readiness
+- Quarterly alert routing drills verify contact accuracy.
+- Dashboards and alert definitions are version-controlled and peer reviewed.
+
+## Validation Checklist
+- [ ] Metrics endpoints respond with `200 OK` and expected labels.
+- [ ] Grafana dashboards display live data for consensus, RPC, oracle, and storage services.
+- [ ] Tempo contains traces linked to Grafana panels.
+- [ ] Alertmanager test notifications reach the correct channels.

--- a/docs/ops/playbooks.md
+++ b/docs/ops/playbooks.md
@@ -1,0 +1,79 @@
+# SRE Playbooks
+
+Operational runbooks for NHB Chain key components. Each playbook includes detection steps, response procedures, and post-incident actions. Maintain copies in the runbook repo and keep PagerDuty services linked here.
+
+## Key Management Service (KMS)
+
+### Routine Key Rotation
+- **Cadence**: Quarterly, or after any operator turnover.
+- **Prerequisites**: Confirm quorum of authorized signers, ensure HSM firmware is current, and announce maintenance window.
+- **Procedure**:
+  1. Drain signing traffic by toggling the `kms_rotation_in_progress` flag via the admin RPC.
+  2. Generate new key material inside the HSM; export public keys only.
+  3. Update validator configs with new key IDs and distribute via secure channel.
+  4. Run the `kms-rotation-smoke` script to sign test transactions on testnet.
+  5. Re-enable signing traffic and monitor `kms_sign_success_rate` for 30 minutes.
+- **Rollback**: Revert to previous key IDs stored in sealed backup, redeploy configs, and re-run smoke tests.
+- **RACI**: SRE owns execution, security reviews approvals, validators acknowledge receipt.
+
+### Incident: KMS Signing Failure
+- **Detection**: Alert `kms_sign_error_rate > 1%` or repeated `kms_connection_timeout` logs.
+- **Immediate Actions**:
+  1. Page on-call SRE and security liaison.
+  2. Switch validators to standby signing pool using the `kms failover` playbook.
+  3. Capture HSM diagnostics and lock audit logs.
+- **Recovery**: Restart KMS service, validate HSM health, run canary transaction. Rotate keys if compromise suspected.
+- **Postmortem**: File incident report, update alert thresholds if needed, add regression tests.
+
+## Oracle Operations
+
+### Incident: Oracle Feed Stale
+- **Detection**: Alert `nhb_oracle_update_age_seconds > 120` or dashboards showing flat price curve.
+- **Immediate Actions**:
+  1. Verify upstream data providers are reachable.
+  2. Restart failed oracle workers and replay missed batches.
+  3. Manually push latest price to testnet for validation.
+- **Recovery**: Confirm on-chain submissions resume and freshness metric returns below 60s.
+- **Escalation**: Notify data provider account managers if outage exceeds 15 minutes.
+
+### Incident: Oracle Signature Skew
+- **Detection**: Alert on signer imbalance > 40% skew.
+- **Response**:
+  1. Inspect signer health dashboard, identify lagging signer.
+  2. Rotate credentials via secure KMS channel.
+  3. Trigger signer reassignment script to rebalance load.
+- **Post-Incident**: Update signer audit logs and review capacity planning.
+
+## Validator Lifecycle
+
+### Onboarding New Validator
+- **Preparation**: Issue least-privilege API tokens, provide testnet access, and share onboarding checklist.
+- **Steps**:
+  1. Provision hardware per spec, install NHB Chain binaries, and sync from snapshot.
+  2. Register validator keys with governance contract.
+  3. Enable Prometheus scraping and log forwarding.
+  4. Run `validator-onboarding-smoke` tests to confirm block signing and RPC connectivity.
+  5. Submit onboarding report to network operations.
+
+### Offboarding Validator
+- **Trigger**: Voluntary exit, slash event, or compliance mandate.
+- **Steps**:
+  1. Disable consensus participation via admin RPC.
+  2. Rotate out validator keys and revoke API tokens.
+  3. Archive logs and metrics, store in cold storage for 90 days.
+  4. Remove from Alertmanager routing and dashboard filters.
+- **Verification**: Confirm no residual RPC or gossip traffic and that stake redistribution completed.
+
+### Incident: Validator Outage
+- **Detection**: Alert `nhb_validator_heartbeat_missing` or finality lag spike.
+- **Immediate Response**:
+  1. Page validator operations contact per RACI.
+  2. Check host health (CPU, disk, network). Restart validator service if safe.
+  3. Fallback to standby validator if downtime > 10 minutes.
+- **Postmortem**: Review logs, update runbook, and schedule redundancy drill.
+
+## Incident Drills
+
+- Conduct quarterly game-days simulating KMS compromise, oracle outage, and multi-validator failure.
+- Use chaos tooling to inject faults in staging prior to production exercises.
+- Record lessons learned and feed back into runbooks and alert policies.

--- a/docs/sdk/go.md
+++ b/docs/sdk/go.md
@@ -1,0 +1,118 @@
+# Go SDK Guide
+
+Use the NHB Chain Go SDK to build backend services with robust authentication, tracing, and idempotency support.
+
+## Installation
+
+```bash
+go get github.com/nhbchain/go-sdk
+```
+
+Initialize the client in your application:
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+
+    nhb "github.com/nhbchain/go-sdk"
+)
+
+func main() {
+    client, err := nhb.NewClient(nhb.Config{
+        Endpoint:  "https://rpc.testnet.nhbchain.xyz",
+        APIKey:    getenv("NHB_API_KEY"),
+        APISecret: getenv("NHB_API_SECRET"),
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    account, err := client.Accounts.Get(context.Background(), "merchant-123")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Printf("balance: %s", account.Balance)
+}
+```
+
+## Authentication & Signing
+
+- Requests use HMAC-SHA256 signatures computed over the HTTP method, path, timestamp, and payload.
+- Signatures are attached via headers `X-NHB-APIKEY`, `X-NHB-SIGNATURE`, and `X-NHB-TIMESTAMP`.
+- The SDK enforces a 5-minute timestamp skew window.
+
+## Idempotency Helpers
+
+```go
+key := nhb.IdempotencyKey{
+    Namespace: "merchant-123",
+    Reference: orderID,
+}.String()
+
+payment, err := client.Payments.Create(ctx, nhb.CreatePaymentRequest{
+    Amount:         "25.00",
+    Currency:       "USD",
+    IdempotencyKey: key,
+})
+```
+
+The helper normalizes whitespace, truncates long references, and includes a SHA-256 checksum.
+
+## Retries & Timeouts
+
+- Default timeout: 10 seconds per request; override with `client.WithTimeout()`.
+- Retries: exponential backoff with jitter, max 4 attempts on retryable errors (`context.DeadlineExceeded`, `HTTP 429`, `HTTP >= 500`).
+- Hooks: implement `RetryObserver` to emit custom metrics.
+
+## Tracing Integration
+
+The SDK integrates with OpenTelemetry:
+
+```go
+import "go.opentelemetry.io/otel"
+
+tracer := otel.Tracer("nhbchain-go-sdk")
+ctx, span := tracer.Start(ctx, "payments.create")
+defer span.End()
+
+_, err := client.Payments.Create(ctx, req)
+if err != nil {
+    span.RecordError(err)
+}
+```
+
+Trace context is propagated downstream so service spans align with RPC traces in Tempo.
+
+## Logging & Redaction
+
+- Structured logs via `zap` or `log/slog` include `trace_id`, `request_id`, and sanitized payload excerpts.
+- Enable payload redaction with `client.SetRedactor(nhb.DefaultRedactor())` to mask PANs and secrets.
+
+## Example Applications
+
+Reference the Go sample apps for end-to-end flows:
+
+- `examples/merchant-go`
+- `examples/escrow-go`
+- `examples/swap-go`
+
+Each example includes Docker Compose files to start dependencies and run against testnet.
+
+## Testing & CI
+
+```bash
+NHB_API_KEY=... NHB_API_SECRET=... go test ./...
+```
+
+- Use the provided `httptest` mocks under `sdk/testutil` for offline tests.
+- Capture coverage reports and ship metrics to Prometheus using the `sdk/metrics` helper.
+
+## Security Practices
+
+- Store secrets in environment variables or KMS-managed secrets, never in source control.
+- Rotate API credentials at least quarterly.
+- Monitor `nhb_rpc_auth_failure_total` and `nhb_sdk_idempotency_conflict_total` metrics for anomalies.

--- a/docs/sdk/js.md
+++ b/docs/sdk/js.md
@@ -1,0 +1,99 @@
+# JavaScript & TypeScript SDK Guide
+
+This guide explains how to install and use the NHB Chain JavaScript/TypeScript SDK to build secure, idempotent integrations.
+
+## Installation
+
+```bash
+npm install @nhbchain/sdk
+# or
+yarn add @nhbchain/sdk
+```
+
+## Authentication
+
+The SDK authenticates every RPC call with HMAC signatures.
+
+```ts
+import { NhbClient } from "@nhbchain/sdk";
+
+const client = new NhbClient({
+  endpoint: "https://rpc.testnet.nhbchain.xyz",
+  apiKey: process.env.NHB_API_KEY!,
+  apiSecret: process.env.NHB_API_SECRET!,
+});
+
+const account = await client.accounts.get("merchant-123");
+```
+
+- API keys are issued with least privilege scopes (e.g., `payments:read`, `escrow:write`).
+- Secrets should be stored in a vault and injected at runtime.
+
+## HMAC Signing & Idempotency
+
+The client signs requests using `HMAC-SHA256` with the `apiSecret` and injects headers:
+
+- `X-NHB-APIKEY`
+- `X-NHB-SIGNATURE`
+- `X-NHB-TIMESTAMP`
+- Optional `Idempotency-Key`
+
+The SDK exposes helpers to generate idempotency keys tied to business identifiers:
+
+```ts
+import { createIdempotencyKey } from "@nhbchain/sdk/idempotency";
+
+const key = createIdempotencyKey({
+  namespace: "merchant-123",
+  reference: order.id,
+});
+
+await client.payments.create({
+  amount: "25.00",
+  currency: "USD",
+  idempotencyKey: key,
+});
+```
+
+## Retries & Error Handling
+
+- Automatic retries with exponential backoff (max 3 attempts) on transient errors (`429`, `5xx`).
+- Circuit breaker trips when error rate exceeds 20% in 1 minute; manual reset via `client.resetBreaker()`.
+- Structured errors contain `code`, `message`, and optional `traceId` for Grafana Tempo lookup.
+
+## Tracing
+
+The client propagates W3C trace headers and supports manual span creation:
+
+```ts
+const span = client.tracer.startSpan("checkout.createPayment");
+await client.withSpan(span, () => client.payments.create({...}));
+span.end();
+```
+
+## Example Apps
+
+Clone the sample repositories and follow `/docs/examples/README.md` to run:
+
+- `examples/merchant-js`
+- `examples/escrow-js`
+- `examples/swap-js`
+
+## Testing Against Testnet
+
+```ts
+const health = await client.system.health();
+console.log(health.status);
+```
+
+Run integration tests with `npm test` after configuring environment variables:
+
+- `NHB_API_KEY`
+- `NHB_API_SECRET`
+- `NHB_ENV=testnet`
+
+## Security Notes
+
+- Rotate API secrets every 90 days.
+- Redact sensitive fields when logging (`client.enableRedaction()` can help mask payloads).
+- Monitor `nhb_rpc_auth_failure_total` in Grafana for brute-force attempts.


### PR DESCRIPTION
## Summary
- document the observability stack including metrics, tracing, logging, and alerting practices
- add runbooks for KMS rotations, oracle operations, validator lifecycle, and incident drills
- provide JS/TS and Go SDK guides plus instructions for running example applications against testnet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5d97f9e7c832db5bcfe8b135c8cf4