### PR TITLE
Implement escrow arbitration quorum verification

### DIFF
--- a/core/state/manager.go
+++ b/core/state/manager.go
@@ -1770,18 +1770,19 @@ func (s *storedFrozenArb) toFrozenArb() (*escrow.FrozenArb, error) {
 }
 
 type storedEscrow struct {
-	ID        [32]byte
-	Payer     [20]byte
-	Payee     [20]byte
-	Mediator  [20]byte
-	Token     string
-	Amount    *big.Int
-	FeeBps    uint32
-	Deadline  *big.Int
-	CreatedAt *big.Int
-	MetaHash  [32]byte
-	Status    uint8
-	RealmID   string
+	ID           [32]byte
+	Payer        [20]byte
+	Payee        [20]byte
+	Mediator     [20]byte
+	Token        string
+	Amount       *big.Int
+	FeeBps       uint32
+	Deadline     *big.Int
+	CreatedAt    *big.Int
+	MetaHash     [32]byte
+	Status       uint8
+	RealmID      string
+	DecisionHash [32]byte
 }
 
 // EscrowRealmPut stores the provided realm definition after sanitising it.
@@ -1866,18 +1867,19 @@ func newStoredEscrow(e *escrow.Escrow) *storedEscrow {
 	deadline := big.NewInt(e.Deadline)
 	created := big.NewInt(e.CreatedAt)
 	return &storedEscrow{
-		ID:        e.ID,
-		Payer:     e.Payer,
-		Payee:     e.Payee,
-		Mediator:  e.Mediator,
-		Token:     e.Token,
-		Amount:    amount,
-		FeeBps:    e.FeeBps,
-		Deadline:  deadline,
-		CreatedAt: created,
-		MetaHash:  e.MetaHash,
-		Status:    uint8(e.Status),
-		RealmID:   strings.TrimSpace(e.RealmID),
+		ID:           e.ID,
+		Payer:        e.Payer,
+		Payee:        e.Payee,
+		Mediator:     e.Mediator,
+		Token:        e.Token,
+		Amount:       amount,
+		FeeBps:       e.FeeBps,
+		Deadline:     deadline,
+		CreatedAt:    created,
+		MetaHash:     e.MetaHash,
+		Status:       uint8(e.Status),
+		RealmID:      strings.TrimSpace(e.RealmID),
+		DecisionHash: e.ResolutionHash,
 	}
 }
 
@@ -1897,10 +1899,11 @@ func (s *storedEscrow) toEscrow() (*escrow.Escrow, error) {
 			}
 			return new(big.Int).Set(s.Amount)
 		}(),
-		FeeBps:   s.FeeBps,
-		MetaHash: s.MetaHash,
-		Status:   escrow.EscrowStatus(s.Status),
-		RealmID:  strings.TrimSpace(s.RealmID),
+		FeeBps:         s.FeeBps,
+		MetaHash:       s.MetaHash,
+		Status:         escrow.EscrowStatus(s.Status),
+		RealmID:        strings.TrimSpace(s.RealmID),
+		ResolutionHash: s.DecisionHash,
 	}
 	if s.Deadline != nil {
 		out.Deadline = s.Deadline.Int64()

--- a/native/escrow/events.go
+++ b/native/escrow/events.go
@@ -62,8 +62,23 @@ func NewExpiredEvent(e *Escrow) *types.Event { return newEscrowEvent(EventTypeEs
 func NewDisputedEvent(e *Escrow) *types.Event { return newEscrowEvent(EventTypeEscrowDisputed, e) }
 
 // NewResolvedEvent returns the canonical event payload emitted when a dispute is
-// resolved.
-func NewResolvedEvent(e *Escrow) *types.Event { return newEscrowEvent(EventTypeEscrowResolved, e) }
+// resolved. When supplied, the decision metadata is included for auditability.
+func NewResolvedEvent(e *Escrow, outcome DecisionOutcome, metaHash [32]byte, signers [][20]byte) *types.Event {
+	evt := newEscrowEvent(EventTypeEscrowResolved, e)
+	if evt == nil {
+		return nil
+	}
+	if outcome.Valid() {
+		evt.Attributes["decision"] = outcome.String()
+	}
+	if metaHash != ([32]byte{}) {
+		evt.Attributes["decisionMetadata"] = hex.EncodeToString(metaHash[:])
+	}
+	if len(signers) > 0 {
+		evt.Attributes["decisionSigners"] = formatArbitratorMembers(signers)
+	}
+	return evt
+}
 
 // NewTradeCreatedEvent emits the canonical payload for a newly created trade.
 func NewTradeCreatedEvent(t *Trade) *types.Event {

--- a/native/escrow/events_test.go
+++ b/native/escrow/events_test.go
@@ -54,7 +54,9 @@ func TestEscrowEventsHaveDeterministicPayload(t *testing.T) {
 		{"refunded", escrowpkg.NewRefundedEvent, escrowpkg.EventTypeEscrowRefunded},
 		{"expired", escrowpkg.NewExpiredEvent, escrowpkg.EventTypeEscrowExpired},
 		{"disputed", escrowpkg.NewDisputedEvent, escrowpkg.EventTypeEscrowDisputed},
-		{"resolved", escrowpkg.NewResolvedEvent, escrowpkg.EventTypeEscrowResolved},
+		{"resolved", func(e *escrowpkg.Escrow) *types.Event {
+			return escrowpkg.NewResolvedEvent(e, escrowpkg.DecisionOutcomeUnknown, [32]byte{}, nil)
+		}, escrowpkg.EventTypeEscrowResolved},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/native/escrow/types.go
+++ b/native/escrow/types.go
@@ -174,24 +174,71 @@ const (
 	EscrowDisputed
 )
 
+// DecisionOutcome enumerates the possible arbitration outcomes supported by the
+// escrow engine.
+type DecisionOutcome uint8
+
+const (
+	DecisionOutcomeUnknown DecisionOutcome = iota
+	DecisionOutcomeRelease
+	DecisionOutcomeRefund
+)
+
+// Valid reports whether the outcome represents a supported arbitration
+// decision.
+func (o DecisionOutcome) Valid() bool {
+	switch o {
+	case DecisionOutcomeRelease, DecisionOutcomeRefund:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the canonical textual representation of the decision.
+func (o DecisionOutcome) String() string {
+	switch o {
+	case DecisionOutcomeRelease:
+		return "release"
+	case DecisionOutcomeRefund:
+		return "refund"
+	default:
+		return "unknown"
+	}
+}
+
+// ParseDecisionOutcome normalises a textual decision string into the enum form.
+func ParseDecisionOutcome(outcome string) (DecisionOutcome, error) {
+	normalized := strings.ToLower(strings.TrimSpace(outcome))
+	switch normalized {
+	case "release":
+		return DecisionOutcomeRelease, nil
+	case "refund":
+		return DecisionOutcomeRefund, nil
+	default:
+		return DecisionOutcomeUnknown, fmt.Errorf("escrow: invalid resolution outcome %s", outcome)
+	}
+}
+
 // Escrow captures the immutable metadata and runtime status of a single escrow
 // agreement managed by the native engine. The identifier is the keccak256 hash
 // of the payer, payee and a caller-supplied nonce, ensuring deterministic IDs
 // without storing the nonce on-chain.
 type Escrow struct {
-	ID        [32]byte
-	Payer     [20]byte
-	Payee     [20]byte
-	Mediator  [20]byte
-	Token     string
-	Amount    *big.Int
-	FeeBps    uint32
-	Deadline  int64
-	CreatedAt int64
-	MetaHash  [32]byte
-	Status    EscrowStatus
-	RealmID   string
-	FrozenArb *FrozenArb
+	ID             [32]byte
+	Payer          [20]byte
+	Payee          [20]byte
+	Mediator       [20]byte
+	Token          string
+	Amount         *big.Int
+	FeeBps         uint32
+	Deadline       int64
+	CreatedAt      int64
+	MetaHash       [32]byte
+	Status         EscrowStatus
+	RealmID        string
+	FrozenArb      *FrozenArb
+	ResolutionHash [32]byte
 }
 
 // Clone returns a deep copy of the escrow object so callers can safely mutate


### PR DESCRIPTION
## Summary
- replace the legacy arbitrator transaction flow with a payload that forwards quorum-signed decisions to the escrow engine
- add ResolveWithSignatures to the escrow engine to verify arbitrator signatures, persist the decision hash, and emit enriched resolution events
- extend escrow tests to cover quorum success, failure, and replay scenarios alongside deterministic key generation

## Testing
- go test ./native/escrow -run TestResolveWithSignatures -count=1 -v
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d67b0b3a44832d922dd12be357048f