### PR TITLE
Route native escrow through hardened engine

### DIFF
--- a/core/node.go
+++ b/core/node.go
@@ -121,6 +121,7 @@ func NewNode(db storage.Database, key *crypto.PrivateKey, genesisPath string, al
 
 	var treasury [20]byte
 	copy(treasury[:], validatorAddr.Bytes())
+	stateProcessor.SetEscrowFeeTreasury(treasury)
 
 	node := &Node{
 		db:               db,

--- a/core/state_transition_escrow_test.go
+++ b/core/state_transition_escrow_test.go
@@ -1,0 +1,248 @@
+package core
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+	"time"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	nhbstate "nhbchain/core/state"
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	"nhbchain/native/escrow"
+)
+
+func TestEscrowNativeLifecycle(t *testing.T) {
+	sp := newStakingStateProcessor(t)
+
+	payerKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate payer key: %v", err)
+	}
+	payeeKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate payee key: %v", err)
+	}
+
+	payerAddr := payerKey.PubKey().Address()
+	payeeAddr := payeeKey.PubKey().Address()
+
+	var treasury [20]byte
+	treasury[0] = 0xAA
+	sp.SetEscrowFeeTreasury(treasury)
+
+	var payerAccountAddr [20]byte
+	copy(payerAccountAddr[:], payerAddr.Bytes())
+	var payeeAccountAddr [20]byte
+	copy(payeeAccountAddr[:], payeeAddr.Bytes())
+
+	writeAccount(t, sp, payerAccountAddr, &types.Account{BalanceNHB: big.NewInt(1_000), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)})
+	writeAccount(t, sp, payeeAccountAddr, &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)})
+	writeAccount(t, sp, treasury, &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	meta := [32]byte{}
+	escrowID := ethcrypto.Keccak256Hash(payerAddr.Bytes(), payeeAddr.Bytes(), meta[:])
+
+	createPayload := struct {
+		Payee    []byte   `json:"payee"`
+		Token    string   `json:"token"`
+		Amount   *big.Int `json:"amount"`
+		FeeBps   uint32   `json:"feeBps"`
+		Deadline int64    `json:"deadline"`
+	}{
+		Payee:    payeeAddr.Bytes(),
+		Token:    "NHB",
+		Amount:   big.NewInt(100),
+		FeeBps:   100,
+		Deadline: time.Now().Add(2 * time.Hour).Unix(),
+	}
+	createData, err := jsonMarshal(createPayload)
+	if err != nil {
+		t.Fatalf("marshal create payload: %v", err)
+	}
+	createTx := &types.Transaction{
+		ChainID:  types.NHBChainID(),
+		Type:     types.TxTypeCreateEscrow,
+		Nonce:    0,
+		Data:     createData,
+		GasLimit: 21000,
+		GasPrice: big.NewInt(1),
+	}
+	if err := createTx.Sign(payerKey.PrivateKey); err != nil {
+		t.Fatalf("sign create: %v", err)
+	}
+	if err := sp.ApplyTransaction(createTx); err != nil {
+		t.Fatalf("apply create: %v", err)
+	}
+
+	manager := nhbstate.NewManager(sp.Trie)
+	esc, ok := manager.EscrowGet(escrowID)
+	if !ok {
+		t.Fatalf("escrow not stored")
+	}
+	if esc.Status != escrow.EscrowInit {
+		t.Fatalf("unexpected escrow status after create: %v", esc.Status)
+	}
+
+	fundTx := &types.Transaction{
+		ChainID:  types.NHBChainID(),
+		Type:     types.TxTypeLockEscrow,
+		Nonce:    1,
+		Data:     escrowID[:],
+		GasLimit: 21000,
+		GasPrice: big.NewInt(1),
+	}
+	if err := fundTx.Sign(payerKey.PrivateKey); err != nil {
+		t.Fatalf("sign fund: %v", err)
+	}
+	if err := sp.ApplyTransaction(fundTx); err != nil {
+		t.Fatalf("apply fund: %v", err)
+	}
+	esc, ok = manager.EscrowGet(escrowID)
+	if !ok {
+		t.Fatalf("escrow missing after fund")
+	}
+	if esc.Status != escrow.EscrowFunded {
+		t.Fatalf("unexpected status after fund: %v", esc.Status)
+	}
+
+	releaseTx := &types.Transaction{
+		ChainID:  types.NHBChainID(),
+		Type:     types.TxTypeReleaseEscrow,
+		Nonce:    0,
+		Data:     escrowID[:],
+		GasLimit: 21000,
+		GasPrice: big.NewInt(1),
+	}
+	if err := releaseTx.Sign(payeeKey.PrivateKey); err != nil {
+		t.Fatalf("sign release: %v", err)
+	}
+	if err := sp.ApplyTransaction(releaseTx); err != nil {
+		t.Fatalf("apply release: %v", err)
+	}
+
+	esc, ok = manager.EscrowGet(escrowID)
+	if !ok {
+		t.Fatalf("escrow missing after release")
+	}
+	if esc.Status != escrow.EscrowReleased {
+		t.Fatalf("unexpected status after release: %v", esc.Status)
+	}
+
+	payerAccount, err := sp.getAccount(payerAddr.Bytes())
+	if err != nil {
+		t.Fatalf("load payer account: %v", err)
+	}
+	if payerAccount.Nonce != 2 {
+		t.Fatalf("unexpected payer nonce: %d", payerAccount.Nonce)
+	}
+	expectedPayer := big.NewInt(1_000)
+	expectedPayer.Sub(expectedPayer, big.NewInt(100))
+	if payerAccount.BalanceNHB.Cmp(expectedPayer) != 0 {
+		t.Fatalf("unexpected payer balance: %s", payerAccount.BalanceNHB)
+	}
+
+	payeeAccount, err := sp.getAccount(payeeAddr.Bytes())
+	if err != nil {
+		t.Fatalf("load payee account: %v", err)
+	}
+	if payeeAccount.Nonce != 1 {
+		t.Fatalf("unexpected payee nonce: %d", payeeAccount.Nonce)
+	}
+	if payeeAccount.BalanceNHB.Cmp(big.NewInt(99)) != 0 {
+		t.Fatalf("unexpected payee balance: %s", payeeAccount.BalanceNHB)
+	}
+
+	treasuryAccount, err := sp.getAccount(treasury[:])
+	if err != nil {
+		t.Fatalf("load treasury account: %v", err)
+	}
+	if treasuryAccount.BalanceNHB.Cmp(big.NewInt(1)) != 0 {
+		t.Fatalf("unexpected treasury balance: %s", treasuryAccount.BalanceNHB)
+	}
+}
+
+func TestEscrowLegacyMigration(t *testing.T) {
+	sp := newStakingStateProcessor(t)
+
+	payerKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate payer key: %v", err)
+	}
+	payeeKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate payee key: %v", err)
+	}
+
+	payerAddr := payerKey.PubKey().Address()
+	payeeAddr := payeeKey.PubKey().Address()
+
+	var treasury [20]byte
+	treasury[0] = 0xBB
+	sp.SetEscrowFeeTreasury(treasury)
+
+	var payerAccountAddr [20]byte
+	copy(payerAccountAddr[:], payerAddr.Bytes())
+	var payeeAccountAddr [20]byte
+	copy(payeeAccountAddr[:], payeeAddr.Bytes())
+
+	writeAccount(t, sp, payerAccountAddr, &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)})
+	writeAccount(t, sp, payeeAccountAddr, &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)})
+	writeAccount(t, sp, treasury, &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	legacyID := ethcrypto.Keccak256Hash([]byte("legacy"), payerAddr.Bytes(), payeeAddr.Bytes())
+	legacy := &escrow.LegacyEscrow{
+		ID:     append([]byte(nil), legacyID[:]...),
+		Buyer:  append([]byte(nil), payeeAddr.Bytes()...),
+		Seller: append([]byte(nil), payerAddr.Bytes()...),
+		Amount: big.NewInt(50),
+		Status: escrow.LegacyStatusInProgress,
+	}
+	encodedLegacy, err := rlp.EncodeToBytes(legacy)
+	if err != nil {
+		t.Fatalf("encode legacy: %v", err)
+	}
+	legacyKey := ethcrypto.Keccak256(append([]byte("escrow-"), legacyID[:]...))
+	if err := sp.Trie.Update(legacyKey, encodedLegacy); err != nil {
+		t.Fatalf("write legacy escrow: %v", err)
+	}
+
+	releaseTx := &types.Transaction{
+		ChainID:  types.NHBChainID(),
+		Type:     types.TxTypeReleaseEscrow,
+		Nonce:    0,
+		Data:     legacyID[:],
+		GasLimit: 21000,
+		GasPrice: big.NewInt(1),
+	}
+	if err := releaseTx.Sign(payeeKey.PrivateKey); err != nil {
+		t.Fatalf("sign legacy release: %v", err)
+	}
+	if err := sp.ApplyTransaction(releaseTx); err != nil {
+		t.Fatalf("apply legacy release: %v", err)
+	}
+
+	manager := nhbstate.NewManager(sp.Trie)
+	esc, ok := manager.EscrowGet(legacyID)
+	if !ok {
+		t.Fatalf("escrow not migrated")
+	}
+	if esc.Status != escrow.EscrowReleased {
+		t.Fatalf("expected released status, got %v", esc.Status)
+	}
+
+	payeeAccount, err := sp.getAccount(payeeAddr.Bytes())
+	if err != nil {
+		t.Fatalf("load payee: %v", err)
+	}
+	if payeeAccount.BalanceNHB.Cmp(big.NewInt(50)) != 0 {
+		t.Fatalf("unexpected payee balance after migration: %s", payeeAccount.BalanceNHB)
+	}
+}
+
+func jsonMarshal(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}

--- a/core/state_transition_nonce_test.go
+++ b/core/state_transition_nonce_test.go
@@ -59,11 +59,22 @@ func TestApplyTransactionRejectsNativeNonceReplay(t *testing.T) {
 					t.Fatalf("seed escrow account: %v", err)
 				}
 			},
-			build: func(t *testing.T, _ *StateProcessor, priv *crypto.PrivateKey) *types.Transaction {
+			build: func(t *testing.T, sp *StateProcessor, priv *crypto.PrivateKey) *types.Transaction {
 				t.Helper()
+				payee := priv.PubKey().Address().Bytes()
 				payload := struct {
-					Amount *big.Int `json:"amount"`
-				}{Amount: big.NewInt(100)}
+					Payee    []byte   `json:"payee"`
+					Token    string   `json:"token"`
+					Amount   *big.Int `json:"amount"`
+					FeeBps   uint32   `json:"feeBps"`
+					Deadline int64    `json:"deadline"`
+				}{
+					Payee:    payee,
+					Token:    "NHB",
+					Amount:   big.NewInt(100),
+					FeeBps:   0,
+					Deadline: time.Now().Add(time.Hour).Unix(),
+				}
 				data, err := json.Marshal(payload)
 				if err != nil {
 					t.Fatalf("marshal payload: %v", err)

--- a/docs/escrow/hardened-engine.md
+++ b/docs/escrow/hardened-engine.md
@@ -1,0 +1,129 @@
+# Hardened Escrow Engine Routing
+
+## Purpose
+
+The hardened escrow engine replaces the prototype "legacy" state transition logic
+with a deterministic, audited implementation that shares the same code paths used
+by the RPC gateway and custody services. Routing all native escrow transactions
+through the engine guarantees:
+
+- **Single source of truth.** Every escrow lifecycle event is handled by the
+  hardened engine, ensuring identical behaviour for RPC-triggered and
+  consensus-triggered flows.
+- **Deterministic accounting.** Balances, vault credits, and fee routing are
+  executed by the engine against the canonical state manager, eliminating custom
+  bookkeeping in the state processor.
+- **Forward compatibility.** Native transactions can exercise new engine
+  features (disputes, mediation, atomic trade settlement) without additional
+  protocol changes.
+- **Transparent migration.** Historical `escrow-<id>` trie entries are migrated
+  lazily into the new storage layout the first time they are touched, avoiding
+  disruptive network upgrades.
+
+## Design Overview
+
+1. **State processor wrapper.** `StateProcessor.configureTradeEngine` now wires
+   both the escrow engine and the trade engine against `core/state.Manager`,
+   configures the fee treasury and clock source, and registers an event emitter
+   so consensus events are produced identically to RPC flows.
+2. **Native transaction handlers.** The `apply*Escrow` handlers convert the
+   transaction payloads into engine calls:
+   - `TxTypeCreateEscrow` → `Engine.Create`
+   - `TxTypeLockEscrow`   → `Engine.Fund`
+   - `TxTypeReleaseEscrow`→ `Engine.Release`
+   - `TxTypeRefundEscrow` → `Engine.Refund`
+   - `TxTypeDisputeEscrow`→ `Engine.Dispute`
+   - `TxTypeArbitrate*`   → `Engine.Resolve`
+   After the engine call succeeds the sender nonce is incremented using the
+   freshly persisted account state.
+3. **Fee treasury management.** `StateProcessor.SetEscrowFeeTreasury` allows the
+   node to configure the address that receives release fees (wired during node
+   start-up). The engine refuses to release funds if the treasury is unset,
+   ensuring fee routing remains explicit.
+4. **Legacy migration.** When an engine operation cannot find a modern escrow
+   record the state processor attempts a one-off migration:
+   - The legacy RLP payload stored at `keccak("escrow-" || id)` is decoded into
+     an `escrow.LegacyEscrow`.
+   - The data is normalised into an `escrow.Escrow` with default mediator,
+     deadlines, and status mapping.
+   - Funds that were implicitly "burned" in the prototype are re-materialised in
+     the deterministic escrow vault accounts so future releases/refunds mirror
+     hardened engine semantics.
+   - The legacy key is cleared to prevent double migrations.
+5. **Trade integration.** The trade engine shares the same configuration path,
+   so dual-leg trades automatically react to escrow funding updates emitted from
+   native transactions.
+
+## Native Transaction Payloads
+
+| Transaction Type         | Payload Fields |
+|--------------------------|----------------|
+| `TxTypeCreateEscrow`     | `payee` (`[]byte`), `token` (`"NHB"`/`"ZNHB"`), `amount` (`big.Int`), `feeBps` (`uint32`), `deadline` (`int64`), optional `mediator` (`[]byte`), optional `meta` (`[]byte <=32`). |
+| `TxTypeLockEscrow`       | `data` = escrow ID (`[32]byte`). |
+| `TxTypeReleaseEscrow`    | `data` = escrow ID (`[32]byte`), caller must be payee or mediator. |
+| `TxTypeRefundEscrow`     | `data` = escrow ID (`[32]byte`), caller must be payer prior to deadline. |
+| `TxTypeDisputeEscrow`    | `data` = escrow ID (`[32]byte`), caller must be payer or payee. |
+| `TxTypeArbitrateRelease` | `data` = escrow ID (`[32]byte`), caller must equal the privileged arbitrator address. |
+| `TxTypeArbitrateRefund`  | Same as above; outcome instructs the engine to refund the payer. |
+
+### Example Create Payload
+
+```json
+{
+  "payee": "\u0001...20-byte...",
+  "token": "NHB",
+  "amount":  "1000000000000000000",
+  "feeBps": 100,
+  "deadline": 1735689600,
+  "mediator": "\u0000...optional...",
+  "meta": "\u0012\u0034...optional..."
+}
+```
+
+### Escrow ID Derivation
+
+The engine derives the escrow identifier deterministically as:
+
+```
+escrowID = keccak256(payer || payee || metaHash)
+```
+
+Because native transactions now defer creation to the engine, clients can
+pre-compute IDs using the same rule, guaranteeing they match the stored record.
+
+## Behavioural Guarantees
+
+- **Nonce management:** Sender nonces are incremented after the engine mutates
+  state, ensuring account balances updated by the engine are preserved when the
+  nonce is written back.
+- **Vault accounting:** Funds locked by legacy escrows are credited into the
+  deterministic module vault during migration so future releases operate on real
+  balances rather than implicit debits.
+- **Event parity:** All engine calls emit the same `types.Event` payloads used by
+  the RPC services, allowing observers to rely on a single event schema.
+- **Idempotency:** Engine methods remain idempotent; repeated fund/release calls
+  are no-ops after the terminal state is reached, matching RPC behaviour.
+
+## Examples
+
+1. **Native single-leg escrow:**
+   - Create escrow with JSON payload embedded in `TxTypeCreateEscrow`.
+   - Payer submits `TxTypeLockEscrow` once funds are deposited on-chain.
+   - Payee finalises with `TxTypeReleaseEscrow`, triggering fee routing to the
+     configured treasury.
+
+2. **Legacy dispute resolution:**
+   - A historical `escrow-<id>` entry is encountered when a validator submits a
+     `TxTypeArbitrateRelease` transaction.
+   - Migration converts the record, rehydrates the vault balance, and
+     `Engine.Resolve` releases the funds to the buyer while recording the modern
+     escrow status.
+
+3. **Trade escrow update:**
+   - When an escrow leg is funded via `TxTypeLockEscrow`, the trade engine (bound
+     through `configureTradeEngine`) receives the funding event and advances the
+     trade status to `TradeFunded` once both legs are complete.
+
+By funnelling all native transactions through the hardened engine, the network
+benefits from consistent validation logic, richer telemetry, and automatic
+support for future escrow and trade extensions.


### PR DESCRIPTION
## Summary
- route all native escrow transactions through the hardened engine and expose treasury configuration on the state processor
- migrate legacy `escrow-<id>` trie entries on demand into the new storage layout and add end-to-end escrow tests
- document the hardened routing design for validators and operators

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d602b1a8c4832d809c6db3dd06e6ca