### PR TITLE
Update examples workspace defaults for public NHB endpoints

### DIFF
--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -23,9 +23,10 @@ The first run installs dependencies, generates the SDK build artifacts (if any),
 
 | Variable | Description |
 | --- | --- |
-| `NHB_RPC_URL` | JSON-RPC endpoint for the NHB gateway. |
-| `NHB_REST_URL` | REST endpoint for the NHB gateway. |
-| `NHB_CHAIN_ID` | Chain identifier used when signing transactions or queries. |
+| `NHB_RPC_URL` | JSON-RPC endpoint for the NHB gateway (HTTP). |
+| `NHB_WS_URL` | WebSocket JSON-RPC endpoint used for subscriptions and streaming. |
+| `NHB_API_URL` | REST gateway that powers escrow, swap, and loyalty flows. |
+| `NHB_CHAIN_ID` | Numeric chain identifier attached to signed requests. |
 | `NHB_API_KEY` | Gateway API key used for authenticated requests. |
 | `NHB_API_SECRET` | Secret used to compute the HMAC signature header. |
 | `NHB_WALLET_PRIVATE_KEY` | Optional wallet private key for demo transactions. |
@@ -33,7 +34,30 @@ The first run installs dependencies, generates the SDK build artifacts (if any),
 | `STATUS_DASHBOARD_PORT` | HTTP port for the status dashboard example. |
 | `NETWORK_MONITOR_PORT` | HTTP port for the network monitor example. |
 
-> **Tip:** Never commit the `.env` file to version control. The `.env.example` template intentionally uses placeholder values.
+### Default endpoints
+
+The `.env.example` template points at the public NHB infrastructure so a fresh clone works out-of-the-box:
+
+- `https://rpc.nhbcoin.net` for HTTP JSON-RPC calls
+- `wss://ws.nhbcoin.net` for WebSocket subscriptions
+- `https://api.nhbcoin.net` for REST and gateway integrations
+
+Rotate the demo API credentials before deploying to production.
+
+### Pointing to self-hosted infrastructure
+
+If you are running your own RPC or gateway stack, update the `.env` file with your endpoints and chain ID. Each app reads the shared `.env`, so no other configuration changes are required. When fronting the services with custom domains:
+
+1. Issue TLS certificates (ACM recommended on AWS) that cover your domains.
+2. Update the `NHB_RPC_URL`, `NHB_WS_URL`, and `NHB_API_URL` values to use the new hostnames.
+3. Restart `yarn dev` or reload the individual apps to pick up the changes.
+
+> **Tip:** Never commit the `.env` file to version control. The `.env.example` template intentionally uses placeholder credentials.
+
+### CORS and rate limits
+
+- Enable CORS on the REST gateway for the origins that host your demo applications. For production, prefer an API gateway or reverse proxy that enforces stricter allowlists.
+- Apply rate limits and Web Application Firewall (WAF) rules, especially on write paths such as swaps or escrow releases. The provided AWS notes in `examples/README.md` outline recommended ALB/NLB placements and Shield integration.
 
 ## Running locally
 

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,11 +1,14 @@
-# RPC endpoints
-NHB_RPC_URL=http://localhost:8545
-NHB_REST_URL=http://localhost:1317
-NHB_CHAIN_ID=nhb-localnet-1
-
-# Gateway authentication
-NHB_API_KEY=demo-api-key
-NHB_API_SECRET=demo-api-secret
+# Public RPC (HTTP)
+NHB_RPC_URL=https://rpc.nhbcoin.net
+# Public RPC (WebSocket)
+NHB_WS_URL=wss://ws.nhbcoin.net
+# REST Gateway (escrow/swap/loyalty)
+NHB_API_URL=https://api.nhbcoin.net
+# Chain ID
+NHB_CHAIN_ID=187001
+# HMAC demo creds (rotate in real env)
+NHB_API_KEY=demo-key
+NHB_API_SECRET=demo-secret
 
 # Optional wallet for signing
 NHB_WALLET_PRIVATE_KEY=0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,9 +18,15 @@ yarn dev
 
 `yarn dev` starts every application in the workspace. Each app watches the shared `.env` file and exposes a health endpoint.
 
+The sample configuration defaults to the public NHB infrastructure:
+
+- `https://rpc.nhbcoin.net` for JSON-RPC (HTTP)
+- `wss://ws.nhbcoin.net` for JSON-RPC (WebSocket)
+- `https://api.nhbcoin.net` for REST, escrow, swap, and loyalty flows
+
 ## Environment
 
-The `.env` file is shared across every app in the workspace. See [docs/examples/overview.md](../docs/examples/overview.md) for an explanation of all variables.
+The `.env` file is shared across every app in the workspace. See [docs/examples/overview.md](../docs/examples/overview.md) for an explanation of all variables and how to target self-hosted endpoints.
 
 ## Workspace layout
 
@@ -51,3 +57,12 @@ yarn test
 - Ensure the `.env` file exists and contains the gateway credentials.
 - Ports are configurable through environment variables (`STATUS_DASHBOARD_PORT`, `NETWORK_MONITOR_PORT`).
 - `yarn dev` uses long-running processes; stop them with `Ctrl+C`.
+
+## AWS deployment notes
+
+- Host the example gateway workloads on **ECS Fargate** or **EKS** for managed scaling and IAM integration.
+- Use **Route 53** records that map to your load balancers:
+  - `rpc.nhbcoin.net` → Application or Network Load Balancer for HTTP JSON-RPC traffic.
+  - `ws.nhbcoin.net` → Network Load Balancer tuned for long-lived WebSocket connections.
+  - `api.nhbcoin.net` → Application Load Balancer for REST and gateway APIs.
+- Request ACM certificates that cover `*.nhbcoin.net` and enable AWS Shield along with WAF rules. Rate-limit or geo/IP allowlist sensitive write paths.

--- a/examples/apps/network-monitor/dev-server.js
+++ b/examples/apps/network-monitor/dev-server.js
@@ -66,8 +66,9 @@ const server = http.createServer(async (req, res) => {
   if (url.pathname === '/metrics' && req.method === 'GET') {
     json(res, {
       status: 'ok',
-      rpcUrl: process.env.NHB_RPC_URL,
-      restUrl: process.env.NHB_REST_URL,
+      rpcHttpUrl: process.env.NHB_RPC_URL,
+      rpcWsUrl: process.env.NHB_WS_URL,
+      apiUrl: process.env.NHB_API_URL,
       chainId: process.env.NHB_CHAIN_ID,
     });
     return;


### PR DESCRIPTION
## Summary
- align the examples environment template with the nhbcoin.net public RPC, WS, and API endpoints
- expand the examples README with default infrastructure context and AWS deployment guidance
- refresh the examples overview doc and network monitor metrics to document the new endpoints and self-hosting guidance

## Testing
- yarn --cwd examples workspace @nhb/examples-lib-sdk test

------
https://chatgpt.com/codex/tasks/task_e_68d69fbfa708832db850fb3dcc799fe6