### PR TITLE
feat: persist swap oracle proofs and dashboards

### DIFF
--- a/core/events/swap.go
+++ b/core/events/swap.go
@@ -10,18 +10,22 @@ import (
 )
 
 const (
-        // TypeSwapMinted is emitted whenever a swap voucher mints ZNHB on-chain.
-        TypeSwapMinted = "swap.minted"
-        // TypeSwapAlertLimitHit indicates that a voucher submission triggered a configured limit.
-        TypeSwapAlertLimitHit = "swap.alert.limit_hit"
-        // TypeSwapAlertSanction indicates that a voucher recipient failed the sanctions hook.
-        TypeSwapAlertSanction = "swap.alert.sanction"
-        // TypeSwapAlertVelocity indicates that a voucher breached the mint velocity guardrail.
-        TypeSwapAlertVelocity = "swap.alert.velocity"
-        // TypeSwapBurnRecorded captures a burn receipt produced by the off-ramp.
-        TypeSwapBurnRecorded = "swap.burn.recorded"
-        // TypeSwapTreasuryReconciled is emitted when vouchers are marked as reconciled against treasury records.
-        TypeSwapTreasuryReconciled = "swap.treasury.reconciled"
+	// TypeSwapMinted is emitted whenever a swap voucher mints ZNHB on-chain.
+	TypeSwapMinted = "swap.minted"
+	// TypeSwapMintProof references the oracle artifacts persisted alongside a mint.
+	TypeSwapMintProof = "swap.mint.proof"
+	// TypeSwapAlertLimitHit indicates that a voucher submission triggered a configured limit.
+	TypeSwapAlertLimitHit = "swap.alert.limit_hit"
+	// TypeSwapAlertSanction indicates that a voucher recipient failed the sanctions hook.
+	TypeSwapAlertSanction = "swap.alert.sanction"
+	// TypeSwapAlertVelocity indicates that a voucher breached the mint velocity guardrail.
+	TypeSwapAlertVelocity = "swap.alert.velocity"
+	// TypeSwapBurnRecorded captures a burn receipt produced by the off-ramp.
+	TypeSwapBurnRecorded = "swap.burn.recorded"
+	// TypeSwapTreasuryReconciled is emitted when vouchers are marked as reconciled against treasury records.
+	TypeSwapTreasuryReconciled = "swap.treasury.reconciled"
+	// TypeSwapRedeemProof references the oracle proofs associated with redeemed vouchers.
+	TypeSwapRedeemProof = "swap.redeem.proof"
 )
 
 type SwapMinted struct {
@@ -55,6 +59,67 @@ func (e SwapMinted) Event() *types.Event {
 			"rate":       strings.TrimSpace(e.Rate),
 		},
 	}
+}
+
+// SwapMintProof captures the oracle metadata persisted for a minted voucher.
+type SwapMintProof struct {
+	ProviderTxID      string
+	OrderID           string
+	Token             string
+	PriceProofID      string
+	OracleSource      string
+	OracleMedian      string
+	OracleFeeders     []string
+	QuoteTimestamp    int64
+	TwapRate          string
+	TwapObservations  int
+	TwapWindowSeconds int64
+	TwapStart         int64
+	TwapEnd           int64
+}
+
+// EventType returns the mint proof event identifier.
+func (SwapMintProof) EventType() string { return TypeSwapMintProof }
+
+// Event renders the mint proof event payload.
+func (p SwapMintProof) Event() *types.Event {
+	attrs := map[string]string{}
+	if trimmed := strings.TrimSpace(p.ProviderTxID); trimmed != "" {
+		attrs["providerTxId"] = trimmed
+	}
+	if trimmed := strings.TrimSpace(p.OrderID); trimmed != "" {
+		attrs["orderId"] = trimmed
+	}
+	if trimmed := strings.TrimSpace(p.Token); trimmed != "" {
+		attrs["token"] = trimmed
+	}
+	if trimmed := strings.TrimSpace(p.PriceProofID); trimmed != "" {
+		attrs["priceProofId"] = trimmed
+	}
+	if trimmed := strings.TrimSpace(p.OracleSource); trimmed != "" {
+		attrs["source"] = trimmed
+	}
+	if trimmed := strings.TrimSpace(p.OracleMedian); trimmed != "" {
+		attrs["oracleMedian"] = trimmed
+	}
+	if len(p.OracleFeeders) > 0 {
+		attrs["oracleFeeders"] = strings.Join(p.OracleFeeders, ",")
+	}
+	if p.QuoteTimestamp > 0 {
+		attrs["quoteTs"] = strconv.FormatInt(p.QuoteTimestamp, 10)
+	}
+	if strings.TrimSpace(p.TwapRate) != "" {
+		attrs["twapRate"] = strings.TrimSpace(p.TwapRate)
+	}
+	attrs["twapObservations"] = strconv.Itoa(p.TwapObservations)
+	attrs["twapWindowSeconds"] = strconv.FormatInt(p.TwapWindowSeconds, 10)
+	if p.TwapStart > 0 {
+		attrs["twapStart"] = strconv.FormatInt(p.TwapStart, 10)
+	}
+	if p.TwapEnd > 0 {
+		attrs["twapEnd"] = strconv.FormatInt(p.TwapEnd, 10)
+	}
+	return &types.Event{Type: TypeSwapMintProof, Attributes: attrs}
 }
 
 // SwapLimitAlert captures metadata describing a limit violation.
@@ -132,29 +197,29 @@ func (SwapVelocityAlert) EventType() string { return TypeSwapAlertVelocity }
 
 // Event renders the velocity alert payload.
 func (a SwapVelocityAlert) Event() *types.Event {
-        attrs := map[string]string{
-                "provider":      strings.TrimSpace(a.Provider),
-                "providerTxId":  strings.TrimSpace(a.ProviderTxID),
-                "windowSeconds": strconv.FormatUint(a.WindowSeconds, 10),
-                "allowedMints":  strconv.FormatUint(a.AllowedMints, 10),
-                "observedCount": strconv.Itoa(a.ObservedCount),
-        }
-        if a.Address != ([20]byte{}) {
-                attrs["address"] = crypto.NewAddress(crypto.NHBPrefix, a.Address[:]).String()
-        }
-        return &types.Event{Type: TypeSwapAlertVelocity, Attributes: attrs}
+	attrs := map[string]string{
+		"provider":      strings.TrimSpace(a.Provider),
+		"providerTxId":  strings.TrimSpace(a.ProviderTxID),
+		"windowSeconds": strconv.FormatUint(a.WindowSeconds, 10),
+		"allowedMints":  strconv.FormatUint(a.AllowedMints, 10),
+		"observedCount": strconv.Itoa(a.ObservedCount),
+	}
+	if a.Address != ([20]byte{}) {
+		attrs["address"] = crypto.NewAddress(crypto.NHBPrefix, a.Address[:]).String()
+	}
+	return &types.Event{Type: TypeSwapAlertVelocity, Attributes: attrs}
 }
 
 // SwapBurnRecorded encapsulates metadata describing an off-ramp burn receipt.
 type SwapBurnRecorded struct {
-        ReceiptID    string
-        ProviderTxID string
-        Token        string
-        Amount       *big.Int
-        BurnTx       string
-        TreasuryTx   string
-        VoucherIDs   []string
-        ObservedAt   int64
+	ReceiptID    string
+	ProviderTxID string
+	Token        string
+	Amount       *big.Int
+	BurnTx       string
+	TreasuryTx   string
+	VoucherIDs   []string
+	ObservedAt   int64
 }
 
 // EventType returns the canonical burn receipt event identifier.
@@ -162,36 +227,69 @@ func (SwapBurnRecorded) EventType() string { return TypeSwapBurnRecorded }
 
 // Event renders the burn receipt event for downstream consumers.
 func (r SwapBurnRecorded) Event() *types.Event {
-        amount := big.NewInt(0)
-        if r.Amount != nil {
-                amount = new(big.Int).Set(r.Amount)
-        }
-        attrs := map[string]string{
-                "receiptId":   strings.TrimSpace(r.ReceiptID),
-                "providerTxId": strings.TrimSpace(r.ProviderTxID),
-                "token":       strings.TrimSpace(r.Token),
-                "amountWei":   amount.String(),
-        }
-        if strings.TrimSpace(r.BurnTx) != "" {
-                attrs["burnTx"] = strings.TrimSpace(r.BurnTx)
-        }
-        if strings.TrimSpace(r.TreasuryTx) != "" {
-                attrs["treasuryTx"] = strings.TrimSpace(r.TreasuryTx)
-        }
-        if len(r.VoucherIDs) > 0 {
-                attrs["vouchers"] = strings.Join(r.VoucherIDs, ",")
-        }
-        if r.ObservedAt > 0 {
-                attrs["observedAt"] = strconv.FormatInt(r.ObservedAt, 10)
-        }
-        return &types.Event{Type: TypeSwapBurnRecorded, Attributes: attrs}
+	amount := big.NewInt(0)
+	if r.Amount != nil {
+		amount = new(big.Int).Set(r.Amount)
+	}
+	attrs := map[string]string{
+		"receiptId":    strings.TrimSpace(r.ReceiptID),
+		"providerTxId": strings.TrimSpace(r.ProviderTxID),
+		"token":        strings.TrimSpace(r.Token),
+		"amountWei":    amount.String(),
+	}
+	if strings.TrimSpace(r.BurnTx) != "" {
+		attrs["burnTx"] = strings.TrimSpace(r.BurnTx)
+	}
+	if strings.TrimSpace(r.TreasuryTx) != "" {
+		attrs["treasuryTx"] = strings.TrimSpace(r.TreasuryTx)
+	}
+	if len(r.VoucherIDs) > 0 {
+		attrs["vouchers"] = strings.Join(r.VoucherIDs, ",")
+	}
+	if r.ObservedAt > 0 {
+		attrs["observedAt"] = strconv.FormatInt(r.ObservedAt, 10)
+	}
+	return &types.Event{Type: TypeSwapBurnRecorded, Attributes: attrs}
+}
+
+// SwapRedeemProof references the proofs attached to vouchers covered by a burn receipt.
+type SwapRedeemProof struct {
+	ReceiptID     string
+	ProviderTxID  string
+	VoucherIDs    []string
+	PriceProofIDs []string
+	ObservedAt    int64
+}
+
+// EventType returns the redeem proof event identifier.
+func (SwapRedeemProof) EventType() string { return TypeSwapRedeemProof }
+
+// Event renders the redeem proof event payload.
+func (p SwapRedeemProof) Event() *types.Event {
+	attrs := map[string]string{}
+	if trimmed := strings.TrimSpace(p.ReceiptID); trimmed != "" {
+		attrs["receiptId"] = trimmed
+	}
+	if trimmed := strings.TrimSpace(p.ProviderTxID); trimmed != "" {
+		attrs["providerTxId"] = trimmed
+	}
+	if len(p.VoucherIDs) > 0 {
+		attrs["vouchers"] = strings.Join(p.VoucherIDs, ",")
+	}
+	if len(p.PriceProofIDs) > 0 {
+		attrs["priceProofIds"] = strings.Join(p.PriceProofIDs, ",")
+	}
+	if p.ObservedAt > 0 {
+		attrs["observedAt"] = strconv.FormatInt(p.ObservedAt, 10)
+	}
+	return &types.Event{Type: TypeSwapRedeemProof, Attributes: attrs}
 }
 
 // SwapTreasuryReconciled captures a treasury reconciliation marker for minted vouchers.
 type SwapTreasuryReconciled struct {
-        VoucherIDs []string
-        ReceiptID  string
-        ObservedAt int64
+	VoucherIDs []string
+	ReceiptID  string
+	ObservedAt int64
 }
 
 // EventType returns the canonical reconciliation event identifier.
@@ -199,17 +297,17 @@ func (SwapTreasuryReconciled) EventType() string { return TypeSwapTreasuryReconc
 
 // Event renders the reconciliation event payload.
 func (r SwapTreasuryReconciled) Event() *types.Event {
-        if len(r.VoucherIDs) == 0 {
-                return nil
-        }
-        attrs := map[string]string{
-                "vouchers": strings.Join(r.VoucherIDs, ","),
-        }
-        if strings.TrimSpace(r.ReceiptID) != "" {
-                attrs["receiptId"] = strings.TrimSpace(r.ReceiptID)
-        }
-        if r.ObservedAt > 0 {
-                attrs["observedAt"] = strconv.FormatInt(r.ObservedAt, 10)
-        }
-        return &types.Event{Type: TypeSwapTreasuryReconciled, Attributes: attrs}
+	if len(r.VoucherIDs) == 0 {
+		return nil
+	}
+	attrs := map[string]string{
+		"vouchers": strings.Join(r.VoucherIDs, ","),
+	}
+	if strings.TrimSpace(r.ReceiptID) != "" {
+		attrs["receiptId"] = strings.TrimSpace(r.ReceiptID)
+	}
+	if r.ObservedAt > 0 {
+		attrs["observedAt"] = strconv.FormatInt(r.ObservedAt, 10)
+	}
+	return &types.Event{Type: TypeSwapTreasuryReconciled, Attributes: attrs}
 }

--- a/core/node_swap_test.go
+++ b/core/node_swap_test.go
@@ -25,6 +25,8 @@ func TestSwapRecordBurnPersistsReceipt(t *testing.T) {
 			MintAmountWei:   big.NewInt(1),
 			QuoteTimestamp:  time.Now().Unix(),
 			OracleSource:    "manual",
+			PriceProofID:    "proof-1",
+			OracleFeeders:   []string{"manual"},
 			MinterSignature: "sig",
 		}
 		return ledger.Put(record)
@@ -73,12 +75,15 @@ func TestSwapRecordBurnPersistsReceipt(t *testing.T) {
 	emitted := node.Events()
 	foundBurn := false
 	foundRecon := false
+	foundProof := false
 	for _, evt := range emitted {
 		switch evt.Type {
 		case events.TypeSwapBurnRecorded:
 			foundBurn = true
 		case events.TypeSwapTreasuryReconciled:
 			foundRecon = true
+		case events.TypeSwapRedeemProof:
+			foundProof = true
 		}
 	}
 	if !foundBurn {
@@ -86,6 +91,9 @@ func TestSwapRecordBurnPersistsReceipt(t *testing.T) {
 	}
 	if !foundRecon {
 		t.Fatalf("expected treasury reconciled event")
+	}
+	if !foundProof {
+		t.Fatalf("expected redeem proof event")
 	}
 }
 

--- a/docs/treasury/dashboards.md
+++ b/docs/treasury/dashboards.md
@@ -1,0 +1,23 @@
+# Treasury Dashboards
+
+The treasury dashboards surface swap oracle health, proof freshness, and redemption status to
+support peg monitoring and operational readiness.
+
+## Core panels
+
+- **Proof freshness** – Track the latest `priceProofId` timestamps from `swap_voucher_list`. Alert
+  if no new proof lands within two TWAP windows or if the feeder set collapses to a single signer.
+- **Deviation bands** – Chart TWAP rate versus median and custody reference rates. Highlight periods
+  when deviation exceeds configured guard rails or when manual feeds drive the price.
+- **Feeder participation** – Display the feeder sets reported in `swap.mint.proof` events, including
+  counts per signer and time since last observation.
+- **Redeem settlement** – List recent `swap.redeem.proof` events showing the vouchers and proof IDs
+  reconciled by treasury burns. Flag burns missing proof references for manual review.
+
+## Alerting hooks
+
+- Page on stale TWAP observations, missing median values, or proof IDs older than the configured SLA.
+- Escalate when redeems land without matching proof IDs or when burn receipts accumulate without
+  reconciliation events.
+- Notify risk when deviation spikes coincide with manual feeder usage or when proof IDs oscillate
+  between signers more frequently than rotation policy allows.

--- a/docs/treasury/operations.md
+++ b/docs/treasury/operations.md
@@ -1,0 +1,31 @@
+# Treasury Operations Runbook
+
+## KMS management
+
+- **Key inventory** – Maintain a signed inventory of active mint signer KMS keys with owner,
+  creation date, and rotation schedule.
+- **Rotation cadence** – Rotate signer keys at least quarterly or after any security incident.
+  Follow the signer rotation steps in the peg policy and verify `swap.mint.proof` events show the
+  new `priceProofId`.
+- **Access controls** – Restrict mint signer roles to the treasury security group. Enable hardware
+  MFA for break-glass administrators.
+
+## Break-glass procedures
+
+1. **Trigger conditions** – Initiate break-glass when the custody oracle is unavailable, deviation
+   exceeds approved limits, or proof freshness alarms fire for more than two windows.
+2. **Activate manual feed** – Inject a manual quote via `SetSwapManualQuote` with explicit
+   justification recorded in the incident ticket. Confirm subsequent mints emit `swap.mint.proof`
+   events with `source=manual` and the temporary feeders listed.
+3. **Pause minting** – If manual rates cannot be trusted, pause minting by disabling the token or
+   revoking the provider in `swap.ProviderStatus` until market conditions normalize.
+4. **Post-incident review** – Export the affected vouchers and burns, capturing `priceProofId` and
+   TWAP artifacts for the audit trail. Document remediation and update dashboards/alerts to prevent
+   recurrence.
+
+## Operational checkpoints
+
+- Daily: review `swap.redeem.proof` events to ensure treasury settlements include proof references.
+- Weekly: reconcile dashboard freshness metrics with ledger `priceProofId` timestamps.
+- Monthly: validate that KMS key rotation plans remain on schedule and break-glass tooling is
+  functional.

--- a/docs/treasury/peg-policy.md
+++ b/docs/treasury/peg-policy.md
@@ -1,0 +1,43 @@
+# Treasury Peg Policy
+
+The treasury relies on a diversified oracle basket to anchor swap mint quotes and to monitor
+pricing risk across custody and exchange venues.
+
+## Oracle basket
+
+- **Primary custody feeds** – Signed samples delivered by the fiat gateway from custody risk
+  engines. These feeds are registered via `swap.ProviderStatus` and occupy the top of the
+  aggregator priority list.
+- **Secondary market data** – CoinGecko and other public APIs remain configured as
+  lower-priority fallbacks. They automatically surface when the primary feeds deviate or fail
+  freshness checks.
+- **Manual breaker feed** – The on-call team can inject a signed manual quote via
+  `SetSwapManualQuote`. Manual rates sit at the bottom of the priority stack and are only used
+  during emergency circuit-breaker scenarios.
+
+## Deviation and freshness guards
+
+- **Max quote age** – `swap.MaxQuoteAgeSeconds` bounds staleness. Quotes older than the cap are
+  rejected by the node and logged for investigation.
+- **Median guardrails** – The fiat gateway enforces per-feed deviation thresholds and circuit
+  breakers before samples are relayed to the chain. The on-chain TWAP calculator now persists the
+  median, TWAP window, feeder set, and a deterministic `priceProofId` with every swap for audit
+  replay.
+- **Circuit breakers** – If the basket deviates from the rolling TWAP by more than the configured
+  basis points, the gateway halts new vouchers and requires break-glass approval to resume.
+
+## Signer rotation
+
+1. Provision a new KMS keypair and record the address in the signer inventory.
+2. Update the payments gateway configuration (`MinterKMSEnv`) and rotate the service. The gateway
+   emits an audit log and new oracle samples should begin populating the on-chain feeder set.
+3. Call `swap_provider_status` and `swap_voucher_get` to confirm the new signer is producing fresh
+   samples and that the resulting `priceProofId` values reference the updated key.
+4. Revoke access for the retired signer, archive the runbook in the security vault, and note the
+   rotation in the treasury change log.
+
+## Circuit-breaker triggers
+
+- Sustained `swap.mint.proof` events showing a single feeder or stagnant TWAP window.
+- Deviation alarms from dashboards exceeding the median/TWAP guard bands.
+- Manual override events from operations indicating custody outages or extreme volatility.

--- a/rpc/swap_handlers.go
+++ b/rpc/swap_handlers.go
@@ -207,38 +207,45 @@ func formatVoucherRecord(record *swap.VoucherRecord) map[string]interface{} {
 	if record == nil {
 		return nil
 	}
-        response := map[string]interface{}{
-                "provider":      record.Provider,
-                "providerTxId":  record.ProviderTxID,
-                "fiatCurrency":  record.FiatCurrency,
-                "fiatAmount":    record.FiatAmount,
-                "usd":           record.USD,
-                "rate":          record.Rate,
-                "token":         record.Token,
-                "mintAmountWei": mintAmountToString(record.MintAmountWei),
-                "username":      record.Username,
-                "address":       record.Address,
-                "quoteTs":       record.QuoteTimestamp,
-                "source":        record.OracleSource,
-                "minterSig":     record.MinterSignature,
-                "status":        record.Status,
-                "createdAt":     record.CreatedAt,
-        }
-        if strings.TrimSpace(record.TwapRate) != "" {
-                response["twapRate"] = record.TwapRate
-        }
-        if record.TwapObservations > 0 {
-                response["twapObservations"] = record.TwapObservations
-        }
-        if record.TwapWindowSeconds > 0 {
-                response["twapWindowSeconds"] = record.TwapWindowSeconds
-        }
-        if record.TwapStart > 0 {
-                response["twapStart"] = record.TwapStart
-        }
-        if record.TwapEnd > 0 {
-                response["twapEnd"] = record.TwapEnd
-        }
+	response := map[string]interface{}{
+		"provider":      record.Provider,
+		"providerTxId":  record.ProviderTxID,
+		"fiatCurrency":  record.FiatCurrency,
+		"fiatAmount":    record.FiatAmount,
+		"usd":           record.USD,
+		"rate":          record.Rate,
+		"token":         record.Token,
+		"mintAmountWei": mintAmountToString(record.MintAmountWei),
+		"username":      record.Username,
+		"address":       record.Address,
+		"quoteTs":       record.QuoteTimestamp,
+		"source":        record.OracleSource,
+		"priceProofId":  record.PriceProofID,
+		"oracleMedian":  record.OracleMedian,
+		"minterSig":     record.MinterSignature,
+		"status":        record.Status,
+		"createdAt":     record.CreatedAt,
+	}
+	if len(record.OracleFeeders) > 0 {
+		response["oracleFeeders"] = append([]string{}, record.OracleFeeders...)
+	}
+	if strings.TrimSpace(record.PriceProofID) == "" {
+		delete(response, "priceProofId")
+	}
+	if strings.TrimSpace(record.OracleMedian) == "" {
+		delete(response, "oracleMedian")
+	}
+	if strings.TrimSpace(record.TwapRate) != "" {
+		response["twapRate"] = record.TwapRate
+	}
+	response["twapObservations"] = record.TwapObservations
+	response["twapWindowSeconds"] = record.TwapWindowSeconds
+	if record.TwapStart > 0 {
+		response["twapStart"] = record.TwapStart
+	}
+	if record.TwapEnd > 0 {
+		response["twapEnd"] = record.TwapEnd
+	}
 	if record.Recipient != ([20]byte{}) {
 		response["recipient"] = crypto.NewAddress(crypto.NHBPrefix, record.Recipient[:]).String()
 	}


### PR DESCRIPTION
## Summary
- extend the swap oracle TWAP snapshot with median, feeder set, window duration, and deterministic proof IDs
- persist the proof artifacts on voucher records, surface them via RPC, and emit `swap.mint.proof`/`swap.redeem.proof` events
- document treasury peg policy, operational runbooks, and dashboards for monitoring proof freshness and deviation guards

## Testing
- `go test ./native/swap ./rpc ./core`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d6cdbdc3e8832d9fcfafbed8074259