### PR TITLE
Add merchant loyalty console Next.js example

### DIFF
--- a/examples/merchant-loyalty-console/.gitignore
+++ b/examples/merchant-loyalty-console/.gitignore
@@ -1,0 +1,4 @@
+.next
+out
+node_modules
+.env.local

--- a/examples/merchant-loyalty-console/README.md
+++ b/examples/merchant-loyalty-console/README.md
@@ -1,0 +1,33 @@
+# Merchant Loyalty Console
+
+A Next.js dashboard for NHBChain loyalty operations teams. It lets you:
+
+- Create loyalty businesses and register paymasters.
+- Manage merchant assignments and rotate pools without leaving the browser.
+- Configure loyalty programs that accrue ZNHB at settlement.
+- Track daily reward stats to verify that accruals fire after real escrow payments.
+
+## Getting started
+
+```bash
+yarn install
+yarn workspace @nhb/merchant-loyalty-console dev
+```
+
+Set the RPC endpoint and authentication token before running in production:
+
+```bash
+export NHB_RPC_URL=https://api.nhbcoin.net/rpc
+export NHB_RPC_TOKEN=... # bearer token for privileged RPCs
+```
+
+By default the console proxies JSON-RPC calls through `app/api/rpc/route.ts`. The proxy automatically attaches the bearer token for privileged methods like `loyalty_createBusiness` and `loyalty_setPaymaster`.
+
+## Features
+
+- **Business bootstrap:** Create a business, add merchants, and rotate paymasters via JSON-RPC (`loyalty_*`).
+- **Program orchestration:** Generate deterministic program IDs, configure accrual rates, and pause/resume programs.
+- **Stats monitor:** Pull `loyalty_programStats` and `loyalty_paymasterBalance` to verify ZNHB accrual after settlements.
+- **Auto-refresh:** Optional polling keeps paymaster balances and program stats current when payments settle in real time.
+
+Refer to [`docs/loyalty/loyalty.md`](../../docs/loyalty/loyalty.md) for RPC semantics and role requirements.

--- a/examples/merchant-loyalty-console/app/api/rpc/route.ts
+++ b/examples/merchant-loyalty-console/app/api/rpc/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const DEFAULT_RPC = 'https://api.nhbcoin.net/rpc';
+
+const rpcUrl = (process.env.NHB_RPC_URL || DEFAULT_RPC).trim().replace(/\/$/, '');
+const rpcToken = process.env.NHB_RPC_TOKEN?.trim();
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { method, params, id, useAuth = true } = body ?? {};
+
+    if (typeof method !== 'string' || method.length === 0) {
+      return NextResponse.json(
+        { error: { message: 'RPC method is required' } },
+        { status: 400 }
+      );
+    }
+
+    const payload = {
+      jsonrpc: '2.0',
+      id: typeof id === 'number' || typeof id === 'string' ? id : Date.now(),
+      method,
+      params: Array.isArray(params) ? params : params ? [params] : []
+    };
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json'
+    };
+    if (rpcToken && useAuth !== false) {
+      headers.Authorization = `Bearer ${rpcToken}`;
+    }
+
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+      cache: 'no-store'
+    });
+
+    const text = await response.text();
+    let data: unknown;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch (error) {
+      return NextResponse.json(
+        {
+          error: {
+            message: 'Failed to decode RPC response',
+            detail: (error as Error).message,
+            raw: text
+          }
+        },
+        { status: 502 }
+      );
+    }
+
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: {
+          message: 'RPC proxy error',
+          detail: error instanceof Error ? error.message : String(error)
+        }
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/examples/merchant-loyalty-console/app/components/CreateBusinessForm.tsx
+++ b/examples/merchant-loyalty-console/app/components/CreateBusinessForm.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+import { z } from 'zod';
+import { rpcCall, RpcError } from '../lib/rpc';
+
+const schema = z.object({
+  caller: z.string().min(1, 'Caller address is required'),
+  owner: z.string().optional(),
+  name: z.string().min(3, 'Business name must contain at least 3 characters')
+});
+
+export interface CreateBusinessFormProps {
+  defaultCaller?: string;
+  onCreated?: (businessId: string, owner: string) => void;
+}
+
+export function CreateBusinessForm({ defaultCaller = '', onCreated }: CreateBusinessFormProps) {
+  const [form, setForm] = useState({ caller: defaultCaller, owner: '', name: '' });
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setResult(null);
+
+    const parsed = schema.safeParse(form);
+    if (!parsed.success) {
+      setSubmitting(false);
+      setError(parsed.error.issues[0]?.message || 'Invalid form values');
+      return;
+    }
+
+    const payload = {
+      caller: parsed.data.caller.trim(),
+      owner: parsed.data.owner?.trim() || parsed.data.caller.trim(),
+      name: parsed.data.name.trim()
+    };
+
+    try {
+      const businessId = await rpcCall<string>('loyalty_createBusiness', [payload]);
+      setResult(businessId);
+      if (onCreated) {
+        onCreated(businessId, payload.owner);
+      }
+    } catch (err) {
+      const message = err instanceof RpcError ? err.message : 'Failed to create business';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section>
+      <h2>Register a new business</h2>
+      <p className="lede">
+        Creates an on-chain business profile that can own merchants and loyalty programs. The caller must be authorised on the
+        NHB RPC endpoint.
+      </p>
+      <form onSubmit={handleSubmit} className="grid">
+        <div>
+          <label htmlFor="create-caller">Caller wallet</label>
+          <input
+            id="create-caller"
+            value={form.caller}
+            onChange={(event) => setForm((prev) => ({ ...prev, caller: event.target.value }))}
+            placeholder="nhb1..."
+            autoComplete="off"
+          />
+        </div>
+        <div>
+          <label htmlFor="create-owner">Owner wallet (optional)</label>
+          <input
+            id="create-owner"
+            value={form.owner}
+            onChange={(event) => setForm((prev) => ({ ...prev, owner: event.target.value }))}
+            placeholder="Defaults to caller if blank"
+            autoComplete="off"
+          />
+        </div>
+        <div>
+          <label htmlFor="create-name">Business name</label>
+          <input
+            id="create-name"
+            value={form.name}
+            onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+            placeholder="e.g. Zenith Coffee Group"
+            autoComplete="off"
+          />
+        </div>
+        <div className="form-footer">
+          <button type="submit" disabled={submitting}>
+            {submitting ? 'Creating…' : 'Create business'}
+          </button>
+          {result ? <small>Business ID: <span className="code-inline">{result}</span></small> : null}
+        </div>
+        {error ? <div className="alert alert-error">{error}</div> : null}
+        {result ? (
+          <div className="alert alert-success">
+            Business created successfully. Use the returned ID to configure merchants and loyalty programs.
+          </div>
+        ) : null}
+      </form>
+    </section>
+  );
+}

--- a/examples/merchant-loyalty-console/app/components/ProgramCard.tsx
+++ b/examples/merchant-loyalty-console/app/components/ProgramCard.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useState } from 'react';
+import { ProgramForm, createDraftFromProgram } from './ProgramForm';
+import type { ProgramResult, ProgramStats } from '../types';
+import { formatAmount } from '../lib/rpc';
+
+export interface ProgramCardProps {
+  program: ProgramResult;
+  stats?: ProgramStats;
+  caller: string;
+  businessId: string;
+  onPause: (programId: string) => Promise<void> | void;
+  onResume: (programId: string) => Promise<void> | void;
+  onRefresh: (programId: string) => Promise<void> | void;
+  onUpdated: () => void;
+}
+
+export function ProgramCard({
+  program,
+  stats,
+  caller,
+  businessId,
+  onPause,
+  onResume,
+  onRefresh,
+  onUpdated
+}: ProgramCardProps) {
+  const [showEditor, setShowEditor] = useState(false);
+  const [lifecyclePending, setLifecyclePending] = useState(false);
+
+  const handleLifecycle = async () => {
+    setLifecyclePending(true);
+    try {
+      if (program.active) {
+        await onPause(program.id);
+      } else {
+        await onResume(program.id);
+      }
+    } finally {
+      setLifecyclePending(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    await onRefresh(program.id);
+  };
+
+  const scheduleSummary = () => {
+    if (program.startTime === 0 && program.endTime === 0) {
+      return 'Always on';
+    }
+    const format = (seconds: number) => {
+      if (!seconds) return '—';
+      return new Date(seconds * 1000).toISOString();
+    };
+    return `${format(program.startTime)} → ${format(program.endTime)}`;
+  };
+
+  const statsSummary = stats
+    ? `${formatAmount(stats.rewardsPaid || '0')} wei paid • ${stats.txCount} settlements • cap usage ${formatAmount(
+        stats.capUsage || '0'
+      )}`
+    : 'No stats available for selected day';
+
+  return (
+    <div className="card-list-item">
+      <div className="form-footer" style={{ marginBottom: '1rem' }}>
+        <div>
+          <h3 style={{ margin: '0 0 0.35rem' }}>{program.tokenSymbol} loyalty</h3>
+          <div className={`status-pill ${program.active ? 'active' : 'paused'}`}>
+            {program.active ? 'Active' : 'Paused'}
+          </div>
+        </div>
+        <div className="stack-sm" style={{ justifyItems: 'flex-end' }}>
+          <button type="button" onClick={handleLifecycle} disabled={lifecyclePending}>
+            {lifecyclePending ? 'Updating…' : program.active ? 'Pause program' : 'Resume program'}
+          </button>
+          <button type="button" className="secondary" onClick={handleRefresh}>
+            Refresh stats
+          </button>
+          <button type="button" className="secondary" onClick={() => setShowEditor((prev) => !prev)}>
+            {showEditor ? 'Hide editor' : 'Edit program'}
+          </button>
+        </div>
+      </div>
+      <div className="grid columns-2" style={{ marginBottom: '1rem' }}>
+        <div>
+          <p className="badge">Program ID</p>
+          <p className="code-inline">{program.id}</p>
+        </div>
+        <div>
+          <p className="badge">Owner (merchant)</p>
+          <p className="code-inline">{program.owner}</p>
+        </div>
+      </div>
+      <div className="grid columns-2" style={{ marginBottom: '1rem' }}>
+        <div>
+          <p className="badge">Paymaster pool</p>
+          <p className="code-inline">{program.pool}</p>
+        </div>
+        <div>
+          <p className="badge">Accrual rate</p>
+          <p className="code-inline">{program.accrualBps} bps</p>
+        </div>
+      </div>
+      <div className="grid columns-2" style={{ marginBottom: '1rem' }}>
+        <div>
+          <p className="badge">Caps</p>
+          <p className="code-inline">
+            Min spend {formatAmount(program.minSpendWei)} • Cap/tx {formatAmount(program.capPerTx)} • Daily user cap{' '}
+            {formatAmount(program.dailyCapUser)}
+          </p>
+        </div>
+        <div>
+          <p className="badge">Schedule</p>
+          <p className="code-inline">{scheduleSummary()}</p>
+        </div>
+      </div>
+      <div className="alert alert-success" style={{ marginBottom: '1rem' }}>{statsSummary}</div>
+      {showEditor ? (
+        <ProgramForm
+          businessId={businessId}
+          caller={caller}
+          mode="update"
+          initialDraft={createDraftFromProgram(program)}
+          renderSection={false}
+          heading="Update program"
+          onCompleted={() => {
+            setShowEditor(false);
+            onUpdated();
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/examples/merchant-loyalty-console/app/components/ProgramForm.tsx
+++ b/examples/merchant-loyalty-console/app/components/ProgramForm.tsx
@@ -1,0 +1,352 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { z } from 'zod';
+import { rpcCall, RpcError, toUnixSeconds, fromUnixSeconds } from '../lib/rpc';
+import type { ProgramResult } from '../types';
+
+const draftSchema = z.object({
+  id: z
+    .string()
+    .min(1, 'Program ID is required')
+    .regex(/^0x[0-9a-fA-F]{64}$/, 'Program ID must be 32-byte hex (0x-prefixed).'),
+  owner: z.string().min(1, 'Owner address is required'),
+  pool: z.string().min(1, 'Paymaster pool address is required'),
+  tokenSymbol: z.string().min(1, 'Token symbol is required'),
+  accrualBps: z
+    .string()
+    .min(1, 'Accrual BPS is required')
+    .refine((value) => /^\d+$/.test(value), 'Accrual BPS must be a non-negative integer'),
+  minSpendWei: z.string().optional(),
+  capPerTx: z.string().optional(),
+  dailyCapUser: z.string().optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
+  active: z.boolean()
+});
+
+export interface ProgramDraft {
+  id: string;
+  owner: string;
+  pool: string;
+  tokenSymbol: string;
+  accrualBps: string;
+  minSpendWei: string;
+  capPerTx: string;
+  dailyCapUser: string;
+  startTime: string;
+  endTime: string;
+  active: boolean;
+}
+
+export interface ProgramFormProps {
+  businessId: string;
+  caller: string;
+  defaultOwner?: string;
+  defaultPool?: string;
+  mode?: 'create' | 'update';
+  initialDraft?: ProgramDraft;
+  onCompleted?: (programId?: string) => void;
+  renderSection?: boolean;
+  heading?: string;
+}
+
+const emptyDraft: ProgramDraft = {
+  id: '',
+  owner: '',
+  pool: '',
+  tokenSymbol: 'ZNHB',
+  accrualBps: '500',
+  minSpendWei: '0',
+  capPerTx: '0',
+  dailyCapUser: '0',
+  startTime: '',
+  endTime: '',
+  active: true
+};
+
+export function ProgramForm({
+  businessId,
+  caller,
+  defaultOwner,
+  defaultPool,
+  mode = 'create',
+  initialDraft,
+  onCompleted,
+  renderSection = true,
+  heading
+}: ProgramFormProps) {
+  const [draft, setDraft] = useState<ProgramDraft>(() => {
+    if (initialDraft) {
+      return initialDraft;
+    }
+    return {
+      ...emptyDraft,
+      owner: defaultOwner || '',
+      pool: defaultPool || ''
+    };
+  });
+  useEffect(() => {
+    if (initialDraft) {
+      setDraft(initialDraft);
+    }
+  }, [initialDraft]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const title = heading || (mode === 'create' ? 'Create loyalty program' : 'Update program');
+  const submitLabel = mode === 'create' ? 'Create program' : 'Update program';
+
+  const showScheduleFields = useMemo(() => draft.startTime !== '' || draft.endTime !== '', [draft.startTime, draft.endTime]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setSuccess(null);
+
+    const parsed = draftSchema.safeParse({ ...draft, active: draft.active });
+    if (!parsed.success) {
+      setSubmitting(false);
+      setError(parsed.error.issues[0]?.message || 'Invalid program configuration');
+      return;
+    }
+
+    const data = parsed.data;
+    const spec: Record<string, unknown> = {
+      id: data.id,
+      owner: data.owner,
+      pool: data.pool,
+      tokenSymbol: data.tokenSymbol.toUpperCase(),
+      accrualBps: Number(data.accrualBps),
+      minSpendWei: (data.minSpendWei && data.minSpendWei.trim() !== '' ? data.minSpendWei : '0'),
+      capPerTx: (data.capPerTx && data.capPerTx.trim() !== '' ? data.capPerTx : '0'),
+      dailyCapUser: (data.dailyCapUser && data.dailyCapUser.trim() !== '' ? data.dailyCapUser : '0'),
+      active: data.active
+    };
+
+    const start = toUnixSeconds(data.startTime || '');
+    const end = toUnixSeconds(data.endTime || '');
+    if (start !== undefined) {
+      spec.startTime = start;
+    }
+    if (end !== undefined) {
+      spec.endTime = end;
+    }
+
+    const envelope = mode === 'create'
+      ? { caller, businessId, spec }
+      : { caller, spec };
+
+    try {
+      if (mode === 'create') {
+        const programId = await rpcCall<string>('loyalty_createProgram', [envelope]);
+        setSuccess(`Program created: ${programId}`);
+        if (onCompleted) onCompleted(programId);
+        setDraft((prev) => ({ ...prev, id: '', owner: defaultOwner || prev.owner, pool: defaultPool || prev.pool }));
+      } else {
+        await rpcCall<string>('loyalty_updateProgram', [envelope]);
+        setSuccess('Program updated successfully');
+        if (onCompleted) onCompleted(draft.id);
+      }
+    } catch (err) {
+      const message = err instanceof RpcError ? err.message : 'RPC request failed';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleGenerateId = () => {
+    const bytes = new Uint8Array(32);
+    if (typeof window !== 'undefined' && window.crypto && window.crypto.getRandomValues) {
+      window.crypto.getRandomValues(bytes);
+    } else {
+      for (let i = 0; i < bytes.length; i += 1) {
+        bytes[i] = Math.floor(Math.random() * 256);
+      }
+    }
+    const hex = Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    setDraft((prev) => ({ ...prev, id: `0x${hex}` }));
+  };
+
+  const form = (
+    <form onSubmit={handleSubmit} className="grid">
+        <div className="grid columns-2">
+          <div>
+            <label htmlFor="program-id">Program ID</label>
+            <div className="stack-sm">
+              <input
+                id="program-id"
+                value={draft.id}
+                onChange={(event) => setDraft((prev) => ({ ...prev, id: event.target.value }))}
+                placeholder="0x...32-byte identifier"
+                autoComplete="off"
+              />
+              {mode === 'create' ? (
+                <button type="button" className="secondary" onClick={handleGenerateId}>
+                  Generate ID
+                </button>
+              ) : null}
+            </div>
+          </div>
+          <div>
+            <label htmlFor="program-owner">Program owner (merchant)</label>
+            <input
+              id="program-owner"
+              value={draft.owner}
+              onChange={(event) => setDraft((prev) => ({ ...prev, owner: event.target.value }))}
+              placeholder="nhb1..."
+              autoComplete="off"
+            />
+          </div>
+        </div>
+        <div className="grid columns-2">
+          <div>
+            <label htmlFor="program-pool">Paymaster pool</label>
+            <input
+              id="program-pool"
+              value={draft.pool}
+              onChange={(event) => setDraft((prev) => ({ ...prev, pool: event.target.value }))}
+              placeholder="nhb1..."
+              autoComplete="off"
+            />
+          </div>
+          <div>
+            <label htmlFor="program-token">Token symbol</label>
+            <input
+              id="program-token"
+              value={draft.tokenSymbol}
+              onChange={(event) => setDraft((prev) => ({ ...prev, tokenSymbol: event.target.value }))}
+              placeholder="ZNHB"
+              autoComplete="off"
+            />
+          </div>
+        </div>
+        <div className="grid columns-2">
+          <div>
+            <label htmlFor="program-bps">Accrual (basis points)</label>
+            <input
+              id="program-bps"
+              value={draft.accrualBps}
+              onChange={(event) => setDraft((prev) => ({ ...prev, accrualBps: event.target.value }))}
+              placeholder="e.g. 500 for 5%"
+            />
+          </div>
+          <div>
+            <label htmlFor="program-active">Program status</label>
+            <div>
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <input
+                  type="checkbox"
+                  checked={draft.active}
+                  onChange={(event) => setDraft((prev) => ({ ...prev, active: event.target.checked }))}
+                />
+                Active
+              </label>
+            </div>
+          </div>
+        </div>
+        <div className="grid columns-2">
+          <div>
+            <label htmlFor="program-min">Minimum spend (wei)</label>
+            <input
+              id="program-min"
+              value={draft.minSpendWei}
+              onChange={(event) => setDraft((prev) => ({ ...prev, minSpendWei: event.target.value }))}
+            />
+          </div>
+          <div>
+            <label htmlFor="program-cap">Cap per transaction (wei)</label>
+            <input
+              id="program-cap"
+              value={draft.capPerTx}
+              onChange={(event) => setDraft((prev) => ({ ...prev, capPerTx: event.target.value }))}
+            />
+          </div>
+        </div>
+        <div className="grid columns-2">
+          <div>
+            <label htmlFor="program-daily">Daily cap per user (wei)</label>
+            <input
+              id="program-daily"
+              value={draft.dailyCapUser}
+              onChange={(event) => setDraft((prev) => ({ ...prev, dailyCapUser: event.target.value }))}
+            />
+          </div>
+          <div>
+            <label htmlFor="program-start">Start time (UTC)</label>
+            <input
+              id="program-start"
+              type="datetime-local"
+              value={draft.startTime}
+              onChange={(event) => setDraft((prev) => ({ ...prev, startTime: event.target.value }))}
+            />
+          </div>
+        </div>
+        <div className="grid columns-2">
+          <div>
+            <label htmlFor="program-end">End time (UTC)</label>
+            <input
+              id="program-end"
+              type="datetime-local"
+              value={draft.endTime}
+              onChange={(event) => setDraft((prev) => ({ ...prev, endTime: event.target.value }))}
+            />
+          </div>
+          {showScheduleFields ? (
+            <div className="alert alert-success">
+              Program schedule will be applied. Leave blank to keep the program always-on.
+            </div>
+          ) : (
+            <div />
+          )}
+        </div>
+        <div className="form-footer">
+          <button type="submit" disabled={submitting || !caller || !businessId}>
+            {submitting ? 'Submitting…' : submitLabel}
+          </button>
+          <small>
+            Caller: <span className="code-inline">{caller || 'Set an admin wallet above'}</span>
+          </small>
+        </div>
+        {error ? <div className="alert alert-error">{error}</div> : null}
+        {success ? <div className="alert alert-success">{success}</div> : null}
+      </form>
+  );
+
+  if (!renderSection) {
+    return (
+      <div className="stack-sm">
+        <h3 style={{ margin: 0 }}>{title}</h3>
+        {form}
+      </div>
+    );
+  }
+
+  return (
+    <section>
+      <h2>{title}</h2>
+      {form}
+    </section>
+  );
+}
+
+export function createDraftFromProgram(program: ProgramResult): ProgramDraft {
+  return {
+    id: program.id,
+    owner: program.owner,
+    pool: program.pool,
+    tokenSymbol: program.tokenSymbol,
+    accrualBps: program.accrualBps.toString(),
+    minSpendWei: program.minSpendWei || '0',
+    capPerTx: program.capPerTx || '0',
+    dailyCapUser: program.dailyCapUser || '0',
+    startTime: fromUnixSeconds(program.startTime),
+    endTime: fromUnixSeconds(program.endTime),
+    active: program.active
+  };
+}

--- a/examples/merchant-loyalty-console/app/globals.css
+++ b/examples/merchant-loyalty-console/app/globals.css
@@ -1,0 +1,279 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #020617;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1e293b, #020617 55%);
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  padding: 2rem 1.25rem 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: 2.4rem;
+  letter-spacing: -0.02em;
+  color: #f8fafc;
+}
+
+p.lede {
+  color: #cbd5f5;
+  max-width: 780px;
+  font-size: 1.05rem;
+}
+
+section {
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 20px;
+  padding: 1.75rem;
+  margin-bottom: 1.75rem;
+  box-shadow: 0 22px 48px rgba(8, 15, 30, 0.45);
+  backdrop-filter: blur(16px);
+}
+
+section h2 {
+  margin-top: 0;
+  color: #f8fafc;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.45rem;
+  color: #cbd5f5;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.72);
+  color: #f8fafc;
+  font-size: 0.96rem;
+  margin-bottom: 1rem;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.25);
+}
+
+textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(120deg, #22d3ee, #6366f1);
+  color: #0f172a;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.secondary {
+  background: rgba(148, 163, 184, 0.16);
+  color: #cbd5f5;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(14, 165, 233, 0.35);
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+small {
+  color: #94a3b8;
+}
+
+pre,
+.code-block {
+  padding: 1rem;
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.68);
+  border: 1px solid rgba(30, 41, 59, 0.6);
+  overflow-x: auto;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #f8fafc;
+}
+
+.code-inline {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.82rem;
+  color: #f8fafc;
+}
+
+.alert {
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  margin-top: 0.75rem;
+  border: 1px solid transparent;
+}
+
+.alert-success {
+  background: rgba(34, 197, 94, 0.18);
+  color: #bbf7d0;
+  border-color: rgba(34, 197, 94, 0.35);
+}
+
+.alert-error {
+  background: rgba(239, 68, 68, 0.18);
+  color: #fecaca;
+  border-color: rgba(239, 68, 68, 0.35);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grid.columns-2 {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.stack-sm {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(94, 234, 212, 0.15);
+  color: #5eead4;
+}
+
+.table-grid {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.table-grid th,
+.table-grid td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.table-grid th {
+  text-align: left;
+  color: #cbd5f5;
+  font-weight: 600;
+}
+
+.table-grid td {
+  color: #e2e8f0;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag {
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  color: #cbd5f5;
+  font-size: 0.8rem;
+}
+
+.form-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+}
+
+.status-pill.active {
+  background: rgba(45, 212, 191, 0.18);
+  color: #5eead4;
+}
+
+.status-pill.paused {
+  background: rgba(248, 113, 113, 0.18);
+  color: #fecaca;
+}
+
+input.inline {
+  max-width: 320px;
+}
+
+button.block {
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  main {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  section {
+    padding: 1.5rem;
+  }
+}

--- a/examples/merchant-loyalty-console/app/layout.tsx
+++ b/examples/merchant-loyalty-console/app/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Merchant Loyalty Console',
+  description:
+    'Configure businesses, paymasters, and loyalty programs on NHBChain. Built for operations teams managing ZNHB accruals.',
+  openGraph: {
+    title: 'Merchant Loyalty Console',
+    description:
+      'Operations console for creating businesses, assigning paymasters, and monitoring loyalty rewards on NHBChain.',
+    siteName: 'Merchant Loyalty Console',
+    url: process.env.APP_PUBLIC_BASE || 'http://localhost:3000',
+    type: 'website'
+  }
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/examples/merchant-loyalty-console/app/lib/rpc.ts
+++ b/examples/merchant-loyalty-console/app/lib/rpc.ts
@@ -1,0 +1,83 @@
+'use client';
+
+export interface JsonRpcError {
+  code?: number;
+  message: string;
+  data?: unknown;
+}
+
+export interface JsonRpcResponse<T> {
+  jsonrpc: string;
+  id: number | string;
+  result?: T;
+  error?: JsonRpcError;
+}
+
+export class RpcError extends Error {
+  code?: number;
+  data?: unknown;
+
+  constructor(message: string, code?: number, data?: unknown) {
+    super(message);
+    this.code = code;
+    this.data = data;
+  }
+}
+
+export async function rpcCall<T>(
+  method: string,
+  params?: unknown[] | Record<string, unknown>,
+  options?: { auth?: boolean }
+): Promise<T> {
+  const body = {
+    method,
+    params,
+    useAuth: options?.auth !== false
+  };
+
+  const response = await fetch('/api/rpc', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  });
+
+  const payload: JsonRpcResponse<T> = await response.json();
+  const rpcError = payload.error;
+
+  if (rpcError) {
+    throw new RpcError(rpcError.message || 'Unknown RPC error', rpcError.code, rpcError.data);
+  }
+
+  if (!response.ok) {
+    throw new RpcError(`RPC HTTP error (${response.status})`);
+  }
+
+  return payload.result as T;
+}
+
+export function formatAmount(amount: string | number | null | undefined): string {
+  if (!amount) return '0';
+  const value = typeof amount === 'string' ? amount : amount.toString();
+  return value.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+export function toUnixSeconds(value: string): number | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return Math.floor(date.getTime() / 1000);
+}
+
+export function fromUnixSeconds(value: number | string | null | undefined): string {
+  if (!value) return '';
+  const num = typeof value === 'string' ? Number(value) : value;
+  if (!Number.isFinite(num) || num <= 0) {
+    return '';
+  }
+  const date = new Date(num * 1000);
+  return date.toISOString().slice(0, 16);
+}

--- a/examples/merchant-loyalty-console/app/page.tsx
+++ b/examples/merchant-loyalty-console/app/page.tsx
@@ -1,0 +1,464 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { z } from 'zod';
+import { CreateBusinessForm } from './components/CreateBusinessForm';
+import { ProgramForm } from './components/ProgramForm';
+import { ProgramCard } from './components/ProgramCard';
+import { RpcError, formatAmount, rpcCall } from './lib/rpc';
+import type { BusinessResult, ProgramResult, ProgramStats } from './types';
+
+interface AlertState {
+  type: 'success' | 'error';
+  message: string;
+}
+
+const businessIdSchema = z
+  .string()
+  .min(1, 'Business ID is required')
+  .regex(/^0x[0-9a-fA-F]{64}$/, 'Business ID must be 32-byte hex (0x-prefixed).');
+
+const addressSchema = z
+  .string()
+  .min(1, 'Address is required')
+  .regex(/^nhb1[0-9a-z]+$/i, 'Expected a valid nhb Bech32 address');
+
+const isoDay = () => new Date().toISOString().slice(0, 10);
+
+export default function MerchantLoyaltyConsole() {
+  const [adminAddress, setAdminAddress] = useState('');
+  const [businessIdInput, setBusinessIdInput] = useState('');
+  const [business, setBusiness] = useState<BusinessResult | null>(null);
+  const [programs, setPrograms] = useState<ProgramResult[]>([]);
+  const [paymasterBalance, setPaymasterBalance] = useState('0');
+  const [statsDay, setStatsDay] = useState(() => isoDay());
+  const [statsByProgram, setStatsByProgram] = useState<Record<string, ProgramStats>>({});
+  const [alert, setAlert] = useState<AlertState | null>(null);
+  const [loadingBusiness, setLoadingBusiness] = useState(false);
+  const [paymasterInput, setPaymasterInput] = useState('');
+  const [paymasterSubmitting, setPaymasterSubmitting] = useState(false);
+  const [newMerchant, setNewMerchant] = useState('');
+  const [merchantSubmitting, setMerchantSubmitting] = useState(false);
+  const [polling, setPolling] = useState(false);
+
+  const programsRef = useRef<ProgramResult[]>([]);
+  programsRef.current = programs;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const storedAdmin = window.localStorage.getItem('mlc-admin');
+    const storedBusiness = window.localStorage.getItem('mlc-business');
+    if (storedAdmin) setAdminAddress(storedAdmin);
+    if (storedBusiness) {
+      setBusinessIdInput(storedBusiness);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (adminAddress) {
+      window.localStorage.setItem('mlc-admin', adminAddress);
+    }
+  }, [adminAddress]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (business?.id) {
+      window.localStorage.setItem('mlc-business', business.id);
+    }
+  }, [business?.id]);
+
+  const handleLoadBusiness = async () => {
+    setAlert(null);
+    const parsed = businessIdSchema.safeParse(businessIdInput.trim());
+    if (!parsed.success) {
+      setAlert({ type: 'error', message: parsed.error.issues[0]?.message || 'Invalid business ID' });
+      return;
+    }
+    setLoadingBusiness(true);
+    try {
+      const businessResult = await rpcCall<BusinessResult>('loyalty_getBusiness', [
+        { businessId: parsed.data }
+      ]);
+      setBusiness(businessResult);
+      setPaymasterInput(businessResult.paymaster || '');
+      await refreshPrograms(parsed.data);
+      await refreshPaymaster(parsed.data);
+      setAlert({ type: 'success', message: `Loaded business ${businessResult.name}` });
+    } catch (err) {
+      const message = err instanceof RpcError ? err.message : 'Failed to load business';
+      setAlert({ type: 'error', message });
+      setBusiness(null);
+      setPrograms([]);
+    } finally {
+      setLoadingBusiness(false);
+    }
+  };
+
+  const refreshPrograms = async (id: string) => {
+    try {
+      const list = await rpcCall<ProgramResult[]>('loyalty_listPrograms', [
+        { businessId: id }
+      ]);
+      setPrograms(list);
+      return list;
+    } catch (err) {
+      const message = err instanceof RpcError ? err.message : 'Failed to list programs';
+      setAlert({ type: 'error', message });
+      return [] as ProgramResult[];
+    }
+  };
+
+  const refreshPaymaster = async (id: string) => {
+    try {
+      const balance = await rpcCall<string>('loyalty_paymasterBalance', [
+        { businessId: id }
+      ]);
+      setPaymasterBalance(balance ?? '0');
+    } catch (err) {
+      const message = err instanceof RpcError ? err.message : 'Failed to fetch paymaster balance';
+      setAlert({ type: 'error', message });
+    }
+  };
+
+  const refreshStats = async (programId: string, day: string) => {
+    try {
+      const result = await rpcCall<ProgramStats>('loyalty_programStats', [
+        { programId, day }
+      ]);
+      setStatsByProgram((prev) => ({ ...prev, [programId]: result }));
+    } catch (err) {
+      const message = err instanceof RpcError ? err.message : 'Failed to fetch program stats';
+      setAlert({ type: 'error', message });
+    }
+  };
+
+  useEffect(() => {
+    if (!business?.id) return;
+    if (programs.length === 0) return;
+    programs.forEach((program) => {
+      void refreshStats(program.id, statsDay);
+    });
+  }, [statsDay, programs, business?.id]);
+
+  useEffect(() => {
+    if (!polling || !business?.id) return;
+    const interval = window.setInterval(async () => {
+      const list = await refreshPrograms(business.id);
+      const nextPrograms = list.length > 0 ? list : programsRef.current;
+      nextPrograms.forEach((program) => {
+        void refreshStats(program.id, statsDay);
+      });
+      await refreshPaymaster(business.id);
+    }, 15000);
+    return () => window.clearInterval(interval);
+  }, [polling, business?.id, statsDay]);
+
+  const handleSetPaymaster = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!business?.id) return;
+    setAlert(null);
+    const parsed = addressSchema.safeParse(paymasterInput.trim());
+    if (!parsed.success) {
+      setAlert({ type: 'error', message: parsed.error.issues[0]?.message || 'Invalid paymaster address' });
+      return;
+    }
+    if (!adminAddress) {
+      setAlert({ type: 'error', message: 'Set an admin caller address before rotating the paymaster' });
+      return;
+    }
+    setPaymasterSubmitting(true);
+    try {
+      await rpcCall<string>('loyalty_setPaymaster', [
+        { caller: adminAddress.trim(), businessId: business.id, paymaster: parsed.data }
+      ]);
+      setAlert({ type: 'success', message: 'Paymaster rotated successfully' });
+      setBusiness((prev) => (prev ? { ...prev, paymaster: parsed.data } : prev));
+      await refreshPaymaster(business.id);
+    } catch (err) {
+      const message = err instanceof RpcError ? err.message : 'Failed to set paymaster';
+      setAlert({ type: 'error', message });
+    } finally {
+      setPaymasterSubmitting(false);
+    }
+  };
+
+  const handleAddMerchant = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!business?.id) return;
+    const parsed = addressSchema.safeParse(newMerchant.trim());
+    if (!parsed.success) {
+      setAlert({ type: 'error', message: parsed.error.issues[0]?.message || 'Invalid merchant address' });
+      return;
+    }
+    if (!adminAddress) {
+      setAlert({ type: 'error', message: 'Set an admin caller address before adding merchants' });
+      return;
+    }
+    setMerchantSubmitting(true);
+    try {
+      await rpcCall<string>('loyalty_addMerchant', [
+        { caller: adminAddress.trim(), businessId: business.id, merchant: parsed.data }
+      ]);
+      setAlert({ type: 'success', message: 'Merchant added successfully' });
+      setNewMerchant('');
+      const updated = await rpcCall<BusinessResult>('loyalty_getBusiness', [
+        { businessId: business.id }
+      ]);
+      setBusiness(updated);
+      await refreshPrograms(business.id);
+    } catch (err) {
+      const message = err instanceof RpcError ? err.message : 'Failed to add merchant';
+      setAlert({ type: 'error', message });
+    } finally {
+      setMerchantSubmitting(false);
+    }
+  };
+
+  const handleRemoveMerchant = async (merchant: string) => {
+    if (!business?.id) return;
+    if (!adminAddress) {
+      setAlert({ type: 'error', message: 'Set an admin caller address before removing merchants' });
+      return;
+    }
+    try {
+      await rpcCall<string>('loyalty_removeMerchant', [
+        { caller: adminAddress.trim(), businessId: business.id, merchant }
+      ]);
+      const updated = await rpcCall<BusinessResult>('loyalty_getBusiness', [
+        { businessId: business.id }
+      ]);
+      setBusiness(updated);
+      await refreshPrograms(business.id);
+      setAlert({ type: 'success', message: 'Merchant removed successfully' });
+    } catch (err) {
+      const message = err instanceof RpcError ? err.message : 'Failed to remove merchant';
+      setAlert({ type: 'error', message });
+    }
+  };
+
+  const handleProgramLifecycle = async (programId: string, action: 'pause' | 'resume') => {
+    if (!adminAddress) {
+      setAlert({ type: 'error', message: 'Set an admin caller address before updating programs' });
+      return;
+    }
+    const method = action === 'pause' ? 'loyalty_pauseProgram' : 'loyalty_resumeProgram';
+    try {
+      await rpcCall<string>(method, [
+        { caller: adminAddress.trim(), programId }
+      ]);
+      if (business?.id) {
+        await refreshPrograms(business.id);
+      }
+      setAlert({ type: 'success', message: `Program ${action}d successfully` });
+    } catch (err) {
+      const message = err instanceof RpcError ? err.message : 'Failed to update program status';
+      setAlert({ type: 'error', message });
+    }
+  };
+
+  const activePrograms = useMemo(() => programs.filter((program) => program.active), [programs]);
+  const pausedPrograms = useMemo(() => programs.filter((program) => !program.active), [programs]);
+
+  return (
+    <>
+      <header>
+        <h1>Merchant Loyalty Console</h1>
+        <p className="lede">
+          Configure NHBChain loyalty businesses, rotate paymasters, and orchestrate program accruals that pay out ZNHB on escrow
+          settlement. RPC requests are proxied via <code>https://api.nhbcoin.net</code> with optional bearer authentication.
+        </p>
+      </header>
+
+      <section>
+        <h2>Environment</h2>
+        <div className="grid columns-2">
+          <div>
+            <label htmlFor="admin-address">Admin / caller wallet</label>
+            <input
+              id="admin-address"
+              value={adminAddress}
+              onChange={(event) => setAdminAddress(event.target.value)}
+              placeholder="nhb1..."
+              autoComplete="off"
+            />
+            <small>RPC calls that mutate state use this wallet as the authorised caller.</small>
+          </div>
+          <div>
+            <label htmlFor="business-id">Business ID</label>
+            <input
+              id="business-id"
+              value={businessIdInput}
+              onChange={(event) => setBusinessIdInput(event.target.value)}
+              placeholder="0x..."
+              autoComplete="off"
+            />
+            <div className="form-footer">
+              <button type="button" onClick={handleLoadBusiness} disabled={loadingBusiness}>
+                {loadingBusiness ? 'Loading…' : 'Load business'}
+              </button>
+              {business?.name ? (
+                <small>
+                  Loaded: <span className="code-inline">{business.name}</span>
+                </small>
+              ) : null}
+            </div>
+          </div>
+        </div>
+        {alert ? <div className={`alert alert-${alert.type}`}>{alert.message}</div> : null}
+      </section>
+
+      <CreateBusinessForm defaultCaller={adminAddress} onCreated={(id) => setBusinessIdInput(id)} />
+
+      {business ? (
+        <section>
+          <h2>Business overview</h2>
+          <div className="grid columns-2">
+            <div>
+              <p className="badge">Business ID</p>
+              <p className="code-inline">{business.id}</p>
+            </div>
+            <div>
+              <p className="badge">Owner</p>
+              <p className="code-inline">{business.owner}</p>
+            </div>
+          </div>
+          <div className="grid columns-2">
+            <div>
+              <p className="badge">Paymaster pool</p>
+              <p className="code-inline">{business.paymaster || 'Not set'}</p>
+            </div>
+            <div>
+              <p className="badge">Paymaster balance (ZNHB wei)</p>
+              <p className="code-inline">{formatAmount(paymasterBalance)}</p>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {business ? (
+        <section>
+          <h2>Rotate paymaster</h2>
+          <form onSubmit={handleSetPaymaster} className="grid columns-2">
+            <div>
+              <label htmlFor="paymaster-input">New paymaster address</label>
+              <input
+                id="paymaster-input"
+                value={paymasterInput}
+                onChange={(event) => setPaymasterInput(event.target.value)}
+                placeholder="nhb1..."
+              />
+            </div>
+            <div className="form-footer">
+              <button type="submit" disabled={paymasterSubmitting}>
+                {paymasterSubmitting ? 'Updating…' : 'Set paymaster'}
+              </button>
+              <small>
+                Caller: <span className="code-inline">{adminAddress || 'Set admin wallet'}</span>
+              </small>
+            </div>
+          </form>
+        </section>
+      ) : null}
+
+      {business ? (
+        <section>
+          <h2>Merchants</h2>
+          <form onSubmit={handleAddMerchant} className="grid columns-2">
+            <div>
+              <label htmlFor="merchant-input">Add merchant</label>
+              <input
+                id="merchant-input"
+                value={newMerchant}
+                onChange={(event) => setNewMerchant(event.target.value)}
+                placeholder="nhb1..."
+              />
+            </div>
+            <div className="form-footer">
+              <button type="submit" disabled={merchantSubmitting}>
+                {merchantSubmitting ? 'Adding…' : 'Add merchant'}
+              </button>
+              <small>Merchants inherit this business&apos;s loyalty programs.</small>
+            </div>
+          </form>
+          <div className="tag-list">
+            {business.merchants.length === 0 ? <span className="tag">No merchants registered</span> : null}
+            {business.merchants.map((merchant) => (
+              <span key={merchant} className="tag">
+                {merchant}{' '}
+                <button
+                  type="button"
+                  className="secondary"
+                  style={{ padding: '0.2rem 0.6rem', fontSize: '0.7rem' }}
+                  onClick={() => handleRemoveMerchant(merchant)}
+                >
+                  Remove
+                </button>
+              </span>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {business ? (
+        <ProgramForm
+          businessId={business.id}
+          caller={adminAddress.trim()}
+          defaultOwner={business.merchants[0] || ''}
+          defaultPool={business.paymaster || ''}
+          onCompleted={async () => {
+            await refreshPrograms(business.id);
+            await refreshPaymaster(business.id);
+          }}
+        />
+      ) : null}
+
+      {business ? (
+        <section>
+          <h2>Loyalty programs</h2>
+          <div className="form-footer" style={{ marginBottom: '1rem' }}>
+            <div>
+              <label htmlFor="stats-day">Stats day (UTC)</label>
+              <input
+                id="stats-day"
+                type="date"
+                value={statsDay}
+                onChange={(event) => setStatsDay(event.target.value)}
+              />
+            </div>
+            <div>
+              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <input
+                  type="checkbox"
+                  checked={polling}
+                  onChange={(event) => setPolling(event.target.checked)}
+                />
+                Auto-refresh every 15s
+              </label>
+            </div>
+          </div>
+          <div className="card-list">
+            {[...activePrograms, ...pausedPrograms].map((program) => (
+              <ProgramCard
+                key={`${program.id}-${program.active}-${program.accrualBps}-${program.startTime}-${program.endTime}`}
+                program={program}
+                stats={statsByProgram[program.id]}
+                caller={adminAddress.trim()}
+                businessId={business.id}
+                onPause={(id) => handleProgramLifecycle(id, 'pause')}
+                onResume={(id) => handleProgramLifecycle(id, 'resume')}
+                onRefresh={(id) => refreshStats(id, statsDay)}
+                onUpdated={async () => {
+                  await refreshPrograms(business.id);
+                  await refreshPaymaster(business.id);
+                  await refreshStats(program.id, statsDay);
+                }}
+              />
+            ))}
+            {programs.length === 0 ? <div className="tag">No programs yet — create one above.</div> : null}
+          </div>
+        </section>
+      ) : null}
+    </>
+  );
+}

--- a/examples/merchant-loyalty-console/app/types.ts
+++ b/examples/merchant-loyalty-console/app/types.ts
@@ -1,0 +1,28 @@
+export interface BusinessResult {
+  id: string;
+  owner: string;
+  name: string;
+  paymaster: string;
+  merchants: string[];
+}
+
+export interface ProgramResult {
+  id: string;
+  owner: string;
+  pool: string;
+  tokenSymbol: string;
+  accrualBps: number;
+  minSpendWei: string;
+  capPerTx: string;
+  dailyCapUser: string;
+  startTime: number;
+  endTime: number;
+  active: boolean;
+}
+
+export interface ProgramStats {
+  rewardsPaid: string;
+  txCount: string;
+  capUsage?: string;
+  skips?: string;
+}

--- a/examples/merchant-loyalty-console/eslint.config.mjs
+++ b/examples/merchant-loyalty-console/eslint.config.mjs
@@ -1,0 +1,10 @@
+import next from 'eslint-config-next';
+
+export default [
+  {
+    ignores: ['.next/**', 'node_modules/**']
+  },
+  ...next({
+    extends: ['next/core-web-vitals']
+  })
+];

--- a/examples/merchant-loyalty-console/next-env.d.ts
+++ b/examples/merchant-loyalty-console/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/merchant-loyalty-console/next.config.mjs
+++ b/examples/merchant-loyalty-console/next.config.mjs
@@ -1,0 +1,10 @@
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    serverActions: {
+      allowedOrigins: [process.env.APP_PUBLIC_BASE || 'http://localhost:3000']
+    }
+  }
+};
+
+export default nextConfig;

--- a/examples/merchant-loyalty-console/package.json
+++ b/examples/merchant-loyalty-console/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@nhb/merchant-loyalty-console",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "2.2.4",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.45",
+    "@types/react-dom": "18.2.18",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/examples/merchant-loyalty-console/tsconfig.json
+++ b/examples/merchant-loyalty-console/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["dom", "dom.iterable", "es2021"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,7 +5,8 @@
   "workspaces": [
     "lib-sdk",
     "apps/*",
-    "wallet-lite"
+    "wallet-lite",
+    "merchant-loyalty-console"
   ],
   "scripts": {
     "dev": "node ./scripts/dev.js",

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -680,7 +680,7 @@ chalk@^4.0.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-client-only@0.0.1:
+client-only@0.0.1, client-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
@@ -2573,6 +2573,14 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+swr@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.4.tgz#03ec4c56019902fbdc904d78544bd7a9a6fa3f07"
+  integrity sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==
+  dependencies:
+    client-only "^0.0.1"
+    use-sync-external-store "^1.2.0"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2728,6 +2736,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#55122e2a3edd2a6c106174c27485e0fd59bcfca0"
+  integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==
 
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## Summary
- add a dedicated Next.js workspace for the merchant loyalty console example
- implement business, paymaster, merchant, and program management flows backed by NHB JSON-RPC
- provide shared RPC proxy, reusable program editor, and documentation for configuring the console

## Testing
- CI=1 yarn workspace @nhb/merchant-loyalty-console build

------
https://chatgpt.com/codex/tasks/task_e_68d6a7abc228832d920c1b43a5498e40