### PR TITLE
Require explicit genesis configuration by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,14 @@ This produces two executables:
 
 ### Initial Configuration
 
-On first launch the node creates `config.toml` alongside an encrypted validator keystore. To pre-configure or inspect settings, edit `config.toml`:
+On first launch the node creates `config.toml` alongside an encrypted validator keystore. To pre-configure or inspect settings, edit `config.toml` and point `GenesisFile` at the vetted genesis JSON supplied by network operations (autogenesis is only for isolated dev workflows):
 
 ```toml
 ListenAddress = "0.0.0.0:6001"
 RPCAddress    = "0.0.0.0:8080"
 DataDir       = "./nhb-data"
+GenesisFile   = "./config/genesis.json" # required: must match the network's published hash
+AllowAutogenesis = false                 # dev override; never enable on shared networks
 ValidatorKeystorePath = ""
 NetworkName = "nhb-local"
 Bootnodes = [

--- a/config-local.toml
+++ b/config-local.toml
@@ -1,7 +1,10 @@
 ListenAddress = "0.0.0.0:6002"
 RPCAddress = "0.0.0.0:8081"
 DataDir = "./nhb-data-local"
-GenesisFile = ""
+# Required: point to the genesis file that defines your local dev network.
+GenesisFile = "./config/local-genesis.json"
+# Set to true only if you intentionally want the node to fabricate an ephemeral genesis.
+AllowAutogenesis = false
 ValidatorKeystorePath = "./validator-local.keystore"
 ValidatorKMSURI = ""
 ValidatorKMSEnv = ""

--- a/config-peer.toml
+++ b/config-peer.toml
@@ -1,7 +1,10 @@
 ListenAddress = ":6002"
 RPCAddress = ":8081"
 DataDir = "./nhb-data-peer"
-GenesisFile = ""
+# Required: point to the genesis file distributed by the network operator.
+GenesisFile = "./config/genesis.json"
+# Never set this to true on shared networks; it is only for isolated dev clusters.
+AllowAutogenesis = false
 ValidatorKeystorePath = "./validator-peer.keystore"
 ValidatorKMSURI = ""
 ValidatorKMSEnv = ""

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,10 @@
 ListenAddress = ":6001"
 RPCAddress = ":8080"
 DataDir = "./nhb-data"
-GenesisFile = ""
+# Provide the absolute or relative path to the vetted genesis file for this network.
+GenesisFile = "./config/genesis.json"
+# DEV ONLY: override to true exclusively for ephemeral local testing.
+AllowAutogenesis = false
 ValidatorKeystorePath = ""
 ValidatorKMSURI = ""
 ValidatorKMSEnv = ""

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	RPCAddress            string      `toml:"RPCAddress"`
 	DataDir               string      `toml:"DataDir"`
 	GenesisFile           string      `toml:"GenesisFile"`
+	AllowAutogenesis      bool        `toml:"AllowAutogenesis"`
 	ValidatorKeystorePath string      `toml:"ValidatorKeystorePath"`
 	ValidatorKMSURI       string      `toml:"ValidatorKMSURI"`
 	ValidatorKMSEnv       string      `toml:"ValidatorKMSEnv"`
@@ -628,6 +629,7 @@ func createDefault(path string) (*Config, error) {
 		RPCAddress:       ":8080",
 		DataDir:          "./nhb-data",
 		GenesisFile:      "",
+		AllowAutogenesis: false,
 		NetworkName:      "nhb-local",
 		Bootnodes:        []string{},
 		PersistentPeers:  []string{},

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -294,10 +294,11 @@ func genesisFromSource(path string, allowAutogenesis bool, db storage.Database) 
 	}
 
 	if !allowAutogenesis {
-		return nil, nil, fmt.Errorf("no genesis block present and autogenesis disabled")
+		fmt.Println("No genesis configuration found and autogenesis disabled; refusing to create an unsafe default genesis.")
+		return nil, nil, fmt.Errorf("genesis is required; provide a vetted genesis file or enable the autogenesis override for development use only")
 	}
 
-	fmt.Println("Auto-genesis created (dev mode)")
+	fmt.Println("Autogenesis override enabled (dev mode); creating ephemeral genesis block.")
 	return createGenesisBlock(), nil, nil
 }
 

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -34,6 +34,8 @@ func TestNewBlockchainRequiresGenesisWhenAutogenesisDisabled(t *testing.T) {
 
 	if _, err := NewBlockchain(db, "", false); err == nil {
 		t.Fatalf("expected error when genesis is required but unavailable")
+	} else if !strings.Contains(err.Error(), "genesis is required") {
+		t.Fatalf("unexpected error message: %v", err)
 	}
 }
 

--- a/docs/governance/devnet-runbook.md
+++ b/docs/governance/devnet-runbook.md
@@ -86,10 +86,12 @@ Start the node (keep this terminal running):
 export NHB_VALIDATOR_PASS=""
 export NHB_RPC_TOKEN="devnet-token"
 RPC_URL="http://127.0.0.1:8081"
+# Explicitly opt into autogenesis for this throwaway devnet instance.
 GOFLAGS=-buildvcs=false bin/nhb-node --config ./devnet.toml --allow-autogenesis
 ```
 
-The first boot creates `validator-devnet.keystore`, autogenerates a genesis block, and logs the validator address.
+The first boot creates `validator-devnet.keystore`, autogenerates a genesis block, and logs the validator address. You can also
+set `NHB_ALLOW_AUTOGENESIS=1` or `AllowAutogenesis = true` in `devnet.toml` if you prefer environment or config-based overrides.
 
 ## 3. Bootstrap accounts & voting power
 


### PR DESCRIPTION
## Summary
- default the nhb-node autogenesis flag to false and add environment/config overrides when explicitly enabled for dev
- enforce clearer error handling in the blockchain when no genesis is provided and update CLI tests for the new override logic
- require genesis file paths in config templates and onboarding docs, including guidance for dev-only autogenesis overrides

## Testing
- `go test ./cmd/nhb ./core ./config`


------
https://chatgpt.com/codex/tasks/task_e_68d68ad20bfc832d91efd1bac520e848