### PR TITLE
Add P2P mini-market dual-lock escrow demo

### DIFF
--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -7,6 +7,7 @@ The `/examples` directory contains a Yarn workspace with runnable demo applicati
 - `examples/apps/` – UI/server examples that showcase different integration patterns. Each application owns its dependencies and a `dev` script.
 - `examples/lib-sdk/` – Shared helper library that exposes RPC clients, signing helpers, and Bech32 utilities.
 - `examples/scripts/` – Tooling that keeps the workspace consistent, including the `yarn dev` orchestrator.
+- `examples/p2p-mini-market/` – Dual-lock escrow demo that accepts NHB ⇄ ZNHB trades and walks through funding, settlement, and dispute outcomes.
 
 ## Quickstart
 

--- a/docs/examples/p2p-mini-market.md
+++ b/docs/examples/p2p-mini-market.md
@@ -1,0 +1,94 @@
+# P2P Mini-Market Walkthrough
+
+The P2P mini-market demo pairs a lightweight marketplace UI with the dual-lock
+escrow RPCs introduced for peer-to-peer NHB ⇄ ZNHB trades. This document outlines
+the trade lifecycle, the pay intents returned to each counterparty, dispute
+resolution outcomes, and the gateway endpoints exposed at
+`https://api.nhbcoin.net`.
+
+## Trade lifecycle
+
+Dual-lock trades progress through the following aggregate states:
+
+| State | Description |
+|-------|-------------|
+| `init` | Trade created. Both escrows exist but are unfunded. |
+| `partial_funded` | Exactly one leg has been funded (`escrow_fund`). |
+| `funded` | Both escrows funded. Trade is ready to settle. |
+| `disputed` | Buyer or seller opened a dispute (`p2p_dispute`). Escrows are frozen. |
+| `settled` | Atomic release executed (`p2p_settle` or arbitrator `release_both`). |
+| `cancelled` | Trade cancelled voluntarily or via arbitrator refund outcome. |
+| `expired` | Funding deadline elapsed and at least one leg refunded. |
+
+Each escrow leg tracks its own status (`init`, `funded`, `released`, `refunded`,
+`disputed`, `expired`). The UI polls `escrow_get` to surface both legs alongside
+the aggregated trade status.
+
+## Pay intents
+
+`p2p_createTrade` returns two pay intents that encode where each party must send
+funds:
+
+```json
+{
+  "tradeId": "0x…",
+  "escrowBaseId": "0x…",
+  "escrowQuoteId": "0x…",
+  "payIntents": {
+    "seller": {
+      "to": "nhb1escrowvault…",
+      "token": "NHB",
+      "amount": "1000000000000000000",
+      "memo": "ESCROW:0xbase"
+    },
+    "buyer": {
+      "to": "nhb1escrowvault…",
+      "token": "ZNHB",
+      "amount": "500000000000000000",
+      "memo": "ESCROW:0xquote"
+    }
+  }
+}
+```
+
+The mini-market renders each intent as a `znhb://pay` QR code and copies the raw
+fields so test accounts can fund the escrow vaults manually. The memo is mandatory
+and lets the module reconcile deposits with the pending escrow record.
+
+## Dispute outcomes
+
+Arbitrators resolve disputes using `p2p_resolve` with one of four outcomes:
+
+| Outcome | Result |
+|---------|--------|
+| `release_both` | Releases both escrows to their payees (equivalent to mutual settle). |
+| `refund_both` | Refunds both escrows to their original payers (trade cancels). |
+| `release_base_refund_quote` | Releases the base leg to the buyer and refunds the quote leg to the buyer (seller loses). |
+| `release_quote_refund_base` | Releases the quote leg to the seller and refunds the base leg to the seller (buyer loses). |
+
+The UI provides controls to open a dispute and then exercise each resolution path.
+Settlement and refunds remain atomic—either both legs execute or neither leg
+moves.
+
+## Gateway endpoints
+
+The production gateway exposes REST endpoints at `https://api.nhbcoin.net`:
+
+| Method & Path | Purpose |
+|---------------|---------|
+| `POST /p2p/offers` | (Optional) Persist an offer with idempotency guarantees. |
+| `GET /p2p/offers` | Enumerate active offers for discovery. |
+| `POST /p2p/accept` | Accept an offer, invoke `p2p_createTrade`, and return the dual pay intents. |
+| `GET /p2p/trades/{id}` | Fetch trade status including escrow snapshots. |
+| `POST /p2p/trades/{id}/settle` | Mutual settlement once both legs are funded. |
+| `POST /p2p/trades/{id}/dispute` | Flag a dispute from either counterparty. |
+| `POST /p2p/trades/{id}/resolve` | Arbitrator resolution using the outcomes above. |
+
+All endpoints require the standard API key + HMAC headers. Mutating calls also
+include the wallet signature of the buyer, seller, or arbitrator so the gateway
+can assert on-chain authority.
+
+The mini-market demo talks to the public RPC (`https://rpc.nhbcoin.net`) to keep
+credentials client-side for self-hosted QA, but production operators integrate
+with `api.nhbcoin.net` to leverage persistent offer storage, idempotency, and
+webhook delivery of trade events.

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,5 +1,7 @@
 # Public RPC (HTTP)
 NHB_RPC_URL=https://rpc.nhbcoin.net
+# RPC bearer token for privileged calls
+NHB_RPC_TOKEN=demo-token
 # Public RPC (WebSocket)
 NHB_WS_URL=wss://ws.nhbcoin.net
 # REST Gateway (escrow/swap/loyalty)

--- a/examples/p2p-mini-market/.eslintrc.json
+++ b/examples/p2p-mini-market/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/examples/p2p-mini-market/.gitignore
+++ b/examples/p2p-mini-market/.gitignore
@@ -1,0 +1,3 @@
+.next
+node_modules
+.DS_Store

--- a/examples/p2p-mini-market/README.md
+++ b/examples/p2p-mini-market/README.md
@@ -1,0 +1,55 @@
+# P2P Mini-Market
+
+P2P Mini-Market is a dual-lock escrow demo that shows how NHB peer-to-peer trades
+progress from an off-chain offer to an atomic settlement. Operators can stage
+buy/sell quotes for NHB ⇄ ZNHB, accept an offer as the counterparty, fund both
+legs, and settle or dispute the trade.
+
+The UI is intentionally transparent: both wallets live side-by-side so it is
+easy to drive end-to-end QA scenarios.
+
+## Getting started
+
+```bash
+# Install workspace dependencies from the examples root
+cd examples
+yarn install
+
+# Launch the mini-market dev server
+cd p2p-mini-market
+yarn dev
+```
+
+The server reads RPC configuration from the shared `.env` file. Ensure the
+following variables are set:
+
+* `NHB_RPC_URL`
+* `NHB_RPC_TOKEN`
+* `NHB_CHAIN_ID`
+* `NHB_WS_URL` (optional for live updates)
+
+## Flows
+
+1. Load seller and buyer private keys. The demo ships with a “Generate” button to
+   create throwaway keys locally.
+2. Publish an offer describing which asset you are selling (`SELL_NHB` or
+   `SELL_ZNHB`), the amounts for each leg, and a funding deadline.
+3. Accept the offer as the counterparty. The server calls
+   `p2p_createTrade` and returns dual pay intents that encode the escrow vaults
+   and memos.
+4. Fund each escrow using the QR codes or by sending from another wallet, then
+   click “Mark funded” once the deposit lands. The UI calls `escrow_fund` for the
+   appropriate leg.
+5. When both legs are funded, call “Settle trade” to execute `p2p_settle` and
+   release both escrows atomically.
+6. Use the “Dispute” and “Resolve dispute” controls to exercise each outcome:
+   `release_both`, `refund_both`, and the mixed release/refund variants.
+
+## Notes
+
+* Credentials (`NHB_RPC_TOKEN`) stay on the Next.js server runtime. They are not
+  exposed to the browser.
+* The local state (offers and trades) is persisted to `localStorage` so a page
+  refresh keeps context.
+* WebSocket updates are optional; the app polls every eight seconds to refresh
+  trade and escrow status.

--- a/examples/p2p-mini-market/app/api/account/route.ts
+++ b/examples/p2p-mini-market/app/api/account/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { rpcRequest } from '../../lib/rpc';
+
+export async function GET(req: NextRequest) {
+  const address = req.nextUrl.searchParams.get('address');
+  if (!address) {
+    return NextResponse.json({ error: 'address query parameter required' }, { status: 400 });
+  }
+  try {
+    const result = await rpcRequest('nhb_getBalance', [address]);
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/examples/p2p-mini-market/app/api/config/route.ts
+++ b/examples/p2p-mini-market/app/api/config/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { readClientConfig } from '../../lib/config';
+
+export async function GET() {
+  const config = readClientConfig();
+  return NextResponse.json(config, { status: 200 });
+}

--- a/examples/p2p-mini-market/app/api/escrow/fund/route.ts
+++ b/examples/p2p-mini-market/app/api/escrow/fund/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { rpcRequest } from '../../../lib/rpc';
+
+const schema = z.object({
+  escrowId: z.string().min(1),
+  from: z.string().min(1)
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const payload = schema.parse(body);
+    const result = await rpcRequest('escrow_fund', [{ id: payload.escrowId, from: payload.from }], true);
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.flatten() }, { status: 400 });
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/examples/p2p-mini-market/app/api/escrow/get/route.ts
+++ b/examples/p2p-mini-market/app/api/escrow/get/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { rpcRequest } from '../../../lib/rpc';
+
+export async function GET(req: NextRequest) {
+  const escrowId = req.nextUrl.searchParams.get('escrowId');
+  if (!escrowId) {
+    return NextResponse.json({ error: 'escrowId query parameter required' }, { status: 400 });
+  }
+  try {
+    const result = await rpcRequest('escrow_get', [{ id: escrowId }], true);
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/examples/p2p-mini-market/app/api/p2p/create-trade/route.ts
+++ b/examples/p2p-mini-market/app/api/p2p/create-trade/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { rpcRequest } from '../../../lib/rpc';
+
+const schema = z.object({
+  offerId: z.string().min(1),
+  buyer: z.string().min(1),
+  seller: z.string().min(1),
+  baseToken: z.string().min(1),
+  baseAmount: z.string().regex(/^[0-9]+$/),
+  quoteToken: z.string().min(1),
+  quoteAmount: z.string().regex(/^[0-9]+$/),
+  deadline: z.number().int().positive()
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const payload = schema.parse(body);
+    const result = await rpcRequest('p2p_createTrade', [payload], true);
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.flatten() }, { status: 400 });
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/examples/p2p-mini-market/app/api/p2p/dispute/route.ts
+++ b/examples/p2p-mini-market/app/api/p2p/dispute/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { rpcRequest } from '../../../lib/rpc';
+
+const schema = z.object({
+  tradeId: z.string().min(1),
+  caller: z.string().min(1),
+  message: z.string().min(1)
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const payload = schema.parse(body);
+    const result = await rpcRequest('p2p_dispute', [payload], true);
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.flatten() }, { status: 400 });
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/examples/p2p-mini-market/app/api/p2p/resolve/route.ts
+++ b/examples/p2p-mini-market/app/api/p2p/resolve/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { rpcRequest } from '../../../lib/rpc';
+
+const schema = z.object({
+  tradeId: z.string().min(1),
+  caller: z.string().min(1),
+  outcome: z.enum(['release_both', 'refund_both', 'release_base_refund_quote', 'release_quote_refund_base']),
+  memo: z.string().optional()
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const payload = schema.parse(body);
+    const result = await rpcRequest('p2p_resolve', [payload], true);
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.flatten() }, { status: 400 });
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/examples/p2p-mini-market/app/api/p2p/settle/route.ts
+++ b/examples/p2p-mini-market/app/api/p2p/settle/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { rpcRequest } from '../../../lib/rpc';
+
+const schema = z.object({
+  tradeId: z.string().min(1),
+  caller: z.string().min(1)
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const payload = schema.parse(body);
+    const result = await rpcRequest('p2p_settle', [payload], true);
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.flatten() }, { status: 400 });
+    }
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/examples/p2p-mini-market/app/api/p2p/trade/route.ts
+++ b/examples/p2p-mini-market/app/api/p2p/trade/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { rpcRequest } from '../../../lib/rpc';
+
+export async function GET(req: NextRequest) {
+  const tradeId = req.nextUrl.searchParams.get('tradeId');
+  if (!tradeId) {
+    return NextResponse.json({ error: 'tradeId query parameter required' }, { status: 400 });
+  }
+  try {
+    const result = await rpcRequest('p2p_getTrade', [{ tradeId }], true);
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/examples/p2p-mini-market/app/components/mini-market-app.tsx
+++ b/examples/p2p-mini-market/app/components/mini-market-app.tsx
@@ -1,0 +1,842 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { PayIntentCard } from './pay-intent-card';
+import { deriveAddressFromPrivateKey, randomPrivateKey } from '../lib/wallet';
+import { formatAmount, formatStatus, formatTimestamp, toBaseUnits } from '../lib/format';
+
+interface BalanceResponse {
+  address: string;
+  balanceNHB: string;
+  balanceZNHB: string;
+  lockedZNHB: string;
+  stake: string;
+  nonce: number;
+}
+
+interface RpcPayIntent {
+  to: string;
+  token: string;
+  amount: string;
+  memo?: string;
+}
+
+interface TradeCreationResponse {
+  tradeId: string;
+  escrowBaseId: string;
+  escrowQuoteId: string;
+  payIntents: Record<string, RpcPayIntent>;
+}
+
+interface TradeSnapshot {
+  id: string;
+  offerId: string;
+  buyer: string;
+  seller: string;
+  quoteToken: string;
+  quoteAmount: string;
+  escrowQuoteId: string;
+  baseToken: string;
+  baseAmount: string;
+  escrowBaseId: string;
+  deadline: number;
+  createdAt: number;
+  status: string;
+}
+
+interface EscrowSnapshot {
+  id: string;
+  payer: string;
+  payee: string;
+  token: string;
+  amount: string;
+  status: string;
+  deadline: number;
+  createdAt: number;
+}
+
+interface OfferRecord {
+  id: string;
+  seller: string;
+  direction: 'SELL_NHB' | 'SELL_ZNHB';
+  baseToken: 'NHB' | 'ZNHB';
+  quoteToken: 'NHB' | 'ZNHB';
+  baseAmount: string; // base units
+  quoteAmount: string; // base units
+  baseDisplay: string;
+  quoteDisplay: string;
+  deadlineHours: number;
+  terms?: string;
+  createdAt: number;
+}
+
+interface TradeRecord {
+  tradeId: string;
+  offerId: string;
+  buyer: string;
+  seller: string;
+  baseToken: string;
+  quoteToken: string;
+  baseAmount: string;
+  quoteAmount: string;
+  escrowBaseId: string;
+  escrowQuoteId: string;
+  payIntents: Record<string, RpcPayIntent>;
+  createdAt: number;
+  deadline: number;
+  status?: string;
+  baseEscrow?: EscrowSnapshot;
+  quoteEscrow?: EscrowSnapshot;
+  lastUpdated?: number;
+  error?: string | null;
+}
+
+const storageOffersKey = 'nhb:p2p-mini-market:offers';
+const storageTradesKey = 'nhb:p2p-mini-market:trades';
+
+function persist<T>(key: string, value: T) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn('Failed to persist state', error);
+  }
+}
+
+function restore<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    console.warn('Failed to restore state', error);
+    return fallback;
+  }
+}
+
+async function fetchJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, init);
+  const payload = await response.json();
+  if (!response.ok) {
+    const message = payload?.error ? JSON.stringify(payload.error) : response.statusText;
+    throw new Error(message || 'Request failed');
+  }
+  return payload as T;
+}
+
+export default function MiniMarketApp() {
+  const [sellerKey, setSellerKey] = useState('');
+  const [sellerAddress, setSellerAddress] = useState('');
+  const [sellerAccount, setSellerAccount] = useState<BalanceResponse | null>(null);
+  const [sellerError, setSellerError] = useState<string | null>(null);
+
+  const [buyerKey, setBuyerKey] = useState('');
+  const [buyerAddress, setBuyerAddress] = useState('');
+  const [buyerAccount, setBuyerAccount] = useState<BalanceResponse | null>(null);
+  const [buyerError, setBuyerError] = useState<string | null>(null);
+
+  const [offers, setOffers] = useState<OfferRecord[]>([]);
+  const [trades, setTrades] = useState<TradeRecord[]>([]);
+
+  const [offerDirection, setOfferDirection] = useState<'SELL_NHB' | 'SELL_ZNHB'>('SELL_NHB');
+  const [baseAmountInput, setBaseAmountInput] = useState('10.0');
+  const [quoteAmountInput, setQuoteAmountInput] = useState('10.0');
+  const [deadlineHours, setDeadlineHours] = useState(6);
+  const [offerTerms, setOfferTerms] = useState('');
+  const [offerError, setOfferError] = useState<string | null>(null);
+
+  const [acceptingOfferId, setAcceptingOfferId] = useState<string | null>(null);
+  const [acceptError, setAcceptError] = useState<string | null>(null);
+
+  const [fundingEscrow, setFundingEscrow] = useState<string | null>(null);
+  const [fundError, setFundError] = useState<string | null>(null);
+
+  const [settleError, setSettleError] = useState<string | null>(null);
+  const [settlingTrade, setSettlingTrade] = useState<string | null>(null);
+
+  const [disputeError, setDisputeError] = useState<string | null>(null);
+  const [resolveError, setResolveError] = useState<string | null>(null);
+  const [resolutionMemo, setResolutionMemo] = useState('');
+  const [resolutionOutcome, setResolutionOutcome] = useState<'release_both' | 'refund_both' | 'release_base_refund_quote' | 'release_quote_refund_base'>('release_both');
+
+  const [manualTradeId, setManualTradeId] = useState('');
+  const [manualTradeError, setManualTradeError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setOffers(restore(storageOffersKey, []));
+    setTrades(restore(storageTradesKey, []));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    persist(storageOffersKey, offers);
+  }, [offers]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    persist(storageTradesKey, trades);
+  }, [trades]);
+
+  useEffect(() => {
+    if (!sellerKey.trim()) {
+      setSellerAddress('');
+      setSellerAccount(null);
+      setSellerError(null);
+      return;
+    }
+    try {
+      const nextAddress = deriveAddressFromPrivateKey(sellerKey);
+      setSellerAddress(nextAddress);
+      setSellerError(null);
+    } catch (error) {
+      setSellerAddress('');
+      setSellerError((error as Error).message);
+    }
+  }, [sellerKey]);
+
+  useEffect(() => {
+    if (!buyerKey.trim()) {
+      setBuyerAddress('');
+      setBuyerAccount(null);
+      setBuyerError(null);
+      return;
+    }
+    try {
+      const nextAddress = deriveAddressFromPrivateKey(buyerKey);
+      setBuyerAddress(nextAddress);
+      setBuyerError(null);
+    } catch (error) {
+      setBuyerAddress('');
+      setBuyerError((error as Error).message);
+    }
+  }, [buyerKey]);
+
+  useEffect(() => {
+    if (!sellerAddress) return;
+    let cancelled = false;
+    async function load() {
+      try {
+        const account = await fetchJson<BalanceResponse>(`/api/account?address=${encodeURIComponent(sellerAddress)}`);
+        if (!cancelled) {
+          setSellerAccount(account);
+          setSellerError(null);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setSellerAccount(null);
+          setSellerError((error as Error).message);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [sellerAddress]);
+
+  useEffect(() => {
+    if (!buyerAddress) return;
+    let cancelled = false;
+    async function load() {
+      try {
+        const account = await fetchJson<BalanceResponse>(`/api/account?address=${encodeURIComponent(buyerAddress)}`);
+        if (!cancelled) {
+          setBuyerAccount(account);
+          setBuyerError(null);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setBuyerAccount(null);
+          setBuyerError((error as Error).message);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [buyerAddress]);
+
+  const refreshTrade = useCallback(async (tradeId: string) => {
+    try {
+      const trade = await fetchJson<TradeSnapshot>(`/api/p2p/trade?tradeId=${encodeURIComponent(tradeId)}`);
+      const [baseEscrow, quoteEscrow] = await Promise.all([
+        fetchJson<EscrowSnapshot>(`/api/escrow/get?escrowId=${encodeURIComponent(trade.escrowBaseId)}`),
+        fetchJson<EscrowSnapshot>(`/api/escrow/get?escrowId=${encodeURIComponent(trade.escrowQuoteId)}`)
+      ]);
+      setTrades((current) =>
+        current.map((entry) =>
+          entry.tradeId === tradeId
+            ? {
+                ...entry,
+                status: trade.status,
+                baseEscrow,
+                quoteEscrow,
+                lastUpdated: Date.now()
+              }
+            : entry
+        )
+      );
+    } catch (error) {
+      setTrades((current) =>
+        current.map((entry) =>
+          entry.tradeId === tradeId
+            ? {
+                ...entry,
+                error: (error as Error).message,
+                lastUpdated: Date.now()
+              }
+            : entry
+        )
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    if (trades.length === 0) return;
+    const interval = setInterval(() => {
+      trades.forEach((trade) => {
+        void refreshTrade(trade.tradeId);
+      });
+    }, 8000);
+    return () => clearInterval(interval);
+  }, [trades, refreshTrade]);
+
+  const handleCreateOffer = async () => {
+    if (!sellerAddress) {
+      setOfferError('Load a seller private key first.');
+      return;
+    }
+    try {
+      const baseToken = offerDirection === 'SELL_NHB' ? 'NHB' : 'ZNHB';
+      const quoteToken = offerDirection === 'SELL_NHB' ? 'ZNHB' : 'NHB';
+      const baseAmount = toBaseUnits(baseAmountInput);
+      const quoteAmount = toBaseUnits(quoteAmountInput);
+      const offer: OfferRecord = {
+        id: `OFF_${Date.now()}`,
+        seller: sellerAddress,
+        direction: offerDirection,
+        baseToken,
+        quoteToken,
+        baseAmount,
+        quoteAmount,
+        baseDisplay: baseAmountInput,
+        quoteDisplay: quoteAmountInput,
+        deadlineHours,
+        terms: offerTerms.trim() || undefined,
+        createdAt: Date.now()
+      };
+      setOffers((current) => [offer, ...current]);
+      setOfferError(null);
+    } catch (error) {
+      setOfferError((error as Error).message);
+    }
+  };
+
+  const handleAcceptOffer = async (offer: OfferRecord) => {
+    if (!buyerAddress) {
+      setAcceptError('Load a buyer private key first.');
+      return;
+    }
+    setAcceptingOfferId(offer.id);
+    setAcceptError(null);
+    try {
+      const deadline = Math.floor(Date.now() / 1000) + offer.deadlineHours * 3600;
+      const payload = {
+        offerId: offer.id,
+        buyer: buyerAddress,
+        seller: offer.seller,
+        baseToken: offer.baseToken,
+        baseAmount: offer.baseAmount,
+        quoteToken: offer.quoteToken,
+        quoteAmount: offer.quoteAmount,
+        deadline
+      };
+      const result = await fetchJson<TradeCreationResponse>('/api/p2p/create-trade', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const record: TradeRecord = {
+        tradeId: result.tradeId,
+        offerId: offer.id,
+        buyer: buyerAddress,
+        seller: offer.seller,
+        baseToken: offer.baseToken,
+        quoteToken: offer.quoteToken,
+        baseAmount: offer.baseAmount,
+        quoteAmount: offer.quoteAmount,
+        escrowBaseId: result.escrowBaseId,
+        escrowQuoteId: result.escrowQuoteId,
+        payIntents: result.payIntents,
+        createdAt: Date.now(),
+        deadline,
+        status: 'init'
+      };
+      setTrades((current) => [record, ...current]);
+      await refreshTrade(result.tradeId);
+    } catch (error) {
+      setAcceptError((error as Error).message);
+    } finally {
+      setAcceptingOfferId(null);
+    }
+  };
+
+  const handleFundEscrow = async (trade: TradeRecord, leg: 'base' | 'quote') => {
+    const escrowId = leg === 'base' ? trade.escrowBaseId : trade.escrowQuoteId;
+    const fromAddress = leg === 'base' ? trade.seller : trade.buyer;
+    setFundingEscrow(escrowId);
+    setFundError(null);
+    try {
+      await fetchJson('/api/escrow/fund', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ escrowId, from: fromAddress })
+      });
+      await refreshTrade(trade.tradeId);
+    } catch (error) {
+      setFundError((error as Error).message);
+    } finally {
+      setFundingEscrow(null);
+    }
+  };
+
+  const handleSettleTrade = async (trade: TradeRecord) => {
+    setSettlingTrade(trade.tradeId);
+    setSettleError(null);
+    try {
+      const caller = buyerAddress && trade.buyer === buyerAddress ? buyerAddress : sellerAddress;
+      if (!caller) {
+        throw new Error('Load either the buyer or seller private key to settle.');
+      }
+      await fetchJson('/api/p2p/settle', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ tradeId: trade.tradeId, caller })
+      });
+      await refreshTrade(trade.tradeId);
+    } catch (error) {
+      setSettleError((error as Error).message);
+    } finally {
+      setSettlingTrade(null);
+    }
+  };
+
+  const handleDispute = async (trade: TradeRecord, reason: string) => {
+    setDisputeError(null);
+    try {
+      const caller = buyerAddress && trade.buyer === buyerAddress ? buyerAddress : sellerAddress;
+      if (!caller) {
+        throw new Error('Load the buyer or seller private key to dispute.');
+      }
+      await fetchJson('/api/p2p/dispute', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ tradeId: trade.tradeId, caller, message: reason })
+      });
+      await refreshTrade(trade.tradeId);
+    } catch (error) {
+      setDisputeError((error as Error).message);
+    }
+  };
+
+  const handleResolve = async (trade: TradeRecord) => {
+    setResolveError(null);
+    try {
+      const caller = sellerAddress || buyerAddress;
+      if (!caller) {
+        throw new Error('Load any authorised arbitrator address to resolve.');
+      }
+      await fetchJson('/api/p2p/resolve', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          tradeId: trade.tradeId,
+          caller,
+          outcome: resolutionOutcome,
+          memo: resolutionMemo.trim() || undefined
+        })
+      });
+      await refreshTrade(trade.tradeId);
+    } catch (error) {
+      setResolveError((error as Error).message);
+    }
+  };
+
+  const handleTrackTrade = async () => {
+    if (!manualTradeId.trim()) {
+      setManualTradeError('Trade ID is required');
+      return;
+    }
+    try {
+      const trade = await fetchJson<TradeSnapshot>(`/api/p2p/trade?tradeId=${encodeURIComponent(manualTradeId.trim())}`);
+      const [baseEscrow, quoteEscrow] = await Promise.all([
+        fetchJson<EscrowSnapshot>(`/api/escrow/get?escrowId=${encodeURIComponent(trade.escrowBaseId)}`),
+        fetchJson<EscrowSnapshot>(`/api/escrow/get?escrowId=${encodeURIComponent(trade.escrowQuoteId)}`)
+      ]);
+      const record: TradeRecord = {
+        tradeId: trade.id,
+        offerId: trade.offerId,
+        buyer: trade.buyer,
+        seller: trade.seller,
+        baseToken: trade.baseToken,
+        quoteToken: trade.quoteToken,
+        baseAmount: trade.baseAmount,
+        quoteAmount: trade.quoteAmount,
+        escrowBaseId: trade.escrowBaseId,
+        escrowQuoteId: trade.escrowQuoteId,
+        payIntents: {},
+        createdAt: Date.now(),
+        deadline: trade.deadline,
+        status: trade.status,
+        baseEscrow,
+        quoteEscrow
+      };
+      setTrades((current) => {
+        const exists = current.some((entry) => entry.tradeId === record.tradeId);
+        return exists ? current : [record, ...current];
+      });
+      setManualTradeError(null);
+    } catch (error) {
+      setManualTradeError((error as Error).message);
+    }
+  };
+
+  const sortedTrades = useMemo(
+    () =>
+      [...trades].sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0)),
+    [trades]
+  );
+
+  return (
+    <div>
+      <header>
+        <h1>NHB P2P Mini-Market</h1>
+        <p className="muted">
+          Compose buy and sell offers for NHB ⇄ ZNHB, accept trades, fund both legs, and settle atomically via dual-lock escrow.
+        </p>
+      </header>
+
+      <section>
+        <h2>Wallets</h2>
+        <div className="grid columns-2">
+          <div>
+            <h3>Seller</h3>
+            <label htmlFor="seller-key">Private key</label>
+            <textarea
+              id="seller-key"
+              className="small"
+              value={sellerKey}
+              onChange={(event) => setSellerKey(event.target.value)}
+              placeholder="0x..."
+            />
+            <div className="flex-row">
+              <button type="button" onClick={() => setSellerKey(randomPrivateKey())}>Generate</button>
+            </div>
+            {sellerError ? <p className="badge warning">{sellerError}</p> : null}
+            {sellerAddress ? (
+              <div className="card-list-item">
+                <strong>Address</strong>
+                <p>{sellerAddress}</p>
+                {sellerAccount ? (
+                  <div className="status-grid" style={{ marginTop: '0.75rem' }}>
+                    <div className="status-item">
+                      <strong>NHB</strong>
+                      <span>{formatAmount(sellerAccount.balanceNHB)}</span>
+                    </div>
+                    <div className="status-item">
+                      <strong>ZNHB</strong>
+                      <span>{formatAmount(sellerAccount.balanceZNHB)}</span>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+
+          <div>
+            <h3>Buyer</h3>
+            <label htmlFor="buyer-key">Private key</label>
+            <textarea
+              id="buyer-key"
+              className="small"
+              value={buyerKey}
+              onChange={(event) => setBuyerKey(event.target.value)}
+              placeholder="0x..."
+            />
+            <div className="flex-row">
+              <button type="button" onClick={() => setBuyerKey(randomPrivateKey())}>Generate</button>
+            </div>
+            {buyerError ? <p className="badge warning">{buyerError}</p> : null}
+            {buyerAddress ? (
+              <div className="card-list-item">
+                <strong>Address</strong>
+                <p>{buyerAddress}</p>
+                {buyerAccount ? (
+                  <div className="status-grid" style={{ marginTop: '0.75rem' }}>
+                    <div className="status-item">
+                      <strong>NHB</strong>
+                      <span>{formatAmount(buyerAccount.balanceNHB)}</span>
+                    </div>
+                    <div className="status-item">
+                      <strong>ZNHB</strong>
+                      <span>{formatAmount(buyerAccount.balanceZNHB)}</span>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Create Offer</h2>
+        <fieldset>
+          <legend>Direction</legend>
+          <div className="flex-row">
+            <label>
+              <input
+                type="radio"
+                name="direction"
+                value="SELL_NHB"
+                checked={offerDirection === 'SELL_NHB'}
+                onChange={() => setOfferDirection('SELL_NHB')}
+              />
+              <span style={{ marginLeft: '0.5rem' }}>Sell NHB for ZNHB</span>
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="direction"
+                value="SELL_ZNHB"
+                checked={offerDirection === 'SELL_ZNHB'}
+                onChange={() => setOfferDirection('SELL_ZNHB')}
+              />
+              <span style={{ marginLeft: '0.5rem' }}>Sell ZNHB for NHB</span>
+            </label>
+          </div>
+        </fieldset>
+        <label htmlFor="base-amount">Sell amount ({offerDirection === 'SELL_NHB' ? 'NHB' : 'ZNHB'})</label>
+        <input id="base-amount" value={baseAmountInput} onChange={(event) => setBaseAmountInput(event.target.value)} />
+        <label htmlFor="quote-amount">Buy amount ({offerDirection === 'SELL_NHB' ? 'ZNHB' : 'NHB'})</label>
+        <input id="quote-amount" value={quoteAmountInput} onChange={(event) => setQuoteAmountInput(event.target.value)} />
+        <label htmlFor="deadline-hours">Funding deadline (hours)</label>
+        <input
+          id="deadline-hours"
+          type="number"
+          min={1}
+          max={168}
+          value={deadlineHours}
+          onChange={(event) => setDeadlineHours(Number(event.target.value))}
+        />
+        <label htmlFor="offer-terms">Terms (optional)</label>
+        <textarea id="offer-terms" className="small" value={offerTerms} onChange={(event) => setOfferTerms(event.target.value)} />
+        <button type="button" onClick={handleCreateOffer} disabled={!sellerAddress}>
+          Publish Offer
+        </button>
+        {offerError ? <p className="badge warning" style={{ marginTop: '0.75rem' }}>{offerError}</p> : null}
+      </section>
+
+      <section>
+        <h2>Open Offers</h2>
+        {offers.length === 0 ? <p className="muted">No offers yet. Create one above to seed the market.</p> : null}
+        <div className="card-list">
+          {offers.map((offer) => (
+            <div className="card-list-item" key={offer.id}>
+              <div className="flex-row" style={{ justifyContent: 'space-between' }}>
+                <div>
+                  <strong>{offer.direction === 'SELL_NHB' ? 'Sell NHB' : 'Sell ZNHB'}</strong>
+                  <p className="muted">Offer ID: {offer.id}</p>
+                </div>
+                <span className="badge">Created {formatTimestamp(Math.floor(offer.createdAt / 1000))}</span>
+              </div>
+              <div className="table-scroll" style={{ marginTop: '0.75rem' }}>
+                <table>
+                  <tbody>
+                    <tr>
+                      <th>Seller</th>
+                      <td>{offer.seller}</td>
+                    </tr>
+                    <tr>
+                      <th>Base</th>
+                      <td>
+                        {offer.baseDisplay} {offer.baseToken}
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>Quote</th>
+                      <td>
+                        {offer.quoteDisplay} {offer.quoteToken}
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>Deadline</th>
+                      <td>{offer.deadlineHours} hours</td>
+                    </tr>
+                    {offer.terms ? (
+                      <tr>
+                        <th>Terms</th>
+                        <td>{offer.terms}</td>
+                      </tr>
+                    ) : null}
+                  </tbody>
+                </table>
+              </div>
+              <button
+                type="button"
+                style={{ marginTop: '1rem' }}
+                disabled={acceptingOfferId === offer.id || !buyerAddress}
+                onClick={() => void handleAcceptOffer(offer)}
+              >
+                {acceptingOfferId === offer.id ? 'Creating trade…' : 'Accept offer'}
+              </button>
+            </div>
+          ))}
+        </div>
+        {acceptError ? <p className="badge warning" style={{ marginTop: '1rem' }}>{acceptError}</p> : null}
+      </section>
+
+      <section>
+        <h2>Active Trades</h2>
+        <div className="flex-row" style={{ marginBottom: '1rem' }}>
+          <input
+            placeholder="Paste trade ID to track"
+            value={manualTradeId}
+            onChange={(event) => setManualTradeId(event.target.value)}
+            style={{ flex: '1 1 320px' }}
+          />
+          <button type="button" onClick={() => void handleTrackTrade()}>
+            Track trade
+          </button>
+        </div>
+        {manualTradeError ? <p className="badge warning">{manualTradeError}</p> : null}
+        {sortedTrades.length === 0 ? <p className="muted">Accept an offer to see the dual-lock workflow.</p> : null}
+        <div className="card-list">
+          {sortedTrades.map((trade) => (
+            <div className="card-list-item" key={trade.tradeId}>
+              <div className="flex-row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+                <div>
+                  <strong>Trade {trade.tradeId}</strong>
+                  <p className="muted">Status: {formatStatus(trade.status)}</p>
+                </div>
+                <span className={`badge ${trade.status === 'settled' ? 'success' : ''}`}>
+                  Last update {trade.lastUpdated ? formatTimestamp(Math.floor(trade.lastUpdated / 1000)) : 'pending'}
+                </span>
+              </div>
+              <div className="table-scroll" style={{ marginTop: '0.75rem' }}>
+                <table>
+                  <tbody>
+                    <tr>
+                      <th>Buyer</th>
+                      <td>{trade.buyer}</td>
+                    </tr>
+                    <tr>
+                      <th>Seller</th>
+                      <td>{trade.seller}</td>
+                    </tr>
+                    <tr>
+                      <th>Base leg</th>
+                      <td>
+                        {formatAmount(trade.baseAmount)} {trade.baseToken} → Escrow {trade.escrowBaseId}
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>Quote leg</th>
+                      <td>
+                        {formatAmount(trade.quoteAmount)} {trade.quoteToken} → Escrow {trade.escrowQuoteId}
+                      </td>
+                    </tr>
+                    <tr>
+                      <th>Deadline</th>
+                      <td>{formatTimestamp(trade.deadline)}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div className="intent-grid two-columns" style={{ marginTop: '1.25rem' }}>
+                <PayIntentCard title="Seller deposit" intent={trade.payIntents.seller ?? null} description="Seller funds base token" />
+                <PayIntentCard title="Buyer deposit" intent={trade.payIntents.buyer ?? null} description="Buyer funds quote token" />
+              </div>
+              <div className="status-grid" style={{ marginTop: '1.25rem' }}>
+                <div className="status-item">
+                  <div>
+                    <strong>Base escrow</strong>
+                    <div className="muted">{trade.escrowBaseId}</div>
+                  </div>
+                  <div>
+                    <span>{formatStatus(trade.baseEscrow?.status)}</span>
+                    <button
+                      type="button"
+                      style={{ marginLeft: '0.75rem' }}
+                      onClick={() => void handleFundEscrow(trade, 'base')}
+                      disabled={fundingEscrow === trade.escrowBaseId}
+                    >
+                      {fundingEscrow === trade.escrowBaseId ? 'Marking funded…' : 'Mark funded'}
+                    </button>
+                  </div>
+                </div>
+                <div className="status-item">
+                  <div>
+                    <strong>Quote escrow</strong>
+                    <div className="muted">{trade.escrowQuoteId}</div>
+                  </div>
+                  <div>
+                    <span>{formatStatus(trade.quoteEscrow?.status)}</span>
+                    <button
+                      type="button"
+                      style={{ marginLeft: '0.75rem' }}
+                      onClick={() => void handleFundEscrow(trade, 'quote')}
+                      disabled={fundingEscrow === trade.escrowQuoteId}
+                    >
+                      {fundingEscrow === trade.escrowQuoteId ? 'Marking funded…' : 'Mark funded'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div className="flex-row" style={{ marginTop: '1.25rem' }}>
+                <button type="button" onClick={() => void handleSettleTrade(trade)} disabled={settlingTrade === trade.tradeId}>
+                  {settlingTrade === trade.tradeId ? 'Settling…' : 'Settle trade'}
+                </button>
+                <button type="button" onClick={() => void handleDispute(trade, 'Manual dispute triggered from demo UI')}>
+                  Dispute
+                </button>
+              </div>
+              {trade.status === 'disputed' ? (
+                <div style={{ marginTop: '1.25rem' }}>
+                  <h4>Resolve dispute</h4>
+                  <label htmlFor={`resolution-outcome-${trade.tradeId}`}>Outcome</label>
+                  <select
+                    id={`resolution-outcome-${trade.tradeId}`}
+                    value={resolutionOutcome}
+                    onChange={(event) => setResolutionOutcome(event.target.value as typeof resolutionOutcome)}
+                  >
+                    <option value="release_both">Release both escrows</option>
+                    <option value="refund_both">Refund both escrows</option>
+                    <option value="release_base_refund_quote">Release base, refund quote</option>
+                    <option value="release_quote_refund_base">Release quote, refund base</option>
+                  </select>
+                  <label htmlFor={`resolution-memo-${trade.tradeId}`}>Resolution memo</label>
+                  <textarea
+                    id={`resolution-memo-${trade.tradeId}`}
+                    className="small"
+                    value={resolutionMemo}
+                    onChange={(event) => setResolutionMemo(event.target.value)}
+                  />
+                  <button type="button" onClick={() => void handleResolve(trade)}>
+                    Submit resolution
+                  </button>
+                </div>
+              ) : null}
+              {trade.error ? <p className="badge warning" style={{ marginTop: '1rem' }}>{trade.error}</p> : null}
+            </div>
+          ))}
+        </div>
+        {fundError ? <p className="badge warning" style={{ marginTop: '1rem' }}>{fundError}</p> : null}
+        {settleError ? <p className="badge warning" style={{ marginTop: '1rem' }}>{settleError}</p> : null}
+        {disputeError ? <p className="badge warning" style={{ marginTop: '1rem' }}>{disputeError}</p> : null}
+        {resolveError ? <p className="badge warning" style={{ marginTop: '1rem' }}>{resolveError}</p> : null}
+      </section>
+    </div>
+  );
+}

--- a/examples/p2p-mini-market/app/components/pay-intent-card.tsx
+++ b/examples/p2p-mini-market/app/components/pay-intent-card.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import QRCode from 'qrcode.react';
+import { formatAmount } from '../lib/format';
+
+export interface PayIntentProps {
+  title: string;
+  intent: {
+    to: string;
+    token: string;
+    amount: string;
+    memo?: string;
+  } | null;
+  description?: string;
+}
+
+export function PayIntentCard({ title, intent, description }: PayIntentProps) {
+  if (!intent) {
+    return (
+      <div className="intent-card">
+        <h3>{title}</h3>
+        <p className="muted">Intent unavailable yet.</p>
+      </div>
+    );
+  }
+
+  const params = new URLSearchParams({
+    to: intent.to,
+    token: intent.token,
+    amount: formatAmount(intent.amount),
+    memo: intent.memo ?? ''
+  });
+  const uri = `znhb://pay?${params.toString()}`;
+
+  return (
+    <div className="intent-card">
+      <h3>{title}</h3>
+      {description ? <p className="muted">{description}</p> : null}
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', alignItems: 'center' }}>
+        <QRCode value={uri} size={128} includeMargin bgColor="#0f172a" fgColor="#e2e8f0" />
+        <dl>
+          <dt>Pay to</dt>
+          <dd>{intent.to}</dd>
+          <dt>Token</dt>
+          <dd>{intent.token}</dd>
+          <dt>Amount</dt>
+          <dd>{formatAmount(intent.amount)}</dd>
+          {intent.memo ? (
+            <>
+              <dt>Memo</dt>
+              <dd>{intent.memo}</dd>
+            </>
+          ) : null}
+          <dt>URI</dt>
+          <dd style={{ wordBreak: 'break-all' }}>{uri}</dd>
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/examples/p2p-mini-market/app/globals.css
+++ b/examples/p2p-mini-market/app/globals.css
@@ -1,0 +1,268 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #050914;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top right, #1d4ed8, #020617);
+  color: #e2e8f0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+main {
+  padding: 2rem 1.5rem 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+section {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 18px;
+  padding: 1.75rem;
+  margin-bottom: 1.75rem;
+  box-shadow: 0 24px 55px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(14px);
+}
+
+section h2 {
+  margin-top: 0;
+  color: #f8fafc;
+}
+
+label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+  color: #cbd5f5;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+  color: #f8fafc;
+  font-size: 0.95rem;
+  margin-bottom: 1rem;
+}
+
+input:disabled,
+textarea:disabled {
+  opacity: 0.7;
+}
+
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(120deg, #38bdf8, #6366f1);
+  color: #0f172a;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 32px rgba(99, 102, 241, 0.35);
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+small {
+  color: #94a3b8;
+}
+
+pre {
+  padding: 1rem;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.65);
+  border: 1px solid rgba(30, 41, 59, 0.6);
+  overflow: auto;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  background: rgba(96, 165, 250, 0.18);
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  color: #bfdbfe;
+}
+
+.badge.success {
+  background: rgba(74, 222, 128, 0.18);
+  border-color: rgba(74, 222, 128, 0.35);
+  color: #bbf7d0;
+}
+
+.badge.warning {
+  background: rgba(253, 224, 71, 0.18);
+  border-color: rgba(253, 224, 71, 0.35);
+  color: #fef9c3;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .grid.columns-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.flex-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.card-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.card-list-item {
+  padding: 1rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.intent-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 960px) {
+  .intent-grid.two-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.intent-card {
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+}
+
+.intent-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: #e0f2fe;
+}
+
+.intent-card dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.35rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.intent-card dt {
+  font-weight: 600;
+  color: #bae6fd;
+}
+
+.intent-card dd {
+  margin: 0;
+  color: #f8fafc;
+}
+
+.status-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.status-item {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.status-item strong {
+  color: #f8fafc;
+}
+
+.muted {
+  color: #94a3b8;
+}
+
+textarea.small {
+  min-height: 72px;
+}
+
+fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: #bae6fd;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  color: #e2e8f0;
+}
+
+thead {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+td,
+th {
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}

--- a/examples/p2p-mini-market/app/layout.tsx
+++ b/examples/p2p-mini-market/app/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'NHB P2P Mini-Market',
+  description: 'Dual-lock escrow marketplace demo for NHB ⇄ ZNHB spot trades.',
+  openGraph: {
+    title: 'NHB P2P Mini-Market',
+    description: 'Demonstrates dual-lock escrow trades with pay intents and atomic settlement.',
+    url: process.env.APP_PUBLIC_BASE || 'http://localhost:4302',
+    siteName: 'NHB P2P Mini-Market',
+    type: 'website'
+  }
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/examples/p2p-mini-market/app/lib/config.ts
+++ b/examples/p2p-mini-market/app/lib/config.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+const serverConfigSchema = z.object({
+  rpcUrl: z.string().url(),
+  rpcToken: z.string().min(1),
+  chainId: z.string().min(1),
+  wsUrl: z.string().url().optional(),
+  appBaseUrl: z.string().url().optional()
+});
+
+const clientConfigSchema = z.object({
+  chainId: z.string().optional(),
+  wsUrl: z.string().optional()
+});
+
+export type ServerConfig = z.infer<typeof serverConfigSchema>;
+export type ClientConfig = z.infer<typeof clientConfigSchema>;
+
+export function readServerConfig(): ServerConfig {
+  const parsed = serverConfigSchema.safeParse({
+    rpcUrl: process.env.NHB_RPC_URL,
+    rpcToken: process.env.NHB_RPC_TOKEN,
+    chainId: process.env.NHB_CHAIN_ID,
+    wsUrl: process.env.NHB_WS_URL,
+    appBaseUrl: process.env.APP_PUBLIC_BASE
+  });
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map((issue) => `${issue.path.join('.') || 'unknown'}: ${issue.message}`).join(', ');
+    throw new Error(`P2P Mini-Market configuration invalid: ${issues}`);
+  }
+  return parsed.data;
+}
+
+export function readClientConfig(): ClientConfig {
+  const parsed = clientConfigSchema.safeParse({
+    chainId: process.env.NEXT_PUBLIC_NHB_CHAIN_ID ?? process.env.NHB_CHAIN_ID,
+    wsUrl: process.env.NEXT_PUBLIC_NHB_WS_URL ?? process.env.NHB_WS_URL
+  });
+  if (!parsed.success) {
+    throw new Error('Invalid client configuration');
+  }
+  return parsed.data;
+}

--- a/examples/p2p-mini-market/app/lib/format.ts
+++ b/examples/p2p-mini-market/app/lib/format.ts
@@ -1,0 +1,51 @@
+export function formatAmount(raw?: string, decimals = 18): string {
+  if (!raw) return '0';
+  const value = raw.trim();
+  if (!/^[0-9]+$/.test(value)) {
+    return raw;
+  }
+  if (decimals === 0) return value;
+  if (value.length <= decimals) {
+    const padded = value.padStart(decimals, '0');
+    const whole = '0';
+    const fraction = padded.replace(/0+$/, '');
+    return fraction ? `${whole}.${fraction}` : '0';
+  }
+  const whole = value.slice(0, value.length - decimals);
+  const fraction = value.slice(-decimals).replace(/0+$/, '');
+  return fraction ? `${whole}.${fraction}` : whole;
+}
+
+export function formatTimestamp(unixSeconds?: number): string {
+  if (!unixSeconds) return '—';
+  return new Date(unixSeconds * 1000).toLocaleString();
+}
+
+export function formatStatus(status?: string): string {
+  if (!status) return 'unknown';
+  return status
+    .toString()
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+export function toBaseUnits(input: string, decimals = 18): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('Amount is required');
+  }
+  if (!/^[0-9]+(\.[0-9]+)?$/.test(trimmed)) {
+    throw new Error('Amount must be a decimal number');
+  }
+  if (decimals === 0) {
+    if (trimmed.includes('.')) {
+      throw new Error('Amount cannot include decimals');
+    }
+    return trimmed.replace(/^0+/, '') || '0';
+  }
+  const [wholePart, fractionPart = ''] = trimmed.split('.');
+  const sanitizedWhole = wholePart.replace(/^0+/, '') || '0';
+  const fraction = (fractionPart + '0'.repeat(decimals)).slice(0, decimals);
+  const combined = `${sanitizedWhole}${fraction}`.replace(/^0+/, '');
+  return combined || '0';
+}

--- a/examples/p2p-mini-market/app/lib/rpc.ts
+++ b/examples/p2p-mini-market/app/lib/rpc.ts
@@ -1,0 +1,40 @@
+import crypto from 'crypto';
+import { CHAIN_ID_HEADER } from '@nhb/examples-lib-sdk';
+import { readServerConfig } from './config';
+
+export interface RpcResult<T> {
+  result: T;
+}
+
+export async function rpcRequest<T>(method: string, params: unknown[], withAuth = false): Promise<T> {
+  const config = readServerConfig();
+  const body = {
+    jsonrpc: '2.0',
+    id: crypto.randomUUID(),
+    method,
+    params
+  };
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    [CHAIN_ID_HEADER]: config.chainId
+  };
+  if (withAuth) {
+    headers.Authorization = `Bearer ${config.rpcToken}`;
+  }
+  const response = await fetch(config.rpcUrl, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`RPC error (${response.status}): ${text}`);
+  }
+  const json = await response.json();
+  if (json.error) {
+    const message = json.error?.message ?? 'unknown error';
+    const details = json.error?.data;
+    throw new Error(details ? `${message}: ${details}` : message);
+  }
+  return json.result as T;
+}

--- a/examples/p2p-mini-market/app/lib/wallet.ts
+++ b/examples/p2p-mini-market/app/lib/wallet.ts
@@ -1,0 +1,20 @@
+import { keccak_256 } from '@noble/hashes/sha3';
+import { utils, getPublicKey } from '@noble/secp256k1';
+import { bech32Helpers } from '@nhb/examples-lib-sdk';
+
+export function deriveAddressFromPrivateKey(hexKey: string, prefix = 'nhb'): string {
+  const normalized = hexKey.trim().toLowerCase().replace(/^0x/, '');
+  if (normalized.length !== 64) {
+    throw new Error('Expected 32-byte private key');
+  }
+  const keyBytes = utils.hexToBytes(normalized);
+  const pubKey = getPublicKey(keyBytes, false).slice(1);
+  const hash = keccak_256(pubKey);
+  const addressBytes = hash.slice(-20);
+  return bech32Helpers.encode(prefix, addressBytes);
+}
+
+export function randomPrivateKey(): string {
+  const keyBytes = utils.randomPrivateKey();
+  return `0x${utils.bytesToHex(keyBytes)}`;
+}

--- a/examples/p2p-mini-market/app/page.tsx
+++ b/examples/p2p-mini-market/app/page.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const MiniMarketApp = dynamic(() => import('./components/mini-market-app'), {
+  ssr: false
+});
+
+export default function Page() {
+  return <MiniMarketApp />;
+}

--- a/examples/p2p-mini-market/next-env.d.ts
+++ b/examples/p2p-mini-market/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/p2p-mini-market/next.config.mjs
+++ b/examples/p2p-mini-market/next.config.mjs
@@ -1,0 +1,8 @@
+import nextConfig from '../wallet-lite/next.config.mjs';
+
+export default {
+  ...nextConfig,
+  experimental: {
+    ...nextConfig.experimental,
+  }
+};

--- a/examples/p2p-mini-market/package.json
+++ b/examples/p2p-mini-market/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@nhb/p2p-mini-market",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@nhb/examples-lib-sdk": "0.1.0",
+    "next": "14.2.3",
+    "qrcode.react": "^3.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "2.2.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.45",
+    "@types/react-dom": "18.2.18",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/examples/p2p-mini-market/tsconfig.json
+++ b/examples/p2p-mini-market/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["dom", "dom.iterable", "es2021"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["app/components/*"],
+      "@/lib/*": ["app/lib/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -6,6 +6,7 @@
     "lib-sdk",
     "apps/*",
     "wallet-lite",
+    "p2p-mini-market",
     "merchant-loyalty-console",
     "escrow-checkout/*"
   ],

--- a/examples/scripts/dev.js
+++ b/examples/scripts/dev.js
@@ -5,7 +5,8 @@ const concurrently = require('concurrently');
 
 const apps = [
   { name: '@nhb/status-dashboard', label: 'dashboard', color: 'cyan' },
-  { name: '@nhb/network-monitor', label: 'monitor', color: 'magenta' }
+  { name: '@nhb/network-monitor', label: 'monitor', color: 'magenta' },
+  { name: '@nhb/p2p-mini-market', label: 'mini-market', color: 'blue' }
 ];
 
 async function run() {

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -4720,6 +4720,14 @@ swr@2.2.4:
     client-only "^0.0.1"
     use-sync-external-store "^1.2.0"
 
+swr@2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.5.tgz#063eea0e9939f947227d5ca760cc53696f46446b"
+  integrity sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==
+  dependencies:
+    client-only "^0.0.1"
+    use-sync-external-store "^1.2.0"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"


### PR DESCRIPTION
## Summary
- add a Next.js P2P mini-market app that walks dual-lock escrow trades from offer creation to settlement and disputes
- proxy escrow and P2P RPC calls through typed API routes with shared formatting utilities and QR pay intent rendering
- document the workflow, workspace wiring, and environment variables for running the new example

## Testing
- yarn lint (examples/p2p-mini-market)


------
https://chatgpt.com/codex/tasks/task_e_68d6b0c44da0832d88c22aa1bc185166