### PR TITLE
Add escrow RPC module and CLI helpers

### DIFF
--- a/cmd/nhb/escrowcmd/main.go
+++ b/cmd/nhb/escrowcmd/main.go
@@ -1,0 +1,394 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type rpcRequest struct {
+	JSONRPC string        `json:"jsonrpc"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+	ID      int           `json:"id"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *rpcError       `json:"error"`
+}
+
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+type realmResult struct {
+	ID              string            `json:"id"`
+	Version         uint64            `json:"version"`
+	NextPolicyNonce uint64            `json:"nextPolicyNonce"`
+	CreatedAt       int64             `json:"createdAt"`
+	UpdatedAt       int64             `json:"updatedAt"`
+	Arbitrators     *arbitratorResult `json:"arbitrators,omitempty"`
+}
+
+type arbitratorResult struct {
+	Scheme    string   `json:"scheme"`
+	Threshold uint32   `json:"threshold"`
+	Members   []string `json:"members,omitempty"`
+}
+
+type snapshotResult struct {
+	ID             string        `json:"id"`
+	Payer          string        `json:"payer"`
+	Payee          string        `json:"payee"`
+	Mediator       *string       `json:"mediator,omitempty"`
+	Token          string        `json:"token"`
+	Amount         string        `json:"amount"`
+	FeeBps         uint32        `json:"feeBps"`
+	Deadline       int64         `json:"deadline"`
+	CreatedAt      int64         `json:"createdAt"`
+	Status         string        `json:"status"`
+	Meta           string        `json:"meta"`
+	Realm          *string       `json:"realm,omitempty"`
+	FrozenPolicy   *frozenPolicy `json:"frozenPolicy,omitempty"`
+	ResolutionHash *string       `json:"resolutionHash,omitempty"`
+}
+
+type frozenPolicy struct {
+	RealmID      string   `json:"realmId"`
+	RealmVersion uint64   `json:"realmVersion"`
+	PolicyNonce  uint64   `json:"policyNonce"`
+	Scheme       string   `json:"scheme"`
+	Threshold    uint32   `json:"threshold"`
+	Members      []string `json:"members,omitempty"`
+	FrozenAt     int64    `json:"frozenAt,omitempty"`
+}
+
+type eventResult struct {
+	Sequence   int64             `json:"sequence"`
+	Type       string            `json:"type"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+type escrowCreateResult struct {
+	ID string `json:"id"`
+}
+
+func main() {
+	defaultRPC := strings.TrimSpace(os.Getenv("NHB_RPC_URL"))
+	if defaultRPC == "" {
+		defaultRPC = "http://127.0.0.1:8545"
+	}
+	defaultAuth := strings.TrimSpace(os.Getenv("NHB_RPC_TOKEN"))
+
+	root := flag.NewFlagSet("nhb-escrow", flag.ExitOnError)
+	rpcURL := root.String("rpc", defaultRPC, "JSON-RPC endpoint")
+	authToken := root.String("auth", defaultAuth, "Bearer token for authenticated RPC calls")
+	root.Parse(os.Args[1:])
+
+	args := root.Args()
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, usage())
+		os.Exit(1)
+	}
+
+	code := 0
+	switch args[0] {
+	case "realm":
+		code = runRealmCommand(*rpcURL, *authToken, args[1:])
+	case "snapshot":
+		code = runSnapshotCommand(*rpcURL, *authToken, args[1:])
+	case "events":
+		code = runEventsCommand(*rpcURL, *authToken, args[1:])
+	case "open":
+		code = runOpenCommand(*rpcURL, *authToken, args[1:])
+	case "resolve":
+		code = runResolveCommand(*rpcURL, *authToken, args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", args[0])
+		fmt.Fprintln(os.Stderr, usage())
+		code = 1
+	}
+	if code != 0 {
+		os.Exit(code)
+	}
+}
+
+func runRealmCommand(rpcURL, auth string, args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: realm get --id <realm-id>")
+		return 1
+	}
+	switch args[0] {
+	case "get":
+		fs := flag.NewFlagSet("realm get", flag.ExitOnError)
+		id := fs.String("id", "", "realm identifier")
+		fs.Parse(args[1:])
+		if strings.TrimSpace(*id) == "" {
+			fmt.Fprintln(os.Stderr, "--id is required")
+			return 1
+		}
+		params := []interface{}{map[string]string{"id": strings.TrimSpace(*id)}}
+		result, rpcErr, err := callRPC(rpcURL, auth, "escrow_getRealm", params)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "RPC call failed: %v\n", err)
+			return 1
+		}
+		if rpcErr != nil {
+			printRPCError(rpcErr)
+			return 1
+		}
+		var realm realmResult
+		if err := json.Unmarshal(result, &realm); err != nil {
+			fmt.Fprintf(os.Stderr, "decode realm response: %v\n", err)
+			return 1
+		}
+		if err := printJSON(realm); err != nil {
+			fmt.Fprintf(os.Stderr, "print response: %v\n", err)
+			return 1
+		}
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "unknown realm subcommand: %s\n", args[0])
+		return 1
+	}
+}
+
+func runSnapshotCommand(rpcURL, auth string, args []string) int {
+	fs := flag.NewFlagSet("snapshot", flag.ExitOnError)
+	id := fs.String("id", "", "escrow identifier")
+	fs.Parse(args)
+	if strings.TrimSpace(*id) == "" {
+		fmt.Fprintln(os.Stderr, "--id is required")
+		return 1
+	}
+	params := []interface{}{map[string]string{"id": strings.TrimSpace(*id)}}
+	result, rpcErr, err := callRPC(rpcURL, auth, "escrow_getSnapshot", params)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "RPC call failed: %v\n", err)
+		return 1
+	}
+	if rpcErr != nil {
+		printRPCError(rpcErr)
+		return 1
+	}
+	var snapshot snapshotResult
+	if err := json.Unmarshal(result, &snapshot); err != nil {
+		fmt.Fprintf(os.Stderr, "decode snapshot response: %v\n", err)
+		return 1
+	}
+	if err := printJSON(snapshot); err != nil {
+		fmt.Fprintf(os.Stderr, "print response: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runEventsCommand(rpcURL, auth string, args []string) int {
+	fs := flag.NewFlagSet("events", flag.ExitOnError)
+	prefix := fs.String("prefix", "", "optional event type prefix (default escrow.)")
+	limitFlag := fs.Int("limit", 0, "maximum number of events to return")
+	fs.Parse(args)
+	var params []interface{}
+	payload := make(map[string]interface{})
+	if strings.TrimSpace(*prefix) != "" {
+		payload["prefix"] = strings.TrimSpace(*prefix)
+	}
+	if *limitFlag > 0 {
+		payload["limit"] = *limitFlag
+	}
+	if len(payload) > 0 {
+		params = []interface{}{payload}
+	}
+	result, rpcErr, err := callRPC(rpcURL, auth, "escrow_listEvents", params)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "RPC call failed: %v\n", err)
+		return 1
+	}
+	if rpcErr != nil {
+		printRPCError(rpcErr)
+		return 1
+	}
+	var events []eventResult
+	if err := json.Unmarshal(result, &events); err != nil {
+		fmt.Fprintf(os.Stderr, "decode events response: %v\n", err)
+		return 1
+	}
+	if err := printJSON(events); err != nil {
+		fmt.Fprintf(os.Stderr, "print response: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runOpenCommand(rpcURL, auth string, args []string) int {
+	fs := flag.NewFlagSet("open", flag.ExitOnError)
+	payer := fs.String("payer", "", "payer Bech32 address")
+	payee := fs.String("payee", "", "payee Bech32 address")
+	token := fs.String("token", "NHB", "token symbol (NHB or ZNHB)")
+	amount := fs.String("amount", "", "escrow amount in wei")
+	feeBps := fs.Uint("fee-bps", 0, "escrow fee in basis points")
+	deadline := fs.Int64("deadline", 0, "escrow deadline as unix timestamp")
+	mediator := fs.String("mediator", "", "optional mediator address")
+	meta := fs.String("meta", "", "optional 0x-prefixed metadata hash")
+	realm := fs.String("realm", "", "optional realm identifier")
+	fs.Parse(args)
+
+	if strings.TrimSpace(*payer) == "" {
+		fmt.Fprintln(os.Stderr, "--payer is required")
+		return 1
+	}
+	if strings.TrimSpace(*payee) == "" {
+		fmt.Fprintln(os.Stderr, "--payee is required")
+		return 1
+	}
+	if strings.TrimSpace(*amount) == "" {
+		fmt.Fprintln(os.Stderr, "--amount is required")
+		return 1
+	}
+	if *deadline <= 0 {
+		fmt.Fprintln(os.Stderr, "--deadline must be a unix timestamp in the future")
+		return 1
+	}
+	params := map[string]interface{}{
+		"payer":    strings.TrimSpace(*payer),
+		"payee":    strings.TrimSpace(*payee),
+		"token":    strings.ToUpper(strings.TrimSpace(*token)),
+		"amount":   strings.TrimSpace(*amount),
+		"feeBps":   *feeBps,
+		"deadline": *deadline,
+	}
+	if trimmed := strings.TrimSpace(*mediator); trimmed != "" {
+		params["mediator"] = trimmed
+	}
+	if trimmed := strings.TrimSpace(*meta); trimmed != "" {
+		params["meta"] = trimmed
+	}
+	if trimmed := strings.TrimSpace(*realm); trimmed != "" {
+		params["realm"] = trimmed
+	}
+	payload := []interface{}{params}
+	result, rpcErr, err := callRPC(rpcURL, auth, "escrow_create", payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "RPC call failed: %v\n", err)
+		return 1
+	}
+	if rpcErr != nil {
+		printRPCError(rpcErr)
+		return 1
+	}
+	var created escrowCreateResult
+	if err := json.Unmarshal(result, &created); err != nil {
+		fmt.Fprintf(os.Stderr, "decode escrow response: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Escrow opened with id %s\n", created.ID)
+	return 0
+}
+
+func runResolveCommand(rpcURL, auth string, args []string) int {
+	fs := flag.NewFlagSet("resolve", flag.ExitOnError)
+	id := fs.String("id", "", "escrow identifier")
+	caller := fs.String("caller", "", "arbitrator Bech32 address")
+	outcome := fs.String("outcome", "", "resolution outcome (release or refund)")
+	fs.Parse(args)
+	if strings.TrimSpace(*id) == "" {
+		fmt.Fprintln(os.Stderr, "--id is required")
+		return 1
+	}
+	if strings.TrimSpace(*caller) == "" {
+		fmt.Fprintln(os.Stderr, "--caller is required")
+		return 1
+	}
+	normalizedOutcome := strings.ToLower(strings.TrimSpace(*outcome))
+	if normalizedOutcome != "release" && normalizedOutcome != "refund" {
+		fmt.Fprintln(os.Stderr, "--outcome must be release or refund")
+		return 1
+	}
+	params := []interface{}{map[string]string{
+		"id":      strings.TrimSpace(*id),
+		"caller":  strings.TrimSpace(*caller),
+		"outcome": normalizedOutcome,
+	}}
+	_, rpcErr, err := callRPC(rpcURL, auth, "escrow_resolve", params)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "RPC call failed: %v\n", err)
+		return 1
+	}
+	if rpcErr != nil {
+		printRPCError(rpcErr)
+		return 1
+	}
+	fmt.Println("Arbitration payload submitted successfully.")
+	return 0
+}
+
+func callRPC(rpcURL, authToken, method string, params []interface{}) (json.RawMessage, *rpcError, error) {
+	if params == nil {
+		params = []interface{}{}
+	}
+	reqBody := rpcRequest{JSONRPC: "2.0", Method: method, Params: params, ID: int(time.Now().UnixNano())}
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+	httpReq, err := http.NewRequest(http.MethodPost, rpcURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if strings.TrimSpace(authToken) != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+strings.TrimSpace(authToken))
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, nil, fmt.Errorf("rpc status %d: %s", resp.StatusCode, string(body))
+	}
+	var rpcResp rpcResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return nil, nil, err
+	}
+	if rpcResp.Error != nil {
+		return nil, rpcResp.Error, nil
+	}
+	return rpcResp.Result, nil, nil
+}
+
+func printRPCError(err *rpcError) {
+	if err == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "RPC error (%d): %s\n", err.Code, err.Message)
+	if len(err.Data) > 0 && string(err.Data) != "null" {
+		fmt.Fprintf(os.Stderr, "Details: %s\n", strings.TrimSpace(string(err.Data)))
+	}
+}
+
+func printJSON(v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+func usage() string {
+	return "nhb-escrow usage:\n  nhb-escrow [--rpc URL] [--auth TOKEN] <command> [options]\n\nCommands:\n  realm get --id <realm>       Display arbitration realm metadata\n  snapshot --id <escrow>        Fetch escrow snapshot including frozen policy\n  events [--prefix P] [--limit N]  List recent escrow.* events\n  open --payer A --payee B --token T --amount X --fee-bps N --deadline TS [--realm R] [--mediator M] [--meta 0x..]\n  resolve --id E --caller A --outcome release|refund\n"
+}

--- a/docs/rpc_escrow_module.md
+++ b/docs/rpc_escrow_module.md
@@ -1,0 +1,119 @@
+# Escrow RPC Module
+
+The `escrow` module surfaces read-only helpers for governance tooling and arbitration dashboards. It complements the transactional `escrow_*` endpoints by exposing realm metadata, deterministic escrow snapshots (including frozen arbitrator policies), and the raw event feed used by downstream indexers.
+
+## Methods
+
+### `escrow_getRealm`
+
+Returns the latest arbitration realm definition.
+
+**Parameters**
+
+- `id` – realm identifier (`string`).
+
+**Result**
+
+```json
+{
+  "id": "core",
+  "version": 3,
+  "nextPolicyNonce": 42,
+  "createdAt": 1716403200,
+  "updatedAt": 1719081600,
+  "arbitrators": {
+    "scheme": "committee",
+    "threshold": 2,
+    "members": ["nhb1…", "nhb1…"]
+  }
+}
+```
+
+### `escrow_getSnapshot`
+
+Fetches the canonical escrow record and any frozen arbitrator policy captured at creation time.
+
+**Parameters**
+
+- `id` – escrow identifier (`0x`-prefixed hex string).
+
+**Result**
+
+```json
+{
+  "id": "0x…",
+  "payer": "nhb1…",
+  "payee": "nhb1…",
+  "token": "NHB",
+  "amount": "1000000000000000000",
+  "feeBps": 50,
+  "deadline": 1720204800,
+  "createdAt": 1719952000,
+  "status": "funded",
+  "meta": "0x…",
+  "realm": "core",
+  "frozenPolicy": {
+    "realmId": "core",
+    "realmVersion": 3,
+    "policyNonce": 17,
+    "scheme": "committee",
+    "threshold": 2,
+    "members": ["nhb1…", "nhb1…"],
+    "frozenAt": 1719952000
+  }
+}
+```
+
+If a dispute has been resolved the `resolutionHash` field contains the recorded decision payload hash.
+
+### `escrow_listEvents`
+
+Streams recent `escrow.*` events emitted by the node. Front-ends can use these payloads to display signer fingerprints (`decisionSigners`), frozen policy metadata, and realm lifecycle information without custom parsing.
+
+**Parameters (optional)**
+
+- `prefix` – filter by event type prefix (defaults to `escrow.`).
+- `limit` – maximum number of events to return.
+
+**Result**
+
+```json
+[
+  {
+    "sequence": 1,
+    "type": "escrow.realm.updated",
+    "attributes": {
+      "realmId": "core",
+      "version": "3",
+      "arbScheme": "1",
+      "arbThreshold": "2",
+      "arbitrators": "0x…"
+    }
+  }
+]
+```
+
+## CLI Helper
+
+A lightweight CLI (`cmd/nhb/escrowcmd`) is available for interacting with the new endpoints:
+
+```bash
+# Fetch realm metadata
+nhb-escrow realm get --id core
+
+# Inspect an escrow snapshot (including frozen arbitrator policy)
+nhb-escrow snapshot --id 0x…
+
+# Tail recent escrow events for dashboards or indexers
+nhb-escrow events --limit 10
+
+# Open a new escrow and submit arbitration outcomes via RPC
+nhb-escrow open --payer nhb1... --payee nhb1... --token NHB --amount 1000000000000000000 --fee-bps 50 --deadline 1720204800 --realm core
+nhb-escrow resolve --id 0x... --caller nhb1... --outcome release
+```
+
+The CLI honours `--auth`/`NHB_RPC_TOKEN` and `--rpc`/`NHB_RPC_URL` for secure deployments.
+
+## Event Stream Integration
+
+The existing gateway indexer now receives the enriched `escrow.*` events returned by `escrow_listEvents`. Because every attribute is persisted in SQLite and propagated to webhooks, front-ends can display signer fingerprints (`decisionSigners`), frozen arbitrator policies (`realmVersion`, `policyNonce`, `arbThreshold`, `arbitrators`), and other metadata without additional state reads.

--- a/rpc/modules/escrow.go
+++ b/rpc/modules/escrow.go
@@ -1,0 +1,335 @@
+package modules
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"nhbchain/core"
+	nhbstate "nhbchain/core/state"
+	"nhbchain/crypto"
+	"nhbchain/native/escrow"
+)
+
+// EscrowModule exposes read helpers for escrow governance metadata and event history.
+type EscrowModule struct {
+	node *core.Node
+}
+
+// NewEscrowModule constructs an escrow RPC helper module.
+func NewEscrowModule(node *core.Node) *EscrowModule {
+	return &EscrowModule{node: node}
+}
+
+type getRealmParams struct {
+	ID string `json:"id"`
+}
+
+type getSnapshotParams struct {
+	ID string `json:"id"`
+}
+
+type listEventsParams struct {
+	Prefix string `json:"prefix,omitempty"`
+	Limit  *int   `json:"limit,omitempty"`
+}
+
+// EscrowRealmResult represents an arbitration realm definition returned over RPC.
+type EscrowRealmResult struct {
+	ID              string                  `json:"id"`
+	Version         uint64                  `json:"version"`
+	NextPolicyNonce uint64                  `json:"nextPolicyNonce"`
+	CreatedAt       int64                   `json:"createdAt"`
+	UpdatedAt       int64                   `json:"updatedAt"`
+	Arbitrators     *EscrowArbitratorResult `json:"arbitrators,omitempty"`
+}
+
+// EscrowArbitratorResult captures the resolved arbitrator policy for a realm.
+type EscrowArbitratorResult struct {
+	Scheme    string   `json:"scheme"`
+	Threshold uint32   `json:"threshold"`
+	Members   []string `json:"members,omitempty"`
+}
+
+// EscrowSnapshotResult describes the latest persisted escrow state along with
+// any frozen arbitration policy metadata.
+type EscrowSnapshotResult struct {
+	ID             string              `json:"id"`
+	Payer          string              `json:"payer"`
+	Payee          string              `json:"payee"`
+	Mediator       *string             `json:"mediator,omitempty"`
+	Token          string              `json:"token"`
+	Amount         string              `json:"amount"`
+	FeeBps         uint32              `json:"feeBps"`
+	Deadline       int64               `json:"deadline"`
+	CreatedAt      int64               `json:"createdAt"`
+	Status         string              `json:"status"`
+	Meta           string              `json:"meta"`
+	Realm          *string             `json:"realm,omitempty"`
+	FrozenPolicy   *FrozenPolicyResult `json:"frozenPolicy,omitempty"`
+	ResolutionHash *string             `json:"resolutionHash,omitempty"`
+}
+
+// FrozenPolicyResult exposes the immutable arbitrator policy captured at
+// escrow creation time.
+type FrozenPolicyResult struct {
+	RealmID      string   `json:"realmId"`
+	RealmVersion uint64   `json:"realmVersion"`
+	PolicyNonce  uint64   `json:"policyNonce"`
+	Scheme       string   `json:"scheme"`
+	Threshold    uint32   `json:"threshold"`
+	Members      []string `json:"members,omitempty"`
+	FrozenAt     int64    `json:"frozenAt,omitempty"`
+}
+
+// EscrowEventResult represents an emitted escrow-related event.
+type EscrowEventResult struct {
+	Sequence   int64             `json:"sequence"`
+	Type       string            `json:"type"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+var (
+	errRealmNotFound = errors.New("escrow realm not found")
+	errModuleOffline = &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: "escrow module not initialised"}
+)
+
+// GetRealm resolves the supplied arbitration realm identifier.
+func (m *EscrowModule) GetRealm(raw json.RawMessage) (*EscrowRealmResult, *ModuleError) {
+	if m == nil || m.node == nil {
+		return nil, errModuleOffline
+	}
+	var params getRealmParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "invalid parameter object", Data: err.Error()}
+	}
+	trimmed := strings.TrimSpace(params.ID)
+	if trimmed == "" {
+		return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "id is required"}
+	}
+	var realm *escrow.EscrowRealm
+	err := m.node.WithState(func(manager *nhbstate.Manager) error {
+		resolved, ok, getErr := manager.EscrowRealmGet(trimmed)
+		if getErr != nil {
+			return getErr
+		}
+		if !ok {
+			return errRealmNotFound
+		}
+		realm = resolved
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, errRealmNotFound) {
+			return nil, &ModuleError{HTTPStatus: http.StatusNotFound, Code: codeInvalidParams, Message: "realm not found"}
+		}
+		return nil, &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: err.Error()}
+	}
+	result := formatRealmResult(realm)
+	return &result, nil
+}
+
+// GetSnapshot fetches the canonical escrow state for the provided identifier.
+func (m *EscrowModule) GetSnapshot(raw json.RawMessage) (*EscrowSnapshotResult, *ModuleError) {
+	if m == nil || m.node == nil {
+		return nil, errModuleOffline
+	}
+	var params getSnapshotParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "invalid parameter object", Data: err.Error()}
+	}
+	id, err := parseEscrowID(params.ID)
+	if err != nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: err.Error()}
+	}
+	snapshot, err := m.node.EscrowGet(id)
+	if err != nil {
+		if errors.Is(err, core.ErrEscrowNotFound) {
+			return nil, &ModuleError{HTTPStatus: http.StatusNotFound, Code: codeInvalidParams, Message: "escrow not found"}
+		}
+		return nil, &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: err.Error()}
+	}
+	result := formatSnapshotResult(snapshot)
+	return result, nil
+}
+
+// ListEvents returns recent escrow-related events emitted by the node. The
+// optional prefix parameter can narrow results to a specific namespace such as
+// "escrow.realm.".
+func (m *EscrowModule) ListEvents(raw json.RawMessage) ([]EscrowEventResult, *ModuleError) {
+	if m == nil || m.node == nil {
+		return nil, errModuleOffline
+	}
+	var params listEventsParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "invalid parameter object", Data: err.Error()}
+		}
+	}
+	prefix := "escrow."
+	if trimmed := strings.TrimSpace(params.Prefix); trimmed != "" {
+		prefix = trimmed
+	}
+	normalizedPrefix := strings.ToLower(prefix)
+	events := m.node.Events()
+	results := make([]EscrowEventResult, 0, len(events))
+	for _, evt := range events {
+		if !strings.HasPrefix(strings.ToLower(evt.Type), normalizedPrefix) {
+			continue
+		}
+		attrs := make(map[string]string, len(evt.Attributes))
+		for k, v := range evt.Attributes {
+			attrs[k] = v
+		}
+		results = append(results, EscrowEventResult{Type: evt.Type, Attributes: attrs})
+	}
+	if params.Limit != nil {
+		limit := *params.Limit
+		if limit < 0 {
+			limit = 0
+		}
+		if limit < len(results) {
+			results = results[:limit]
+		}
+	}
+	for i := range results {
+		results[i].Sequence = int64(i + 1)
+	}
+	return results, nil
+}
+
+func formatRealmResult(realm *escrow.EscrowRealm) EscrowRealmResult {
+	if realm == nil {
+		return EscrowRealmResult{}
+	}
+	result := EscrowRealmResult{
+		ID:              strings.TrimSpace(realm.ID),
+		Version:         realm.Version,
+		NextPolicyNonce: realm.NextPolicyNonce,
+		CreatedAt:       realm.CreatedAt,
+		UpdatedAt:       realm.UpdatedAt,
+	}
+	if realm.Arbitrators != nil {
+		result.Arbitrators = &EscrowArbitratorResult{
+			Scheme:    formatScheme(realm.Arbitrators.Scheme),
+			Threshold: realm.Arbitrators.Threshold,
+			Members:   formatAddressList(realm.Arbitrators.Members),
+		}
+	}
+	return result
+}
+
+func formatSnapshotResult(esc *escrow.Escrow) *EscrowSnapshotResult {
+	if esc == nil {
+		return nil
+	}
+	amount := "0"
+	if esc.Amount != nil {
+		amount = esc.Amount.String()
+	}
+	result := &EscrowSnapshotResult{
+		ID:        formatEscrowID(esc.ID),
+		Payer:     crypto.NewAddress(crypto.NHBPrefix, esc.Payer[:]).String(),
+		Payee:     crypto.NewAddress(crypto.NHBPrefix, esc.Payee[:]).String(),
+		Token:     esc.Token,
+		Amount:    amount,
+		FeeBps:    esc.FeeBps,
+		Deadline:  esc.Deadline,
+		CreatedAt: esc.CreatedAt,
+		Status:    escrowStatusString(esc.Status),
+		Meta:      "0x" + hex.EncodeToString(esc.MetaHash[:]),
+	}
+	if esc.Mediator != ([20]byte{}) {
+		mediator := crypto.NewAddress(crypto.NHBPrefix, esc.Mediator[:]).String()
+		result.Mediator = &mediator
+	}
+	if trimmed := strings.TrimSpace(esc.RealmID); trimmed != "" {
+		realm := trimmed
+		result.Realm = &realm
+	}
+	if esc.FrozenArb != nil {
+		result.FrozenPolicy = &FrozenPolicyResult{
+			RealmID:      strings.TrimSpace(esc.FrozenArb.RealmID),
+			RealmVersion: esc.FrozenArb.RealmVersion,
+			PolicyNonce:  esc.FrozenArb.PolicyNonce,
+			Scheme:       formatScheme(esc.FrozenArb.Scheme),
+			Threshold:    esc.FrozenArb.Threshold,
+			Members:      formatAddressList(esc.FrozenArb.Members),
+			FrozenAt:     esc.FrozenArb.FrozenAt,
+		}
+	}
+	if esc.ResolutionHash != ([32]byte{}) {
+		hash := "0x" + hex.EncodeToString(esc.ResolutionHash[:])
+		result.ResolutionHash = &hash
+	}
+	return result
+}
+
+func formatScheme(s escrow.ArbitrationScheme) string {
+	switch s {
+	case escrow.ArbitrationSchemeSingle:
+		return "single"
+	case escrow.ArbitrationSchemeCommittee:
+		return "committee"
+	default:
+		return "unspecified"
+	}
+}
+
+func formatAddressList(members [][20]byte) []string {
+	if len(members) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(members))
+	for _, member := range members {
+		if member == ([20]byte{}) {
+			continue
+		}
+		out = append(out, crypto.NewAddress(crypto.NHBPrefix, member[:]).String())
+	}
+	return out
+}
+
+func parseEscrowID(id string) ([32]byte, error) {
+	var out [32]byte
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return out, fmt.Errorf("id required")
+	}
+	cleaned := strings.TrimPrefix(strings.TrimPrefix(trimmed, "0x"), "0X")
+	if len(cleaned) != 64 {
+		return out, fmt.Errorf("id must be 32 bytes")
+	}
+	bytes, err := hex.DecodeString(cleaned)
+	if err != nil {
+		return out, err
+	}
+	copy(out[:], bytes)
+	return out, nil
+}
+
+func formatEscrowID(id [32]byte) string {
+	return "0x" + hex.EncodeToString(id[:])
+}
+
+func escrowStatusString(status escrow.EscrowStatus) string {
+	switch status {
+	case escrow.EscrowInit:
+		return "init"
+	case escrow.EscrowFunded:
+		return "funded"
+	case escrow.EscrowReleased:
+		return "released"
+	case escrow.EscrowRefunded:
+		return "refunded"
+	case escrow.EscrowExpired:
+		return "expired"
+	case escrow.EscrowDisputed:
+		return "disputed"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
## Summary
- add an escrow RPC module that surfaces realm metadata, escrow snapshots, and filtered event feeds
- wire the module into the JSON-RPC server and add a lightweight CLI for realm, snapshot, event, open, and resolve helpers
- document the new endpoints and CLI usage for downstream integrators

## Testing
- go test ./...

------
https://chatgpt.com/codex/tasks/task_e_68d6863d2e30832d9b7417f9ec555951