### PR TITLE
Add RPC/REST cookbook documentation and tooling

### DIFF
--- a/docs/examples/cookbook.md
+++ b/docs/examples/cookbook.md
@@ -1,0 +1,220 @@
+# NHBCoin RPC & REST Cookbook
+
+This cookbook shows how to move between the public JSON-RPC endpoints (`https://rpc.nhbcoin.net`) and the escrow REST gateway (`https://api.nhbcoin.net`). Each scenario can be run against devnet or testnet by flipping environment variables, and every command is safe to copy/paste.
+
+---
+
+## 1. Environment targets
+
+| Network | JSON-RPC | WebSocket | REST gateway |
+|---------|----------|-----------|--------------|
+| **Testnet** | `https://rpc.nhbcoin.net` | `wss://ws.nhbcoin.net` | `https://api.nhbcoin.net/escrow/v1` |
+| **Devnet** | `https://rpc.devnet.nhbcoin.net` | `wss://ws.devnet.nhbcoin.net` | `https://api.devnet.nhbcoin.net/escrow/v1` |
+
+Set the targets once per shell:
+
+```bash
+export NHB_RPC_URL=https://rpc.nhbcoin.net
+export NHB_WS_URL=wss://ws.nhbcoin.net
+export NHB_API_BASE=https://api.nhbcoin.net/escrow/v1
+export NHB_ADDRESS=nhb1exampleaddress000000000000000000000000
+export NHB_API_KEY=your-escrow-api-key            # required for REST writes/reads
+export NHB_API_SECRET=your-escrow-api-secret      # HMAC secret paired with the API key
+```
+
+> Replace `NHB_ADDRESS` with a funded wallet on the chosen network. For devnet you can request faucet funds; for testnet coordinate with the NHB team. Keep API credentials secret.
+
+---
+
+## 2. Scenario A – Account snapshot via JSON-RPC
+
+Use `nhb_getBalance` to retrieve balances, staking metadata, and human-readable alias data for any account.
+
+```bash
+curl -sS "$NHB_RPC_URL" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"nhb_getBalance","params":["'"$NHB_ADDRESS"'"]}' | jq
+```
+
+Expected response (values vary per account):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "address": "nhb1exampleaddress000000000000000000000000",
+    "balanceNHB": "125000000",
+    "balanceZNHB": "50000000",
+    "stake": "75000000",
+    "lockedZNHB": "25000000",
+    "delegatedValidator": "nhb1validatoralias0000000000000000000000",
+    "pendingUnbonds": [],
+    "username": "merchant.alpha",
+    "nonce": 42,
+    "engagementScore": 1180
+  }
+}
+```
+
+Error handling examples:
+
+- Missing address → HTTP 400 with `"message": "address parameter required"`.
+- Invalid Bech32 string → HTTP 400 with `"message": "failed to decode address"`.
+
+### Verify balances/events
+
+1. Confirm `balanceNHB` matches the explorer balance for the address.
+2. When running on devnet, send a small transfer (e.g. via `nhb-cli send`) and re-run the command—`nonce` should increment and the new transaction should appear in Scenario B below.
+
+---
+
+## 3. Scenario B – Monitor the latest activity
+
+Leverage the helper scripts to combine multiple RPC calls and surface recent transactions.
+
+### Go helper
+
+```bash
+NHB_ADDRESS=$NHB_ADDRESS \
+NHB_RPC_URL=${NHB_RPC_URL:-https://rpc.nhbcoin.net} \
+NHB_API_BASE=${NHB_API_BASE:-https://api.nhbcoin.net/escrow/v1} \
+NHB_API_KEY=$NHB_API_KEY \
+NHB_API_SECRET=$NHB_API_SECRET \
+go run ./examples/cookbook/go
+```
+
+What it does:
+
+1. Calls `nhb_getBalance` and prints a formatted JSON snapshot.
+2. Calls `nhb_getLatestTransactions` (count = 10) and lists recent transfers.
+3. If REST credentials are present, signs a HMAC request and queries `GET /trades?buyer=...` on the escrow gateway to surface settled trades.
+
+Sample terminal output:
+
+```
+RPC base: https://rpc.nhbcoin.net
+REST base: https://api.nhbcoin.net/escrow/v1
+Address: nhb1example...
+
+==> nhb_getBalance
+{
+  "address": "nhb1example...",
+  "balanceNHB": "125000000",
+  "balanceZNHB": "50000000",
+  "stake": "75000000",
+  "username": "merchant.alpha",
+  "nonce": 42,
+  "engagementScore": 1180
+}
+
+==> nhb_getLatestTransactions
+ 1. nhb1payor... -> nhb1example... (25000000)
+ 2. nhb1example... -> nhb1payee... (10000000)
+
+==> GET /trades (escrow gateway)
+trade trd_01HXYZ... status SETTLED amount 35000000
+```
+
+### JavaScript helper
+
+The Node.js variant exposes the same flow and is handy for automation pipelines:
+
+```bash
+node ./examples/cookbook/js/index.mjs
+```
+
+> Requires Node.js 18+ (for the built-in `fetch`). Both helpers exit early with descriptive messages if required environment variables are missing or if the RPC returns an error code.
+
+### Verify balances/events
+
+- After submitting a test transfer on devnet, re-run either helper: the recent transaction list should include the new hash.
+- For escrow flows, expect `status` to move through `TRADE_INIT` → `FUNDED` → `SETTLED`. The helper reports the last five settled trades for the configured buyer.
+
+---
+
+## 4. Scenario C – Escrow audit via REST
+
+All REST calls must be signed. The signature formula matches the escrow gateway specification:
+
+```
+signature = Base64(HMAC-SHA256(api_secret, method + "\n" + path_with_query + "\n" + body + "\n" + timestamp))
+```
+
+A one-liner using Python and `curl` keeps things copy/paste friendly:
+
+```bash
+python3 - <<'PY'
+import base64, hashlib, hmac, os, time, urllib.parse, json, urllib.request
+api_base = os.environ.get('NHB_API_BASE', 'https://api.nhbcoin.net/escrow/v1')
+api_key = os.environ['NHB_API_KEY']
+api_secret = os.environ['NHB_API_SECRET']
+address = os.environ['NHB_ADDRESS']
+path = f"/trades?buyer={urllib.parse.quote(address)}&status=SETTLED&limit=5"
+timestamp = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+msg = '\n'.join(['GET', path, '', timestamp]).encode()
+sig = base64.b64encode(hmac.new(api_secret.encode(), msg, hashlib.sha256).digest()).decode()
+req = urllib.request.Request(api_base + path, method='GET', headers={
+    'Accept': 'application/json',
+    'X-API-Key': api_key,
+    'X-Timestamp': timestamp,
+    'X-Signature': sig,
+})
+with urllib.request.urlopen(req) as resp:
+    print(resp.read().decode())
+PY
+```
+
+Expected JSON envelope:
+
+```json
+{
+  "data": [
+    {
+      "id": "trd_01HXYZ...",
+      "buyer": "nhb1example...",
+      "seller": "nhb1market...",
+      "status": "SETTLED",
+      "amount": "35000000",
+      "token": "NHB",
+      "settled_at": "2024-06-24T18:11:03Z"
+    }
+  ],
+  "paging": {
+    "next_cursor": null,
+    "prev_cursor": null,
+    "limit": 5
+  }
+}
+```
+
+To check SLA health for the same environment, swap the path to `/metrics/sla`—the signature logic stays identical.
+
+### Verify balances/events
+
+- Compare `amount` and `settled_at` against on-chain settlement transactions returned by `nhb_getLatestTransactions`.
+- For devnet dispute testing, change the query to `status=DISPUTED` and confirm the trade history reflects the dispute event.
+
+---
+
+## 5. Postman collection
+
+Import [`examples/postman/NHB.postman_collection.json`](../../examples/postman/NHB.postman_collection.json) into Postman. The collection contains:
+
+- Four JSON-RPC requests (`nhb_getBalance`, `nhb_getLatestBlocks`, `nhb_getLatestTransactions`, `nhb_getEpochSummary`).
+- Two REST requests (`GET /trades`, `GET /metrics/sla`).
+
+Fill in the collection variables (`rpc_base`, `api_base`, `wallet_address`, `api_key`, `api_secret`). The pre-request script automatically signs REST calls using the HMAC recipe above. Switch to devnet by editing the base URLs (e.g., `https://rpc.devnet.nhbcoin.net`).
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `rpc responded with status 401` | RPC bearer token required for privileged methods. | Stick to public methods listed above or include the bearer token header. |
+| `gateway returned status 401` | Missing/invalid `X-API-Key` or HMAC signature. | Re-issue credentials and ensure the timestamp is RFC 3339 within ±60 seconds. |
+| Empty `data` array on escrow call | Address has no trades matching the filter. | Drop the `status` filter or query on `seller=` instead of `buyer=`. |
+| `invalid address parameter` | Input is not Bech32 (`nhb1...`). | Copy the address from `nhb-cli` or explorer and retry. |
+
+With these recipes you can validate balances, watch real-time activity, and audit escrow settlements on both devnet and testnet without digging through raw node logs.

--- a/examples/cookbook/go/main.go
+++ b/examples/cookbook/go/main.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+type rpcRequest struct {
+	JSONRPC string        `json:"jsonrpc"`
+	ID      int           `json:"id"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+}
+
+type rpcError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *rpcError       `json:"error"`
+}
+
+type balanceResponse struct {
+	Address            string          `json:"address"`
+	BalanceNHB         string          `json:"balanceNHB"`
+	BalanceZNHB        string          `json:"balanceZNHB"`
+	Stake              string          `json:"stake"`
+	LockedZNHB         string          `json:"lockedZNHB"`
+	DelegatedValidator string          `json:"delegatedValidator"`
+	PendingUnbonds     json.RawMessage `json:"pendingUnbonds"`
+	Username           string          `json:"username"`
+	Nonce              uint64          `json:"nonce"`
+	EngagementScore    uint64          `json:"engagementScore"`
+}
+
+type transaction struct {
+	Hash      string `json:"hash"`
+	From      string `json:"from"`
+	To        string `json:"to"`
+	Nonce     uint64 `json:"nonce"`
+	Value     string `json:"value"`
+	Type      string `json:"type"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+type restPage struct {
+	Data   []map[string]any `json:"data"`
+	Paging map[string]any   `json:"paging"`
+}
+
+func main() {
+	address := strings.TrimSpace(os.Getenv("NHB_ADDRESS"))
+	if address == "" {
+		log.Fatal("NHB_ADDRESS environment variable is required")
+	}
+
+	rpcURL := strings.TrimSpace(os.Getenv("NHB_RPC_URL"))
+	if rpcURL == "" {
+		rpcURL = "https://rpc.nhbcoin.net"
+	}
+
+	apiBase := strings.TrimSpace(os.Getenv("NHB_API_BASE"))
+	if apiBase == "" {
+		apiBase = "https://api.nhbcoin.net/escrow/v1"
+	}
+
+	apiKey := strings.TrimSpace(os.Getenv("NHB_API_KEY"))
+	apiSecret := strings.TrimSpace(os.Getenv("NHB_API_SECRET"))
+
+	fmt.Printf("RPC base: %s\n", rpcURL)
+	fmt.Printf("REST base: %s\n", apiBase)
+	fmt.Printf("Address: %s\n\n", address)
+
+	if err := runRPCBalance(rpcURL, address); err != nil {
+		log.Fatalf("rpc balance query failed: %v", err)
+	}
+
+	if err := runLatestTransactions(rpcURL); err != nil {
+		log.Fatalf("rpc latest transactions failed: %v", err)
+	}
+
+	if apiKey == "" || apiSecret == "" {
+		log.Println("skipping REST escrow lookup: set NHB_API_KEY and NHB_API_SECRET to enable")
+		return
+	}
+
+	if err := runEscrowLookup(apiBase, apiKey, apiSecret, address); err != nil {
+		log.Fatalf("escrow lookup failed: %v", err)
+	}
+}
+
+func runRPCBalance(rpcURL, address string) error {
+	fmt.Println("==> nhb_getBalance")
+	result, err := callRPC(rpcURL, "nhb_getBalance", []interface{}{address})
+	if err != nil {
+		return err
+	}
+	var balance balanceResponse
+	if err := json.Unmarshal(result, &balance); err != nil {
+		return fmt.Errorf("decode balance payload: %w", err)
+	}
+	prettyPrint(balance)
+	fmt.Println()
+	return nil
+}
+
+func runLatestTransactions(rpcURL string) error {
+	fmt.Println("==> nhb_getLatestTransactions")
+	result, err := callRPC(rpcURL, "nhb_getLatestTransactions", []interface{}{10})
+	if err != nil {
+		return err
+	}
+	var txs []transaction
+	if err := json.Unmarshal(result, &txs); err != nil {
+		return fmt.Errorf("decode transactions payload: %w", err)
+	}
+	if len(txs) == 0 {
+		fmt.Println("no recent transactions returned")
+	} else {
+		for i, tx := range txs {
+			fmt.Printf("%2d. %s -> %s (%s)\n", i+1, tx.From, tx.To, tx.Value)
+		}
+	}
+	fmt.Println()
+	return nil
+}
+
+func runEscrowLookup(apiBase, apiKey, apiSecret, address string) error {
+	fmt.Println("==> GET /trades (escrow gateway)")
+	params := url.Values{}
+	params.Set("buyer", address)
+	params.Set("status", "SETTLED")
+	params.Set("limit", "5")
+
+	body, status, err := restRequest("GET", apiBase, "/trades", params, "", apiKey, apiSecret)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return fmt.Errorf("gateway returned status %d: %s", status, string(body))
+	}
+	var page restPage
+	if err := json.Unmarshal(body, &page); err != nil {
+		return fmt.Errorf("decode escrow response: %w", err)
+	}
+	if len(page.Data) == 0 {
+		fmt.Println("no settled trades for buyer; try seller or remove status filter")
+	} else {
+		for _, trade := range page.Data {
+			fmt.Printf("trade %v status %v amount %v\n", trade["id"], trade["status"], trade["amount"])
+		}
+	}
+	fmt.Println()
+	return nil
+}
+
+func callRPC(rpcURL, method string, params []interface{}) (json.RawMessage, error) {
+	payload := rpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  method,
+		Params:  params,
+	}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.Post(rpcURL, "application/json", bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("rpc responded with status %d: %s", resp.StatusCode, string(body))
+	}
+	var rpcResp rpcResponse
+	if err := json.Unmarshal(body, &rpcResp); err != nil {
+		return nil, err
+	}
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("rpc error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+	if rpcResp.Result == nil {
+		return nil, errors.New("rpc result is empty")
+	}
+	return rpcResp.Result, nil
+}
+
+func restRequest(method, apiBase, path string, query url.Values, body string, apiKey, apiSecret string) ([]byte, int, error) {
+	baseURL, err := url.Parse(apiBase)
+	if err != nil {
+		return nil, 0, fmt.Errorf("parse NHB_API_BASE: %w", err)
+	}
+	full := *baseURL
+	full.Path = strings.TrimSuffix(baseURL.Path, "/") + path
+	full.RawQuery = query.Encode()
+
+	var reqBody io.Reader
+	if method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch {
+		reqBody = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, full.String(), reqBody)
+	if err != nil {
+		return nil, 0, err
+	}
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	canonical := full.EscapedPath()
+	if full.RawQuery != "" {
+		canonical += "?" + full.RawQuery
+	}
+
+	stringToSign := strings.Join([]string{method, canonical, body, timestamp}, "\n")
+	mac := hmac.New(sha256.New, []byte(apiSecret))
+	mac.Write([]byte(stringToSign))
+	signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("X-Timestamp", timestamp)
+	req.Header.Set("X-Signature", signature)
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return respBody, resp.StatusCode, nil
+}
+
+func prettyPrint(v interface{}) {
+	buf, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		fmt.Println(v)
+		return
+	}
+	fmt.Println(string(buf))
+}

--- a/examples/cookbook/js/index.mjs
+++ b/examples/cookbook/js/index.mjs
@@ -1,0 +1,126 @@
+import crypto from 'node:crypto';
+
+const rpcUrl = (process.env.NHB_RPC_URL || 'https://rpc.nhbcoin.net').trim();
+const apiBase = (process.env.NHB_API_BASE || 'https://api.nhbcoin.net/escrow/v1').trim().replace(/\/$/, '');
+const address = (process.env.NHB_ADDRESS || '').trim();
+const apiKey = (process.env.NHB_API_KEY || '').trim();
+const apiSecret = (process.env.NHB_API_SECRET || '').trim();
+
+if (!address) {
+  console.error('NHB_ADDRESS environment variable is required');
+  process.exit(1);
+}
+
+console.log(`RPC base: ${rpcUrl}`);
+console.log(`REST base: ${apiBase}`);
+console.log(`Address: ${address}`);
+console.log('');
+
+await runBalance();
+await runLatestTransactions();
+
+if (!apiKey || !apiSecret) {
+  console.warn('Skipping REST escrow lookup (set NHB_API_KEY and NHB_API_SECRET to enable).');
+  process.exit(0);
+}
+
+await runEscrowLookup();
+
+async function runBalance() {
+  console.log('==> nhb_getBalance');
+  const result = await rpcCall('nhb_getBalance', [address]);
+  console.log(JSON.stringify(result, null, 2));
+  console.log('');
+}
+
+async function runLatestTransactions() {
+  console.log('==> nhb_getLatestTransactions');
+  const result = await rpcCall('nhb_getLatestTransactions', [10]);
+  if (!Array.isArray(result) || result.length === 0) {
+    console.log('no recent transactions returned');
+  } else {
+    result.forEach((tx, idx) => {
+      console.log(`${String(idx + 1).padStart(2, ' ')}. ${tx.from} -> ${tx.to} (${tx.value})`);
+    });
+  }
+  console.log('');
+}
+
+async function runEscrowLookup() {
+  console.log('==> GET /trades (escrow gateway)');
+  const params = new URLSearchParams({ buyer: address, status: 'SETTLED', limit: '5' });
+  const { body, status } = await restRequest('GET', '/trades', params, undefined);
+  if (status >= 400) {
+    console.error(`gateway returned status ${status}: ${body}`);
+    process.exit(1);
+  }
+  const parsed = JSON.parse(body);
+  if (!Array.isArray(parsed?.data) || parsed.data.length === 0) {
+    console.log('no settled trades for buyer; try seller or adjust filters');
+  } else {
+    parsed.data.forEach((trade) => {
+      console.log(`trade ${trade.id} status ${trade.status} amount ${trade.amount}`);
+    });
+  }
+  console.log('');
+}
+
+async function rpcCall(method, params = []) {
+  const payload = {
+    jsonrpc: '2.0',
+    id: 1,
+    method,
+    params,
+  };
+  const response = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`rpc responded with ${response.status}: ${text}`);
+  }
+  const json = await response.json();
+  if (json.error) {
+    throw new Error(`rpc error ${json.error.code}: ${json.error.message}`);
+  }
+  if (json.result === undefined) {
+    throw new Error('rpc result missing');
+  }
+  return json.result;
+}
+
+async function restRequest(method, path, params, body) {
+  const url = new URL(apiBase + path);
+  if (params && [...params.keys()].length > 0) {
+    url.search = params.toString();
+  }
+
+  const timestamp = new Date().toISOString();
+  const canonicalPath = url.pathname + (url.search || '');
+  let payload = '';
+  if (method !== 'GET') {
+    payload = typeof body === 'string' ? body : JSON.stringify(body ?? {});
+  }
+  const stringToSign = [method.toUpperCase(), canonicalPath, payload, timestamp].join('\n');
+  const signature = crypto.createHmac('sha256', apiSecret).update(stringToSign).digest('base64');
+
+  const headers = {
+    'X-API-Key': apiKey,
+    'X-Timestamp': timestamp,
+    'X-Signature': signature,
+  };
+  if (method !== 'GET') {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: method === 'GET' ? undefined : payload,
+  });
+
+  const text = await response.text();
+  return { body: text, status: response.status };
+}

--- a/examples/postman/NHB.postman_collection.json
+++ b/examples/postman/NHB.postman_collection.json
@@ -1,0 +1,177 @@
+{
+  "info": {
+    "name": "NHBCoin RPC & REST Cookbook",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Reference requests for rpc.nhbcoin.net (JSON-RPC) and api.nhbcoin.net (REST escrow gateway). Update the collection variables to switch between devnet/testnet hosts or to inject credentials."
+  },
+  "item": [
+    {
+      "name": "RPC → Account balance",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"nhb_getBalance\",\n  \"params\": [\"{{wallet_address}}\"]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_base}}"
+        },
+        "description": "Fetch balances, stake, and alias metadata for the configured wallet address."
+      }
+    },
+    {
+      "name": "RPC → Latest blocks",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"nhb_getLatestBlocks\",\n  \"params\": [5]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_base}}"
+        },
+        "description": "Return metadata for the five most recent blocks (max 20)."
+      }
+    },
+    {
+      "name": "RPC → Latest transactions",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"nhb_getLatestTransactions\",\n  \"params\": [10]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_base}}"
+        },
+        "description": "List the most recent transactions observed across the chain (max 50)."
+      }
+    },
+    {
+      "name": "RPC → Epoch summary",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"nhb_getEpochSummary\",\n  \"params\": []\n}"
+        },
+        "url": {
+          "raw": "{{rpc_base}}"
+        },
+        "description": "Return validator participation for the current epoch. Pass a number to inspect historical epochs."
+      }
+    },
+    {
+      "name": "REST → Trades by buyer",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{api_base}}/trades?buyer={{wallet_address}}&status=SETTLED&limit=5"
+        },
+        "description": "List the five most recent settled escrow trades for the configured buyer. Requires API key and HMAC signature."
+      }
+    },
+    {
+      "name": "REST → SLA metrics",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{api_base}}/metrics/sla"
+        },
+        "description": "Return rolling gateway latency and error ratios. Requires API key and HMAC signature."
+      }
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "const apiBase = pm.variables.get('api_base');",
+          "if (!apiBase) { return; }",
+          "const requestUrl = pm.request.url.toString();",
+          "if (!requestUrl.startsWith(apiBase)) { return; }",
+          "const apiKey = pm.variables.get('api_key');",
+          "const apiSecret = pm.variables.get('api_secret');",
+          "if (!apiKey || !apiSecret) { return; }",
+          "const method = pm.request.method.toUpperCase();",
+          "const url = new URL(requestUrl);",
+          "const timestamp = new Date().toISOString();",
+          "let body = '';",
+          "if (method !== 'GET' && pm.request.body) {",
+          "  if (pm.request.body.mode === 'raw') {",
+          "    body = pm.request.body.raw || '';",
+          "  } else if (pm.request.body.mode === 'urlencoded') {",
+          "    body = pm.request.body.urlencoded.toString();",
+          "  }",
+          "}",
+          "const canonical = url.pathname + (url.search || '');",
+          "const stringToSign = [method, canonical, body, timestamp].join('\\n');",
+          "const signature = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(stringToSign, apiSecret));",
+          "pm.request.headers.upsert({ key: 'X-API-Key', value: apiKey });",
+          "pm.request.headers.upsert({ key: 'X-Timestamp', value: timestamp });",
+          "pm.request.headers.upsert({ key: 'X-Signature', value: signature });"
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "rpc_base",
+      "value": "https://rpc.nhbcoin.net"
+    },
+    {
+      "key": "api_base",
+      "value": "https://api.nhbcoin.net/escrow/v1"
+    },
+    {
+      "key": "wallet_address",
+      "value": "nhb1exampleaddress000000000000000000000000"
+    },
+    {
+      "key": "api_key",
+      "value": ""
+    },
+    {
+      "key": "api_secret",
+      "value": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document RPC and REST cookbook scenarios that target nhbcoin.net endpoints
- add Go and JavaScript helper scripts plus a Postman collection aligned with the cookbook flows

## Testing
- go test ./... *(interrupted after running for an extended period)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b5918f18832da9a5487b898aa2b2