### PR TITLE
Clarify paymaster sponsorship preview response fields

### DIFF
--- a/docs/launch/paymaster-admin.md
+++ b/docs/launch/paymaster-admin.md
@@ -82,10 +82,15 @@ curl -s \
 
 Response fields:
 
-* `status`: One of `ready`, `module_disabled`, `signature_missing`, `signature_invalid`, `insufficient_balance`, or `none`.
+* `status`: One of `ready`, `module_disabled`, `signature_missing`, `signature_invalid`, `insufficient_balance`, or `none`. A `status` of `none` now carries the reason "transaction does not request sponsorship," distinguishing unsponsored submissions from malformed paymaster payloads.
 * `reason`: Human-readable explanation when the status is not `ready`.
 * `requiredBudgetWei`: Gas limit × price budget expected from the sponsor.
+* `sponsor`: Address that would be charged for gas if sponsorship proceeds.
+* `gasPriceWei`: Effective gas price the sponsor is expected to cover.
+* `willRevert`: Boolean flag set to `true` when the request cannot reach `ApplyMessage`—specifically when `status` is `module_disabled`, `signature_missing`, `signature_invalid`, or `insufficient_balance`.
 * `moduleEnabled`: Echoes the current global toggle.
+
+When `willRevert` is `true`, the node aborts before `ApplyMessage`, meaning the transaction never reaches execution and no sponsor fallback occurs. Integrators must treat these cases as hard failures instead of attempting to fall back to sender-funded gas.
 
 Clients should only broadcast transactions with `status == "ready"` to avoid fallback gas charges to the sender.
 


### PR DESCRIPTION
## Summary
- document additional tx_previewSponsorship response fields, including sponsor, gasPriceWei, and willRevert
- explain why willRevert statuses abort before ApplyMessage and must be treated as hard failures
- clarify that status none indicates the transaction does not request sponsorship

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d68593ad88832db2473ab6f7119c63