### PR TITLE
Add transaction sponsorship paymaster support

### DIFF
--- a/core/events/sponsorship.go
+++ b/core/events/sponsorship.go
@@ -1,0 +1,85 @@
+package events
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strings"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+const (
+	// TypeTxSponsorshipApplied indicates a transaction's gas was paid by a sponsor.
+	TypeTxSponsorshipApplied = "tx.sponsorship.applied"
+	// TypeTxSponsorshipFailed indicates the sponsorship request was rejected and gas fell back to the sender.
+	TypeTxSponsorshipFailed = "tx.sponsorship.failed"
+)
+
+// TxSponsorshipApplied captures a successful paymaster sponsorship outcome.
+type TxSponsorshipApplied struct {
+	TxHash   [32]byte
+	Sender   [20]byte
+	Sponsor  [20]byte
+	GasUsed  uint64
+	GasPrice *big.Int
+	Charged  *big.Int
+	Refund   *big.Int
+}
+
+// EventType satisfies the events.Event interface.
+func (TxSponsorshipApplied) EventType() string { return TypeTxSponsorshipApplied }
+
+// Event renders the applied sponsorship payload.
+func (e TxSponsorshipApplied) Event() *types.Event {
+	attrs := map[string]string{
+		"txHash":  "0x" + hex.EncodeToString(e.TxHash[:]),
+		"gasUsed": new(big.Int).SetUint64(e.GasUsed).String(),
+	}
+	if e.Sender != ([20]byte{}) {
+		attrs["sender"] = crypto.NewAddress(crypto.NHBPrefix, e.Sender[:]).String()
+	}
+	if e.Sponsor != ([20]byte{}) {
+		attrs["sponsor"] = crypto.NewAddress(crypto.NHBPrefix, e.Sponsor[:]).String()
+	}
+	if e.GasPrice != nil {
+		attrs["gasPriceWei"] = new(big.Int).Set(e.GasPrice).String()
+	}
+	if e.Charged != nil {
+		attrs["chargedWei"] = new(big.Int).Set(e.Charged).String()
+	}
+	if e.Refund != nil {
+		attrs["refundWei"] = new(big.Int).Set(e.Refund).String()
+	}
+	return &types.Event{Type: TypeTxSponsorshipApplied, Attributes: attrs}
+}
+
+// TxSponsorshipFailed captures why a sponsorship attempt was rejected.
+type TxSponsorshipFailed struct {
+	TxHash  [32]byte
+	Sender  [20]byte
+	Sponsor [20]byte
+	Status  string
+	Reason  string
+}
+
+// EventType satisfies the events.Event interface.
+func (TxSponsorshipFailed) EventType() string { return TypeTxSponsorshipFailed }
+
+// Event renders the failure payload.
+func (e TxSponsorshipFailed) Event() *types.Event {
+	attrs := map[string]string{
+		"txHash": "0x" + hex.EncodeToString(e.TxHash[:]),
+		"status": strings.TrimSpace(e.Status),
+	}
+	if strings.TrimSpace(e.Reason) != "" {
+		attrs["reason"] = strings.TrimSpace(e.Reason)
+	}
+	if e.Sender != ([20]byte{}) {
+		attrs["sender"] = crypto.NewAddress(crypto.NHBPrefix, e.Sender[:]).String()
+	}
+	if e.Sponsor != ([20]byte{}) {
+		attrs["sponsor"] = crypto.NewAddress(crypto.NHBPrefix, e.Sponsor[:]).String()
+	}
+	return &types.Event{Type: TypeTxSponsorshipFailed, Attributes: attrs}
+}

--- a/core/sponsorship.go
+++ b/core/sponsorship.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"fmt"
+	"math/big"
+
+	"nhbchain/core/types"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// SponsorshipStatus describes the evaluation outcome for a transaction's
+// paymaster request.
+type SponsorshipStatus string
+
+const (
+	SponsorshipStatusNone                SponsorshipStatus = "none"
+	SponsorshipStatusModuleDisabled      SponsorshipStatus = "module_disabled"
+	SponsorshipStatusSignatureMissing    SponsorshipStatus = "signature_missing"
+	SponsorshipStatusSignatureInvalid    SponsorshipStatus = "signature_invalid"
+	SponsorshipStatusInsufficientBalance SponsorshipStatus = "insufficient_balance"
+	SponsorshipStatusReady               SponsorshipStatus = "ready"
+)
+
+// SponsorshipAssessment summarises the pre-flight checks for a paymaster
+// sponsored transaction. Callers may surface the status and reason to clients.
+type SponsorshipAssessment struct {
+	Status   SponsorshipStatus
+	Reason   string
+	Sponsor  common.Address
+	GasCost  *big.Int
+	GasPrice *big.Int
+}
+
+// EvaluateSponsorship inspects the transaction and returns the expected
+// sponsorship status. Errors represent unexpected state retrieval failures; all
+// validation issues are reflected in the returned assessment instead.
+func (sp *StateProcessor) EvaluateSponsorship(tx *types.Transaction) (*SponsorshipAssessment, error) {
+	if tx == nil {
+		return nil, fmt.Errorf("transaction required")
+	}
+	assessment := &SponsorshipAssessment{Status: SponsorshipStatusNone}
+	if len(tx.Paymaster) == 0 {
+		return assessment, nil
+	}
+
+	sponsorAddr := common.BytesToAddress(tx.Paymaster)
+	assessment.Sponsor = sponsorAddr
+
+	if sponsorAddr == (common.Address{}) {
+		assessment.Status = SponsorshipStatusSignatureInvalid
+		assessment.Reason = "paymaster address cannot be zero"
+		return assessment, nil
+	}
+
+	if !sp.paymasterEnabled {
+		assessment.Status = SponsorshipStatusModuleDisabled
+		assessment.Reason = "paymaster module disabled"
+		return assessment, nil
+	}
+
+	sponsor, err := tx.PaymasterSponsor()
+	if err != nil {
+		switch err {
+		case types.ErrPaymasterSignatureMissing:
+			assessment.Status = SponsorshipStatusSignatureMissing
+			assessment.Reason = "missing paymaster signature"
+			return assessment, nil
+		case types.ErrPaymasterSignatureInvalid:
+			assessment.Status = SponsorshipStatusSignatureInvalid
+			assessment.Reason = "invalid paymaster signature"
+			return assessment, nil
+		default:
+			return nil, err
+		}
+	}
+	if len(sponsor) == 0 {
+		assessment.Status = SponsorshipStatusSignatureInvalid
+		assessment.Reason = "unable to recover paymaster"
+		return assessment, nil
+	}
+
+	gasPrice := big.NewInt(0)
+	if tx.GasPrice != nil {
+		gasPrice = new(big.Int).Set(tx.GasPrice)
+	}
+	gasCost := new(big.Int).Mul(new(big.Int).SetUint64(tx.GasLimit), gasPrice)
+	assessment.GasCost = gasCost
+	assessment.GasPrice = gasPrice
+
+	account, err := sp.getAccount(tx.Paymaster)
+	if err != nil {
+		return nil, err
+	}
+	if account == nil || account.BalanceNHB == nil || account.BalanceNHB.Cmp(gasCost) < 0 {
+		assessment.Status = SponsorshipStatusInsufficientBalance
+		assessment.Reason = "paymaster balance below required gas budget"
+		return assessment, nil
+	}
+
+	assessment.Status = SponsorshipStatusReady
+	assessment.Reason = ""
+	return assessment, nil
+}

--- a/core/sponsorship_test.go
+++ b/core/sponsorship_test.go
@@ -1,0 +1,196 @@
+package core
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	"nhbchain/storage"
+	statetrie "nhbchain/storage/trie"
+)
+
+func newSponsorshipState(t *testing.T) *StateProcessor {
+	t.Helper()
+	db := storage.NewMemDB()
+	t.Cleanup(func() { db.Close() })
+	trie, err := statetrie.NewTrie(db, nil)
+	if err != nil {
+		t.Fatalf("create trie: %v", err)
+	}
+	sp, err := NewStateProcessor(trie)
+	if err != nil {
+		t.Fatalf("new state processor: %v", err)
+	}
+	return sp
+}
+
+func signTransaction(t *testing.T, tx *types.Transaction, key *crypto.PrivateKey) {
+	t.Helper()
+	if err := tx.Sign(key.PrivateKey); err != nil {
+		t.Fatalf("sign transaction: %v", err)
+	}
+}
+
+func signPaymaster(t *testing.T, tx *types.Transaction, key *crypto.PrivateKey) {
+	t.Helper()
+	hash, err := tx.Hash()
+	if err != nil {
+		t.Fatalf("hash transaction: %v", err)
+	}
+	sig, err := ethcrypto.Sign(hash, key.PrivateKey)
+	if err != nil {
+		t.Fatalf("sign paymaster: %v", err)
+	}
+	tx.PaymasterR = new(big.Int).SetBytes(sig[:32])
+	tx.PaymasterS = new(big.Int).SetBytes(sig[32:64])
+	tx.PaymasterV = new(big.Int).SetUint64(uint64(sig[64]) + 27)
+}
+
+func TestEvaluateSponsorship(t *testing.T) {
+	sp := newSponsorshipState(t)
+
+	senderKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate sender key: %v", err)
+	}
+	senderAddr := senderKey.PubKey().Address().Bytes()
+	if err := sp.setAccount(senderAddr, &types.Account{BalanceNHB: big.NewInt(1_000_000), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}); err != nil {
+		t.Fatalf("seed sender: %v", err)
+	}
+
+	paymasterKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate paymaster key: %v", err)
+	}
+	paymasterAddr := paymasterKey.PubKey().Address().Bytes()
+
+	baseTx := func() *types.Transaction {
+		to := make([]byte, 20)
+		to[0] = 0x99
+		tx := &types.Transaction{
+			ChainID:  types.NHBChainID(),
+			Type:     types.TxTypeTransfer,
+			Nonce:    0,
+			To:       to,
+			GasLimit: 21000,
+			GasPrice: big.NewInt(1_000_000_000),
+			Value:    big.NewInt(1),
+		}
+		signTransaction(t, tx, senderKey)
+		return tx
+	}
+
+	cases := []struct {
+		name     string
+		prepare  func(tx *types.Transaction)
+		mutateSP func()
+		status   SponsorshipStatus
+	}{
+		{
+			name:   "no paymaster",
+			status: SponsorshipStatusNone,
+		},
+		{
+			name: "module disabled",
+			prepare: func(tx *types.Transaction) {
+				tx.Paymaster = append([]byte(nil), paymasterAddr...)
+				signPaymaster(t, tx, paymasterKey)
+				if err := sp.setAccount(paymasterAddr, &types.Account{BalanceNHB: big.NewInt(1_000_000_000_000), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}); err != nil {
+					t.Fatalf("seed paymaster: %v", err)
+				}
+			},
+			mutateSP: func() { sp.SetPaymasterEnabled(false) },
+			status:   SponsorshipStatusModuleDisabled,
+		},
+		{
+			name: "missing signature",
+			prepare: func(tx *types.Transaction) {
+				tx.Paymaster = append([]byte(nil), paymasterAddr...)
+				if err := sp.setAccount(paymasterAddr, &types.Account{BalanceNHB: big.NewInt(1_000_000_000_000), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}); err != nil {
+					t.Fatalf("seed paymaster: %v", err)
+				}
+			},
+			status: SponsorshipStatusSignatureMissing,
+		},
+		{
+			name: "invalid signature",
+			prepare: func(tx *types.Transaction) {
+				tx.Paymaster = append([]byte(nil), paymasterAddr...)
+				otherKey, err := crypto.GeneratePrivateKey()
+				if err != nil {
+					t.Fatalf("generate alt key: %v", err)
+				}
+				signPaymaster(t, tx, otherKey)
+				if err := sp.setAccount(paymasterAddr, &types.Account{BalanceNHB: big.NewInt(1_000_000_000_000), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}); err != nil {
+					t.Fatalf("seed paymaster: %v", err)
+				}
+			},
+			status: SponsorshipStatusSignatureInvalid,
+		},
+		{
+			name: "insufficient balance",
+			prepare: func(tx *types.Transaction) {
+				tx.Paymaster = append([]byte(nil), paymasterAddr...)
+				signPaymaster(t, tx, paymasterKey)
+				if err := sp.setAccount(paymasterAddr, &types.Account{BalanceNHB: big.NewInt(1), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}); err != nil {
+					t.Fatalf("seed paymaster: %v", err)
+				}
+			},
+			status: SponsorshipStatusInsufficientBalance,
+		},
+		{
+			name: "ready",
+			prepare: func(tx *types.Transaction) {
+				tx.Paymaster = append([]byte(nil), paymasterAddr...)
+				signPaymaster(t, tx, paymasterKey)
+				required := new(big.Int).Mul(new(big.Int).SetUint64(tx.GasLimit), tx.GasPrice)
+				balance := new(big.Int).Mul(required, big.NewInt(2))
+				if err := sp.setAccount(paymasterAddr, &types.Account{BalanceNHB: balance, BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}); err != nil {
+					t.Fatalf("seed paymaster: %v", err)
+				}
+			},
+			status: SponsorshipStatusReady,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sp.SetPaymasterEnabled(true)
+			tx := baseTx()
+			if tc.prepare != nil {
+				tc.prepare(tx)
+			}
+			if tc.mutateSP != nil {
+				tc.mutateSP()
+				t.Cleanup(func() { sp.SetPaymasterEnabled(true) })
+			}
+			assessment, err := sp.EvaluateSponsorship(tx)
+			if err != nil {
+				t.Fatalf("evaluate: %v", err)
+			}
+			if assessment == nil {
+				t.Fatalf("assessment nil")
+			}
+			if assessment.Status != tc.status {
+				t.Fatalf("expected status %s, got %s", tc.status, assessment.Status)
+			}
+			if tc.status == SponsorshipStatusReady {
+				expected := new(big.Int).Mul(new(big.Int).SetUint64(tx.GasLimit), tx.GasPrice)
+				if assessment.GasCost == nil || assessment.GasCost.Cmp(expected) != 0 {
+					t.Fatalf("expected gas cost %s, got %v", expected.String(), assessment.GasCost)
+				}
+				if assessment.Sponsor != (common.Address{}) {
+					// ensure sponsor matches paymaster address
+					if !bytes.Equal(assessment.Sponsor.Bytes(), paymasterAddr) {
+						t.Fatalf("unexpected sponsor address")
+					}
+				}
+			}
+		})
+	}
+}

--- a/docs/launch/paymaster-admin.md
+++ b/docs/launch/paymaster-admin.md
@@ -1,0 +1,117 @@
+# Paymaster Sponsorship Administration
+
+This guide documents how the NHB genesis operator ("master key") can manage the paymaster sponsorship module during network launch and outlines the path to migrate control to on-chain governance.
+
+The paymaster module enables gas sponsorship for end-user transactions. When active, transactions that include a populated `paymaster` payload and valid sponsor signature will have their execution fees debited from the sponsor account rather than the sender. Sponsors must pre-fund the required gas budget; any unused allowance is automatically refunded after execution.
+
+## 1. Genesis Configuration and Roles
+
+* The canonical NHB chain ID is `0x4e4842` (ASCII `"NHB"`). All administration calls must target this chain ID to be accepted by the node.
+* The genesis spec should assign the network owner (master key) to the `ROLE_PAYMASTER_ADMIN` role under the `roles` section. Example snippet:
+
+```json
+{
+  "roles": {
+    "ROLE_PAYMASTER_ADMIN": ["nhb1masterkeyaddress…"]
+  }
+}
+```
+
+* Only addresses with `ROLE_PAYMASTER_ADMIN` may toggle the module via RPC. Additional administrators can be added later through role management transactions or governance proposals.
+
+## 2. Inspecting Module Status
+
+Use the unauthenticated `tx_getSponsorshipConfig` JSON-RPC method to confirm the module status:
+
+```bash
+curl -s \
+  -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tx_getSponsorshipConfig","params":[]}'
+```
+
+Example response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "enabled": true,
+    "adminRole": "ROLE_PAYMASTER_ADMIN"
+  }
+}
+```
+
+The `enabled` flag reflects the node's current sponsorship mode. This call is read-only and does not require the admin bearer token.
+
+## 3. Enabling or Disabling Sponsorship
+
+Administrative changes require the RPC bearer token (`NHB_RPC_TOKEN`) and must include the caller address assigned to `ROLE_PAYMASTER_ADMIN`.
+
+```bash
+curl -s \
+  -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $NHB_RPC_TOKEN" \
+  -d '{
+        "jsonrpc":"2.0",
+        "id":2,
+        "method":"tx_setSponsorshipEnabled",
+        "params":[{"caller":"nhb1masterkeyaddress…","enabled":false}]
+      }'
+```
+
+Set `enabled` to `true` to turn sponsorship back on. A successful call returns the updated configuration object. If the caller lacks the role, the node responds with HTTP `403` and message `"paymaster: caller lacks ROLE_PAYMASTER_ADMIN"`.
+
+## 4. Previewing Sponsorship Diagnostics
+
+Clients can preflight a transaction to understand sponsorship viability using `tx_previewSponsorship` (no authentication required). Submit the signed transaction payload (matching chain ID `0x4e4842`) and review the response:
+
+```bash
+curl -s \
+  -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "jsonrpc":"2.0",
+        "id":3,
+        "method":"tx_previewSponsorship",
+        "params":[{"chainId":"0x4e4842","gasLimit":21000,"gasPrice":"1000000000","nonce":5,"paymaster":"0x…","paymasterR":"…","paymasterS":"…","paymasterV":"…","r":"…","s":"…","v":"…"}]
+      }'
+```
+
+Response fields:
+
+* `status`: One of `ready`, `module_disabled`, `signature_missing`, `signature_invalid`, `insufficient_balance`, or `none`.
+* `reason`: Human-readable explanation when the status is not `ready`.
+* `requiredBudgetWei`: Gas limit × price budget expected from the sponsor.
+* `moduleEnabled`: Echoes the current global toggle.
+
+Clients should only broadcast transactions with `status == "ready"` to avoid fallback gas charges to the sender.
+
+## 5. Operational Playbook
+
+1. **Launch phase (network-sponsored):** Leave the module enabled (default). The master key monitors paymaster balances, tops up sponsor accounts, and uses `tx_previewSponsorship` to diagnose any user support cases.
+2. **Transition phase:** Disable the module (`enabled: false`) once users are educated on self-funded transactions. All future transactions will have gas debited from senders automatically, while historical sponsorship events remain auditable via `tx.sponsorship.*` events.
+3. **Governance handover:** Draft a governance proposal that grants `ROLE_PAYMASTER_ADMIN` to the governance executor (e.g., treasury multi-sig) and removes the master key from the role set. Future toggles then require a proposal vote instead of direct RPC calls.
+
+## 6. Event Audit Trail
+
+When the module processes transactions it emits structured events that downstream systems or indexers can consume:
+
+| Event Type | Description | Key Attributes |
+|------------|-------------|----------------|
+| `tx.sponsorship.applied` | Sponsor successfully covered gas. | `txHash`, `sender`, `sponsor`, `gasUsed`, `chargedWei`, `refundWei`. |
+| `tx.sponsorship.failed` | Sponsorship rejected; sender paid gas. | `txHash`, `sender`, `sponsor`, `status`, `reason`. |
+
+These events are accessible via the node's event stream and help support teams reconcile gas reimbursements and failures.
+
+## 7. Future Governance Integration
+
+To migrate control to governance:
+
+1. Submit a governance proposal that assigns `ROLE_PAYMASTER_ADMIN` to the designated governance executor address and, optionally, removes the master key role member.
+2. Upon proposal execution, administrators should verify `tx_getSponsorshipConfig` to confirm the new role holder.
+3. The governance engine can then encode calls to `tx_setSponsorshipEnabled` in future proposals, allowing on-chain votes to enable or disable network sponsorship.
+
+By following this playbook, the chain owner can safely operate the paymaster module during the onboarding phase and gradually transition control to decentralised governance.

--- a/rpc/modules/transactions.go
+++ b/rpc/modules/transactions.go
@@ -1,0 +1,115 @@
+package modules
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"strings"
+
+	"nhbchain/core"
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TransactionsModule surfaces transaction sponsorship diagnostics via RPC.
+type TransactionsModule struct {
+	node *core.Node
+}
+
+// NewTransactionsModule constructs a module for transaction-focused RPC helpers.
+func NewTransactionsModule(node *core.Node) *TransactionsModule {
+	return &TransactionsModule{node: node}
+}
+
+// SponsorshipPreviewResult summarises the sponsorship evaluation for a transaction payload.
+type SponsorshipPreviewResult struct {
+	Status            string `json:"status"`
+	Reason            string `json:"reason,omitempty"`
+	Sponsor           string `json:"sponsor,omitempty"`
+	GasPriceWei       string `json:"gasPriceWei,omitempty"`
+	RequiredBudgetWei string `json:"requiredBudgetWei,omitempty"`
+	ModuleEnabled     bool   `json:"moduleEnabled"`
+}
+
+// SponsorshipConfigResult describes the current module configuration.
+type SponsorshipConfigResult struct {
+	Enabled   bool   `json:"enabled"`
+	AdminRole string `json:"adminRole"`
+}
+
+type setSponsorshipParams struct {
+	Caller  string `json:"caller"`
+	Enabled bool   `json:"enabled"`
+}
+
+// PreviewSponsorship returns the sponsorship assessment for the provided transaction payload without executing it.
+func (m *TransactionsModule) PreviewSponsorship(raw json.RawMessage) (*SponsorshipPreviewResult, *ModuleError) {
+	if m == nil || m.node == nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: "transactions module not initialised"}
+	}
+	if len(raw) == 0 {
+		return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "transaction parameter required"}
+	}
+	var tx types.Transaction
+	if err := json.Unmarshal(raw, &tx); err != nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "invalid transaction", Data: err.Error()}
+	}
+	assessment, err := m.node.EvaluateSponsorship(&tx)
+	if err != nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: err.Error()}
+	}
+	result := &SponsorshipPreviewResult{ModuleEnabled: m.node.PaymasterModuleEnabled()}
+	if assessment != nil {
+		result.Status = string(assessment.Status)
+		result.Reason = assessment.Reason
+		if assessment.Sponsor != (common.Address{}) {
+			result.Sponsor = crypto.NewAddress(crypto.NHBPrefix, assessment.Sponsor.Bytes()).String()
+		}
+		if assessment.GasPrice != nil {
+			result.GasPriceWei = new(big.Int).Set(assessment.GasPrice).String()
+		}
+		if assessment.GasCost != nil {
+			result.RequiredBudgetWei = new(big.Int).Set(assessment.GasCost).String()
+		}
+	}
+	return result, nil
+}
+
+// SetSponsorshipEnabled updates the paymaster module status after verifying the caller is authorised.
+func (m *TransactionsModule) SetSponsorshipEnabled(raw json.RawMessage) (*SponsorshipConfigResult, *ModuleError) {
+	if m == nil || m.node == nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: "transactions module not initialised"}
+	}
+	var params setSponsorshipParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "invalid parameter object", Data: err.Error()}
+	}
+	caller := strings.TrimSpace(params.Caller)
+	if caller == "" {
+		return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "caller required"}
+	}
+	decoded, err := crypto.DecodeAddress(caller)
+	if err != nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "invalid caller address", Data: err.Error()}
+	}
+	if err := m.node.SetPaymasterModuleEnabled(decoded.Bytes(), params.Enabled); err != nil {
+		switch {
+		case errors.Is(err, core.ErrPaymasterUnauthorized):
+			return nil, &ModuleError{HTTPStatus: http.StatusForbidden, Code: codeInvalidParams, Message: err.Error()}
+		default:
+			return nil, &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: err.Error()}
+		}
+	}
+	return &SponsorshipConfigResult{Enabled: m.node.PaymasterModuleEnabled(), AdminRole: "ROLE_PAYMASTER_ADMIN"}, nil
+}
+
+// SponsorshipConfig returns the current sponsorship configuration metadata.
+func (m *TransactionsModule) SponsorshipConfig() (*SponsorshipConfigResult, *ModuleError) {
+	if m == nil || m.node == nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: "transactions module not initialised"}
+	}
+	return &SponsorshipConfigResult{Enabled: m.node.PaymasterModuleEnabled(), AdminRole: "ROLE_PAYMASTER_ADMIN"}, nil
+}


### PR DESCRIPTION
## Summary
- add paymaster-aware transaction types, sponsorship evaluation, and event emission so sponsors cover gas budgets with refunds
- introduce node controls and RPC endpoints to preview or toggle sponsorship along with launch documentation for administrators
- expand tests around sponsorship readiness and conversions for gas budgeting

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d5e55d4be8832d99d7d9a0a8ebf9a5