### PR TITLE
Add creator module and studio example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /build/
 /dist/
 /out/
+.next/
+node_modules/
 *.exe
 *.test
 *.out

--- a/docs/creator/api.md
+++ b/docs/creator/api.md
@@ -1,0 +1,102 @@
+# Creator Module API
+
+The module is exposed through authenticated JSON-RPC endpoints. All calls require the standard RPC auth token and accept one JSON object as the sole parameter.
+
+## `creator_publish`
+
+Registers new content under the caller’s address.
+
+```jsonc
+// request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "creator_publish",
+  "params": [
+    {
+      "caller": "nhb1...",
+      "contentId": "beatdrop-001",
+      "uri": "ipfs://Qm...",
+      "metadata": "{\"title\":\"Friday Drop\"}"
+    }
+  ]
+}
+```
+
+```jsonc
+// response
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "id": "beatdrop-001",
+    "creator": "nhb1...",
+    "uri": "ipfs://Qm...",
+    "metadata": "{\"title\":\"Friday Drop\"}",
+    "publishedAt": 1712083200,
+    "totalTips": "0",
+    "totalStake": "0"
+  }
+}
+```
+
+## `creator_tip`
+
+Transfers NHB from the caller to the target creator and credits their payout ledger.
+
+Parameters:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `caller` | string | Fan address (Bech32). |
+| `contentId` | string | Previously published ID. |
+| `amount` | string | Decimal NHB amount in wei. |
+
+Response body includes the latest pending and lifetime payout tallies.
+
+## `creator_stake`
+
+Locks NHB behind a creator. The engine mints staking yield into the payout ledger using the configured basis points rate. The response returns the updated stake position, minted reward, and ledger snapshot.
+
+## `creator_unstake`
+
+Unlocks a fan’s stake and returns the funds to their liquid balance. Any remaining position is echoed back so clients can update UI state.
+
+## `creator_payouts`
+
+Inspects or claims the creator’s payout ledger.
+
+Parameters:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `caller` | string | Creator address. |
+| `claim` | bool | Optional. When true the pending amount is credited to the creator account and zeroed in the ledger. |
+
+Response example:
+
+```jsonc
+{
+  "pending": "4200000000000000000",
+  "totalTips": "8400000000000000000",
+  "totalYield": "210000000000000000",
+  "lastPayout": 1712087200,
+  "claimed": "4200000000000000000"
+}
+```
+
+## Error Semantics
+
+All creator endpoints return `-32602` (`codeInvalidParams`) for validation failures such as malformed addresses, empty content IDs, or non-positive amounts. Runtime issues (e.g. insufficient balance) are also surfaced as `codeInvalidParams` with a descriptive message to keep client logic simple.
+
+## Event Consumption
+
+Every RPC action emits one or more events accessible through the node’s event log stream:
+
+- Publish → `creator.content.published`
+- Tip → `creator.content.tipped`, `creator.payout.accrued`
+- Stake → `creator.fan.staked`, `creator.payout.accrued`
+- Unstake → `creator.fan.unstaked`
+- Claim → `creator.payout.accrued`
+
+Indexers should subscribe to these types to power discovery views, feed the `/examples/creator-studio` UI, and surface real-time insights for devnet demos.

--- a/docs/creator/overview.md
+++ b/docs/creator/overview.md
@@ -1,0 +1,46 @@
+# Creator Module Overview
+
+The creator module powers a native fan economy on NHB Chain. It lets artists and communities publish content, receive direct tips, and bootstrap sustainable revenue via fan staking. Every action emits structured events so downstream indexers, discovery portals, and devnet demos can track lifecycle changes in real time.
+
+## Core Concepts
+
+| Concept | Description |
+| --- | --- |
+| **Content** | Immutable publication envelope containing the creator address, canonical ID, off-chain URI, metadata stub, publish timestamp, and cumulative engagement counters. |
+| **Tip** | Transfer of liquid NHB from a fan to a content creator. Tips immediately credit the creator’s balance and are tracked against the originating content. |
+| **Stake** | Fans can lock NHB behind a creator to signal long-term support. Staking mints yield into the creator’s payout ledger at a configurable reward rate. |
+| **Payout Ledger** | Rolling ledger that records total tips, staking yield, pending distribution, and last payout time for each creator. Creators can inspect or claim the ledger at any time via JSON-RPC. |
+
+## State Layout
+
+The module persists data under the following storage prefixes:
+
+- `creator/content/<contentId>` – RLP-encoded `Content` records.
+- `creator/stake/<creator>/<fan>` – RLP-encoded `Stake` positions keyed by creator/fan pair.
+- `creator/ledger/<creator>` – RLP-encoded `PayoutLedger` for each creator.
+
+Accounts are debited/credited atomically through the existing account manager, ensuring balance consistency with other modules.
+
+## Event Stream
+
+Every mutation emits an indexed event ready for discovery tooling:
+
+| Event | Attributes |
+| --- | --- |
+| `creator.content.published` | `contentId`, `creator`, `uri` |
+| `creator.content.tipped` | `contentId`, `creator`, `fan`, `amount` |
+| `creator.fan.staked` | `creator`, `fan`, `amount`, `shares` |
+| `creator.fan.unstaked` | `creator`, `fan`, `amount` |
+| `creator.payout.accrued` | `creator`, `pending`, `totalTips`, `totalYield` |
+
+Events are wrapped with the standard `events.Event` interface so `StateProcessor.AppendEvent` receives structured payloads for RPC and archive indexing. Devnet scripts can subscribe to this stream to power the creator studio demo and surface live accrual progress.
+
+## Lifecycle Flow
+
+1. **Publish** – A creator calls `creator_publish` to register a new content ID. The engine normalises the payload, persists the record, and emits `creator.content.published`.
+2. **Tip** – A fan calls `creator_tip` with the published ID and amount. Balances are transferred, content totals incremented, the payout ledger is updated, and twin `creator.content.tipped` / `creator.payout.accrued` events fire.
+3. **Stake** – Supporters lock NHB with `creator_stake`, producing shares and a staking yield bump that is added to `PendingDistribution`. A discovery event highlights the backing and yield change.
+4. **Unstake** – Fans can exit via `creator_unstake`, returning funds and adjusting share counts while emitting `creator.fan.unstaked`.
+5. **Claim** – Creators view or withdraw pending balances through `creator_payouts`, optionally zeroing the pending amount and logging the new ledger snapshot.
+
+This flow is mirrored in the `/examples/creator-studio` Next.js app and the accompanying documentation so operators can experiment end-to-end on devnet.

--- a/docs/creator/security.md
+++ b/docs/creator/security.md
@@ -1,0 +1,29 @@
+# Creator Module Security Notes
+
+The creator economy introduces new flows for capital and engagement. Operators should harden deployments around the following safeguards.
+
+## Smart Account Hygiene
+
+* **Authentication** – All RPC endpoints require the existing bearer token. Rotate credentials regularly and restrict access to trusted apps (e.g. the devnet studio).
+* **Input validation** – The engine enforces non-empty content IDs and positive amounts. Clients should still validate locally to catch mistakes before signatures are gathered.
+* **Idempotency** – Content IDs are unique. Publishing with an existing ID will fail, preventing accidental overwrites.
+
+## Treasury & Balance Protection
+
+* **Sufficient funds** – Tipping and staking debit the caller immediately. Failed balance checks surface as validation errors; clients should present clear messaging to avoid repeated retries.
+* **Rate limits** – The RPC server already enforces a sliding window (5 tx/min). Consider lowering this in public devnets to reduce griefing and wash trading.
+* **Reward configuration** – Staking yield is controlled in-code (2.5% BPS in this build). Networks can fork to adjust or gate staking entirely if needed.
+
+## Anti-Abuse Guidance
+
+* **Content moderation** – The chain stores only references. Operators should run off-chain scanners to flag abusive URIs or metadata and surface trust scores in front-ends.
+* **Sybil detection** – Pair creator staking with existing engagement metrics and sanctions lists. High-velocity staking from new accounts should trigger monitoring before payouts are claimed.
+* **Withdrawal monitoring** – The `creator_payouts` claim path emits `creator.payout.accrued`. Hook this into fraud analytics so suspicious drains are quarantined quickly.
+
+## Devnet Playbook
+
+* Spin up the JSON-RPC server with auth enabled.
+* Deploy the `/examples/creator-studio` workspace and follow the “publish → tip → stake → payout” walkthrough.
+* Use the emitted events (see [`docs/creator/overview.md`](./overview.md)) to verify indexing coverage and ensure dashboards capture every lifecycle edge.
+
+By following these practices the creator module can be rolled out on devnet with predictable behaviour and clear recovery paths for edge cases.

--- a/docs/examples/creator-studio.md
+++ b/docs/examples/creator-studio.md
@@ -1,0 +1,39 @@
+# Creator Studio Example
+
+The creator studio is a Next.js workspace that demonstrates the new creator module lifecycle: publish → tip → stake → payout. It proxies JSON-RPC requests through an API route and renders real-time ledger feedback driven by the events emitted from the chain.
+
+## Getting Started
+
+```bash
+cd examples
+cp .env.example creator-studio/.env.local # populate NHB_RPC_URL + NHB_RPC_TOKEN
+cd creator-studio
+yarn install
+yarn dev
+```
+
+Visit `http://localhost:3000` and provide the following inputs:
+
+1. **Creator / Fan** – Devnet Bech32 addresses with funded balances.
+2. **Content** – Choose a unique `contentId`, URI, and metadata JSON.
+3. **Tip** – Enter the NHB amount (in wei) a fan will tip the creator.
+4. **Stake** – Lock additional NHB behind the creator to mint staking yield.
+5. **Payouts** – Inspect the payout ledger or claim pending accruals directly.
+
+The right-hand log shows every RPC call so you can correlate UI actions with emitted events. When running against devnet, tail the node logs or connect an indexer to the following event keys to confirm indexing coverage:
+
+- `creator.content.published`
+- `creator.content.tipped`
+- `creator.fan.staked`
+- `creator.fan.unstaked`
+- `creator.payout.accrued`
+
+## Devnet Workflow
+
+1. Publish content from the creator address.
+2. Send a tip from the fan address and observe balances shift.
+3. Stake additional NHB to trigger payout accruals.
+4. Refresh the ledger to view pending totals.
+5. Claim payouts and verify the pending balance drops to zero.
+
+This walkthrough mirrors the behaviour described in [`docs/creator/overview.md`](../creator/overview.md) and is intended for demos, QA, and partner onboarding.

--- a/examples/creator-studio/.eslintrc.json
+++ b/examples/creator-studio/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/examples/creator-studio/next-env.d.ts
+++ b/examples/creator-studio/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/creator-studio/next.config.js
+++ b/examples/creator-studio/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  output: 'standalone'
+};
+
+module.exports = nextConfig;

--- a/examples/creator-studio/package.json
+++ b/examples/creator-studio/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@nhb/examples-creator-studio",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "2.2.4"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "eslint": "8.57.0",
+    "eslint-config-next": "13.5.6",
+    "typescript": "5.4.5"
+  }
+}

--- a/examples/creator-studio/pages/_app.tsx
+++ b/examples/creator-studio/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/examples/creator-studio/pages/api/rpc.ts
+++ b/examples/creator-studio/pages/api/rpc.ts
@@ -1,0 +1,55 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const RPC_URL = process.env.NHB_RPC_URL ?? 'http://localhost:8545';
+const RPC_TOKEN = process.env.NHB_RPC_TOKEN ?? process.env.NEXT_PUBLIC_NHB_RPC_TOKEN ?? '';
+
+type RPCPayload = {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params: unknown[];
+};
+
+type ErrorBody = { error: string };
+
+type HandlerResponse = RPCPayload & { result?: unknown; error?: unknown };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<HandlerResponse | ErrorBody>
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const { method, params } = req.body ?? {};
+  if (typeof method !== 'string') {
+    res.status(400).json({ error: 'method is required' });
+    return;
+  }
+
+  const payload: RPCPayload = {
+    jsonrpc: '2.0',
+    id: Date.now(),
+    method,
+    params: Array.isArray(params) ? params : [],
+  };
+
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (RPC_TOKEN) {
+      headers['Authorization'] = `Bearer ${RPC_TOKEN}`;
+    }
+    const response = await fetch(RPC_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    });
+    const body = (await response.json()) as HandlerResponse;
+    res.status(response.status).json(body);
+  } catch (error) {
+    res.status(500).json({ error: (error as Error).message });
+  }
+}

--- a/examples/creator-studio/pages/index.tsx
+++ b/examples/creator-studio/pages/index.tsx
@@ -1,0 +1,270 @@
+import { FormEvent, useMemo, useState } from 'react';
+
+const fetcher = async (method: string, params: unknown[]) => {
+  const response = await fetch('/api/rpc', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ method, params }),
+  });
+  const json = await response.json();
+  if (!response.ok || json.error) {
+    throw new Error(json?.error?.message ?? json?.error ?? 'RPC error');
+  }
+  return json.result;
+};
+
+type LedgerState = {
+  pending: string;
+  totalTips: string;
+  totalYield: string;
+  lastPayout: number;
+  claimed?: string;
+};
+
+type ContentResult = {
+  id: string;
+  creator: string;
+  uri: string;
+  metadata: string;
+  publishedAt: number;
+  totalTips: string;
+  totalStake: string;
+};
+
+export default function CreatorStudio() {
+  const [creator, setCreator] = useState('');
+  const [fan, setFan] = useState('');
+  const [contentId, setContentId] = useState('demo-drop');
+  const [uri, setUri] = useState('ipfs://cid');
+  const [metadata, setMetadata] = useState('{"title":"Demo Drop"}');
+  const [tipAmount, setTipAmount] = useState('100000000000000000');
+  const [stakeAmount, setStakeAmount] = useState('500000000000000000');
+  const [statusLog, setStatusLog] = useState<string[]>([]);
+  const [content, setContent] = useState<ContentResult | null>(null);
+  const [ledger, setLedger] = useState<LedgerState | null>(null);
+
+  const log = (entry: string) => {
+    setStatusLog((prev) => [new Date().toLocaleTimeString(), entry, ...prev]);
+  };
+
+  const call = async (method: string, params: unknown[]) => {
+    try {
+      const result = await fetcher(method, params);
+      log(`${method} → success`);
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`${method} → ${message}`);
+      throw error;
+    }
+  };
+
+  const handlePublish = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!creator) {
+      log('creator address required');
+      return;
+    }
+    try {
+      const result = (await call('creator_publish', [
+        {
+          caller: creator,
+          contentId,
+          uri,
+          metadata,
+        },
+      ])) as ContentResult;
+      setContent(result);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleTip = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!fan) {
+      log('fan address required');
+      return;
+    }
+    try {
+      const result = (await call('creator_tip', [
+        {
+          caller: fan,
+          contentId,
+          amount: tipAmount,
+        },
+      ])) as LedgerState & { creator: string; fan: string; amount: string };
+      setLedger((prev) => ({
+        pending: result.pending,
+        totalTips: result.totalTips,
+        totalYield: result.totalYield,
+        lastPayout: prev?.lastPayout ?? 0,
+      }));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleStake = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!fan || !creator) {
+      log('creator and fan addresses required');
+      return;
+    }
+    try {
+      const result = (await call('creator_stake', [
+        {
+          caller: fan,
+          creator,
+          amount: stakeAmount,
+        },
+      ])) as LedgerState & { shares: string; reward: string };
+      setLedger({
+        pending: result.pending,
+        totalTips: result.totalTips,
+        totalYield: result.totalYield,
+        lastPayout: result.lastPayout ?? 0,
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handlePayouts = async (claim: boolean) => {
+    if (!creator) {
+      log('creator address required');
+      return;
+    }
+    try {
+      const result = (await call('creator_payouts', [
+        {
+          caller: creator,
+          claim,
+        },
+      ])) as LedgerState;
+      setLedger(result);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const prettyLedger = useMemo(() => {
+    if (!ledger) {
+      return 'no payouts yet';
+    }
+    const lines = [
+      `Pending: ${ledger.pending ?? '0'} wei`,
+      `Total Tips: ${ledger.totalTips ?? '0'} wei`,
+      `Total Yield: ${ledger.totalYield ?? '0'} wei`,
+    ];
+    if (ledger.lastPayout) {
+      lines.push(`Last Payout: ${new Date(ledger.lastPayout * 1000).toLocaleString()}`);
+    }
+    if (ledger.claimed) {
+      lines.push(`Claimed: ${ledger.claimed} wei`);
+    }
+    return lines.join('\n');
+  }, [ledger]);
+
+  return (
+    <main>
+      <header style={{ marginBottom: '2rem' }}>
+        <span className="badge">Creator Studio Demo</span>
+        <h1>Publish → Tip → Stake → Payout</h1>
+        <p>
+          Use devnet addresses to exercise the full lifecycle. The app proxies JSON-RPC calls through
+          <code> /api/rpc</code> so you only need to provide the correct bearer token in <code>.env.local</code>.
+        </p>
+      </header>
+
+      <section className="card">
+        <h2>Actor Setup</h2>
+        <div className="grid">
+          <div>
+            <label>
+              Creator Address
+              <input value={creator} onChange={(event) => setCreator(event.target.value.trim())} placeholder="nhb1..." />
+            </label>
+          </div>
+          <div>
+            <label>
+              Fan Address
+              <input value={fan} onChange={(event) => setFan(event.target.value.trim())} placeholder="nhb1..." />
+            </label>
+          </div>
+        </div>
+      </section>
+
+      <section className="card">
+        <h2>1. Publish Content</h2>
+        <form onSubmit={handlePublish} className="grid">
+          <label>
+            Content ID
+            <input value={contentId} onChange={(event) => setContentId(event.target.value)} />
+          </label>
+          <label>
+            Content URI
+            <input value={uri} onChange={(event) => setUri(event.target.value)} />
+          </label>
+          <label style={{ gridColumn: 'span 2' }}>
+            Metadata JSON
+            <textarea rows={3} value={metadata} onChange={(event) => setMetadata(event.target.value)} />
+          </label>
+          <button type="submit" disabled={!creator}>
+            Publish
+          </button>
+        </form>
+        {content && (
+          <p style={{ marginTop: '1rem' }}>
+            Latest content <strong>{content.id}</strong> published at{' '}
+            {new Date(content.publishedAt * 1000).toLocaleString()}
+          </p>
+        )}
+      </section>
+
+      <section className="card">
+        <h2>2. Tip the Drop</h2>
+        <form onSubmit={handleTip} className="grid">
+          <label>
+            Amount (wei)
+            <input value={tipAmount} onChange={(event) => setTipAmount(event.target.value)} />
+          </label>
+          <button type="submit">Send Tip</button>
+        </form>
+      </section>
+
+      <section className="card">
+        <h2>3. Stake Behind the Creator</h2>
+        <form onSubmit={handleStake} className="grid">
+          <label>
+            Amount (wei)
+            <input value={stakeAmount} onChange={(event) => setStakeAmount(event.target.value)} />
+          </label>
+          <button type="submit">Stake</button>
+        </form>
+      </section>
+
+      <section className="card">
+        <h2>4. Payouts</h2>
+        <div className="grid">
+          <button type="button" onClick={() => handlePayouts(false)}>
+            Refresh Ledger
+          </button>
+          <button type="button" onClick={() => handlePayouts(true)}>
+            Claim Pending
+          </button>
+        </div>
+        <div className="log" style={{ marginTop: '1.5rem' }}>
+          {prettyLedger}
+        </div>
+      </section>
+
+      <section className="card">
+        <h2>Activity Log</h2>
+        <div className="log">
+          {statusLog.length === 0 ? 'no activity yet' : statusLog.join('\n')}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/examples/creator-studio/styles/globals.css
+++ b/examples/creator-studio/styles/globals.css
@@ -1,0 +1,97 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, sans-serif;
+  background: radial-gradient(circle at top, #1f2937, #0b1120);
+  color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+a {
+  color: #38bdf8;
+}
+
+button {
+  cursor: pointer;
+  border-radius: 8px;
+  border: none;
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  color: #fff;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(14, 165, 233, 0.35);
+}
+
+input, textarea, select {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  padding: 0.75rem 1rem;
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+section.card {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1.75rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.3);
+}
+
+section.card h2 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.2);
+  color: #bfdbfe;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.log {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  white-space: pre-wrap;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  max-height: 320px;
+  overflow-y: auto;
+}

--- a/examples/creator-studio/tsconfig.json
+++ b/examples/creator-studio/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,8 @@
     "wallet-lite",
     "p2p-mini-market",
     "merchant-loyalty-console",
-    "escrow-checkout/*"
+    "escrow-checkout/*",
+    "creator-studio"
   ],
   "scripts": {
     "dev": "node ./scripts/dev.js",

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -842,10 +842,22 @@
     "@emnapi/runtime" "^1.4.3"
     "@tybys/wasm-util" "^0.10.0"
 
+"@next/env@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.5.6.tgz#c1148e2e1aa166614f05161ee8f77ded467062bc"
+  integrity sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==
+
 "@next/env@14.2.3":
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-14.2.3.tgz#d6def29d1c763c0afb397343a15a82e7d92353a0"
   integrity sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA==
+
+"@next/eslint-plugin-next@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.6.tgz#cf279b94ddc7de49af8e8957f0c3b7349bc489bf"
+  integrity sha512-ng7pU/DDsxPgT6ZPvuprxrkeew3XaRf4LAT4FabaEO/hAbvVx4P7wqnqdbTdDn1kgTvsI4tpIgT4Awn/m0bGbg==
+  dependencies:
+    glob "7.1.7"
 
 "@next/eslint-plugin-next@14.2.3":
   version "14.2.3"
@@ -854,45 +866,90 @@
   dependencies:
     glob "10.3.10"
 
+"@next/swc-darwin-arm64@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz#b15d139d8971360fca29be3bdd703c108c9a45fb"
+  integrity sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==
+
 "@next/swc-darwin-arm64@14.2.3":
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz#db1a05eb88c0224089b815ad10ac128ec79c2cdb"
   integrity sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==
+
+"@next/swc-darwin-x64@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz#9c72ee31cc356cb65ce6860b658d807ff39f1578"
+  integrity sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==
 
 "@next/swc-darwin-x64@14.2.3":
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz#a3f8af05b5f9a52ac3082e66ac29e125ab1d7b9c"
   integrity sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==
 
+"@next/swc-linux-arm64-gnu@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz#59f5f66155e85380ffa26ee3d95b687a770cfeab"
+  integrity sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==
+
 "@next/swc-linux-arm64-gnu@14.2.3":
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz#4e63f43879285b52554bfd39e6e0cc78a9b27bbf"
   integrity sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==
+
+"@next/swc-linux-arm64-musl@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz#f012518228017052736a87d69bae73e587c76ce2"
+  integrity sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==
 
 "@next/swc-linux-arm64-musl@14.2.3":
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz#ebdaed26214448b1e6f2c3e8b3cd29bfba387990"
   integrity sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==
 
+"@next/swc-linux-x64-gnu@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz#339b867a7e9e7ee727a700b496b269033d820df4"
+  integrity sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==
+
 "@next/swc-linux-x64-gnu@14.2.3":
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz#19e3bcc137c3b582a1ab867106817e5c90a20593"
   integrity sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==
+
+"@next/swc-linux-x64-musl@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz#ae0ae84d058df758675830bcf70ca1846f1028f2"
+  integrity sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==
 
 "@next/swc-linux-x64-musl@14.2.3":
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz#794a539b98e064169cf0ff7741b2a4fb16adec7d"
   integrity sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==
 
+"@next/swc-win32-arm64-msvc@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz#a5cc0c16920485a929a17495064671374fdbc661"
+  integrity sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==
+
 "@next/swc-win32-arm64-msvc@14.2.3":
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz#eda9fa0fbf1ff9113e87ac2668ee67ce9e5add5a"
   integrity sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==
 
+"@next/swc-win32-ia32-msvc@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz#6a2409b84a2cbf34bf92fe714896455efb4191e4"
+  integrity sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==
+
 "@next/swc-win32-ia32-msvc@14.2.3":
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz#7c1190e3f640ab16580c6bdbd7d0e766b9920457"
   integrity sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==
+
+"@next/swc-win32-x64-msvc@13.5.6":
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz#4a3e2a206251abc729339ba85f60bc0433c2865d"
+  integrity sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==
 
 "@next/swc-win32-x64-msvc@14.2.3":
   version "14.2.3"
@@ -1482,6 +1539,13 @@
   resolved "https://registry.yarnpkg.com/@swc/counter/-/counter-0.1.3.tgz#cc7463bd02949611c6329596fccd2b0ec782b0e9"
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
 
+"@swc/helpers@0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.2.tgz#85ea0c76450b61ad7d10a37050289eded783c27d"
+  integrity sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==
+  dependencies:
+    tslib "^2.4.0"
+
 "@swc/helpers@0.5.5":
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.5.tgz#12689df71bfc9b21c4f4ca00ae55f2f16c8b77c0"
@@ -1602,6 +1666,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@18.2.7":
+  version "18.2.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.7.tgz#67222a08c0a6ae0a0da33c3532348277c70abb63"
+  integrity sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@^18.2.14":
   version "18.3.7"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
@@ -1612,6 +1683,15 @@
   resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.13.tgz#fc650ffa680d739a25a530f5d7ebe00cdd771883"
   integrity sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==
   dependencies:
+    csstype "^3.0.2"
+
+"@types/react@18.2.21":
+  version "18.2.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.21.tgz#774c37fd01b522d0b91aed04811b58e4e0514ed9"
+  integrity sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/react@18.2.45":
@@ -1653,6 +1733,17 @@
     "@types/node" "*"
     "@types/send" "*"
 
+"@typescript-eslint/parser@^5.4.2 || ^6.0.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.21.0.tgz#af8fcf66feee2edc86bc5d1cf45e33b0630bf35b"
+  integrity sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==
+  dependencies:
+    "@typescript-eslint/scope-manager" "6.21.0"
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/typescript-estree" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+    debug "^4.3.4"
+
 "@typescript-eslint/parser@^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-7.2.0.tgz#44356312aea8852a3a82deebdacd52ba614ec07a"
@@ -1664,6 +1755,14 @@
     "@typescript-eslint/visitor-keys" "7.2.0"
     debug "^4.3.4"
 
+"@typescript-eslint/scope-manager@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz#ea8a9bfc8f1504a6ac5d59a6df308d3a0630a2b1"
+  integrity sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+
 "@typescript-eslint/scope-manager@7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz#cfb437b09a84f95a0930a76b066e89e35d94e3da"
@@ -1672,10 +1771,29 @@
     "@typescript-eslint/types" "7.2.0"
     "@typescript-eslint/visitor-keys" "7.2.0"
 
+"@typescript-eslint/types@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.21.0.tgz#205724c5123a8fef7ecd195075fa6e85bac3436d"
+  integrity sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==
+
 "@typescript-eslint/types@7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.2.0.tgz#0feb685f16de320e8520f13cca30779c8b7c403f"
   integrity sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==
+
+"@typescript-eslint/typescript-estree@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz#c47ae7901db3b8bddc3ecd73daff2d0895688c46"
+  integrity sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    minimatch "9.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
 
 "@typescript-eslint/typescript-estree@7.2.0":
   version "7.2.0"
@@ -1690,6 +1808,14 @@
     minimatch "9.0.3"
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
+
+"@typescript-eslint/visitor-keys@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz#87a99d077aa507e20e238b11d56cc26ade45fe47"
+  integrity sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    eslint-visitor-keys "^3.4.1"
 
 "@typescript-eslint/visitor-keys@7.2.0":
   version "7.2.0"
@@ -2145,7 +2271,7 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-caniuse-lite@^1.0.30001579:
+caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001579:
   version "1.0.30001745"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz#ab2a36e3b6ed5bfb268adc002c476aab6513f859"
   integrity sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==
@@ -2635,6 +2761,21 @@ escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+eslint-config-next@13.5.6:
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/eslint-config-next/-/eslint-config-next-13.5.6.tgz#3a5a6222d5cb32256760ad68ab8e976e866a08c8"
+  integrity sha512-o8pQsUHTo9aHqJ2YiZDym5gQAMRf7O2HndHo/JZeY7TDD+W4hk6Ma8Vw54RHiBeb7OWWO5dPirQB+Is/aVQ7Kg==
+  dependencies:
+    "@next/eslint-plugin-next" "13.5.6"
+    "@rushstack/eslint-patch" "^1.3.3"
+    "@typescript-eslint/parser" "^5.4.2 || ^6.0.0"
+    eslint-import-resolver-node "^0.3.6"
+    eslint-import-resolver-typescript "^3.5.2"
+    eslint-plugin-import "^2.28.1"
+    eslint-plugin-jsx-a11y "^6.7.1"
+    eslint-plugin-react "^7.33.2"
+    eslint-plugin-react-hooks "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
 
 eslint-config-next@14.2.3:
   version "14.2.3"
@@ -3133,6 +3274,11 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
 glob@10.3.10:
   version "10.3.10"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.10.tgz#0351ebb809fd187fe421ab96af83d3a70715df4b"
@@ -3143,6 +3289,18 @@ glob@10.3.10:
     minimatch "^9.0.1"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
+
+glob@7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^10.3.10:
   version "10.4.5"
@@ -3200,7 +3358,7 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.2.11:
+graceful-fs@^4.1.2, graceful-fs@^4.2.11:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -3764,7 +3922,7 @@ minimatch@9.0.3:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -3837,6 +3995,29 @@ negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+next@13.5.6:
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/next/-/next-13.5.6.tgz#e964b5853272236c37ce0dd2c68302973cf010b1"
+  integrity sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==
+  dependencies:
+    "@next/env" "13.5.6"
+    "@swc/helpers" "0.5.2"
+    busboy "1.6.0"
+    caniuse-lite "^1.0.30001406"
+    postcss "8.4.31"
+    styled-jsx "5.1.1"
+    watchpack "2.4.0"
+  optionalDependencies:
+    "@next/swc-darwin-arm64" "13.5.6"
+    "@next/swc-darwin-x64" "13.5.6"
+    "@next/swc-linux-arm64-gnu" "13.5.6"
+    "@next/swc-linux-arm64-musl" "13.5.6"
+    "@next/swc-linux-x64-gnu" "13.5.6"
+    "@next/swc-linux-x64-musl" "13.5.6"
+    "@next/swc-win32-arm64-msvc" "13.5.6"
+    "@next/swc-win32-ia32-msvc" "13.5.6"
+    "@next/swc-win32-x64-msvc" "13.5.6"
 
 next@14.2.3:
   version "14.2.3"
@@ -4992,6 +5173,14 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+watchpack@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
+  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"

--- a/native/creator/engine.go
+++ b/native/creator/engine.go
@@ -1,0 +1,397 @@
+package creator
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"nhbchain/core/events"
+	"nhbchain/core/types"
+)
+
+var (
+	errNilState          = errors.New("creator engine: state not configured")
+	errContentExists     = errors.New("creator engine: content already exists")
+	errContentNotFound   = errors.New("creator engine: content not found")
+	errInvalidAmount     = errors.New("creator engine: amount must be positive")
+	errInsufficientFunds = errors.New("creator engine: insufficient balance")
+	errStakeNotFound     = errors.New("creator engine: stake not found")
+)
+
+const stakingAccrualBps = 250 // 2.5% accrual when staking behind a creator.
+
+type engineState interface {
+	CreatorContentGet(id string) (*Content, bool, error)
+	CreatorContentPut(content *Content) error
+	CreatorStakeGet(creator [20]byte, fan [20]byte) (*Stake, bool, error)
+	CreatorStakePut(stake *Stake) error
+	CreatorStakeDelete(creator [20]byte, fan [20]byte) error
+	CreatorPayoutLedgerGet(creator [20]byte) (*PayoutLedger, bool, error)
+	CreatorPayoutLedgerPut(ledger *PayoutLedger) error
+	GetAccount(addr []byte) (*types.Account, error)
+	PutAccount(addr []byte, account *types.Account) error
+}
+
+// Engine wires creator economy business logic with persistence and event emission.
+type Engine struct {
+	state   engineState
+	emitter events.Emitter
+	nowFn   func() int64
+}
+
+// NewEngine constructs a creator engine with default dependencies.
+func NewEngine() *Engine {
+	return &Engine{
+		emitter: events.NoopEmitter{},
+		nowFn: func() int64 {
+			return time.Now().Unix()
+		},
+	}
+}
+
+// SetState configures the state backend used by the engine.
+func (e *Engine) SetState(state engineState) { e.state = state }
+
+// SetEmitter configures the event emitter used by the engine.
+func (e *Engine) SetEmitter(emitter events.Emitter) {
+	if emitter == nil {
+		e.emitter = events.NoopEmitter{}
+		return
+	}
+	e.emitter = emitter
+}
+
+// SetNowFunc overrides the time source used for deterministic testing.
+func (e *Engine) SetNowFunc(now func() int64) {
+	if now == nil {
+		e.nowFn = func() int64 { return time.Now().Unix() }
+		return
+	}
+	e.nowFn = now
+}
+
+func (e *Engine) emit(evt *types.Event) {
+	if e == nil || evt == nil || e.emitter == nil {
+		return
+	}
+	e.emitter.Emit(WrapEvent(evt))
+}
+
+func (e *Engine) now() int64 {
+	if e == nil || e.nowFn == nil {
+		return time.Now().Unix()
+	}
+	return e.nowFn()
+}
+
+func ensureAccount(acc *types.Account) *types.Account {
+	if acc == nil {
+		return &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}
+	}
+	if acc.BalanceNHB == nil {
+		acc.BalanceNHB = big.NewInt(0)
+	}
+	if acc.BalanceZNHB == nil {
+		acc.BalanceZNHB = big.NewInt(0)
+	}
+	if acc.Stake == nil {
+		acc.Stake = big.NewInt(0)
+	}
+	return acc
+}
+
+func sanitizeContentID(id string) (string, error) {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return "", errors.New("content id required")
+	}
+	return trimmed, nil
+}
+
+func hexAddr(addr [20]byte) string {
+	return "0x" + hex.EncodeToString(addr[:])
+}
+
+func newBigInt(v *big.Int) *big.Int {
+	if v == nil {
+		return big.NewInt(0)
+	}
+	return new(big.Int).Set(v)
+}
+
+func newLedger(creator [20]byte) *PayoutLedger {
+	return &PayoutLedger{
+		Creator:             creator,
+		TotalTips:           big.NewInt(0),
+		TotalStakingYield:   big.NewInt(0),
+		PendingDistribution: big.NewInt(0),
+		LastPayout:          0,
+	}
+}
+
+// PublishContent registers a new piece of content and emits the corresponding event.
+func (e *Engine) PublishContent(creator [20]byte, id string, uri string, metadata string) (*Content, error) {
+	if e == nil || e.state == nil {
+		return nil, errNilState
+	}
+	sanitized, err := sanitizeContentID(id)
+	if err != nil {
+		return nil, err
+	}
+	if existing, ok, err := e.state.CreatorContentGet(sanitized); err != nil {
+		return nil, err
+	} else if ok && existing != nil {
+		return nil, errContentExists
+	}
+	content := &Content{
+		ID:          sanitized,
+		Creator:     creator,
+		URI:         strings.TrimSpace(uri),
+		Metadata:    strings.TrimSpace(metadata),
+		PublishedAt: e.now(),
+		TotalTips:   big.NewInt(0),
+		TotalStake:  big.NewInt(0),
+	}
+	if err := e.state.CreatorContentPut(content); err != nil {
+		return nil, err
+	}
+	e.emit(ContentPublishedEvent(content.ID, hexAddr(content.Creator), content.URI))
+	return content, nil
+}
+
+// TipContent processes a fan tipping a piece of content.
+func (e *Engine) TipContent(fan [20]byte, contentID string, amount *big.Int) (*Tip, error) {
+	if e == nil || e.state == nil {
+		return nil, errNilState
+	}
+	if amount == nil || amount.Sign() <= 0 {
+		return nil, errInvalidAmount
+	}
+	sanitized, err := sanitizeContentID(contentID)
+	if err != nil {
+		return nil, err
+	}
+	content, ok, err := e.state.CreatorContentGet(sanitized)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || content == nil {
+		return nil, errContentNotFound
+	}
+	fanAccount, err := e.state.GetAccount(fan[:])
+	if err != nil {
+		return nil, err
+	}
+	fanAccount = ensureAccount(fanAccount)
+	if fanAccount.BalanceNHB.Cmp(amount) < 0 {
+		return nil, errInsufficientFunds
+	}
+	fanAccount.BalanceNHB = new(big.Int).Sub(fanAccount.BalanceNHB, amount)
+	creatorAccount, err := e.state.GetAccount(content.Creator[:])
+	if err != nil {
+		return nil, err
+	}
+	creatorAccount = ensureAccount(creatorAccount)
+	creatorAccount.BalanceNHB = new(big.Int).Add(creatorAccount.BalanceNHB, amount)
+	if err := e.state.PutAccount(fan[:], fanAccount); err != nil {
+		return nil, err
+	}
+	if err := e.state.PutAccount(content.Creator[:], creatorAccount); err != nil {
+		return nil, err
+	}
+	content.TotalTips = new(big.Int).Add(content.TotalTips, amount)
+	if err := e.state.CreatorContentPut(content); err != nil {
+		return nil, err
+	}
+	ledger, ok, err := e.state.CreatorPayoutLedgerGet(content.Creator)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || ledger == nil {
+		ledger = newLedger(content.Creator)
+	}
+	ledger.TotalTips = new(big.Int).Add(ledger.TotalTips, amount)
+	ledger.PendingDistribution = new(big.Int).Add(ledger.PendingDistribution, amount)
+	if err := e.state.CreatorPayoutLedgerPut(ledger); err != nil {
+		return nil, err
+	}
+	e.emit(ContentTippedEvent(content.ID, hexAddr(content.Creator), hexAddr(fan), amount.String()))
+	e.emit(CreatorPayoutAccruedEvent(hexAddr(content.Creator), ledger.PendingDistribution.String(), ledger.TotalTips.String(), ledger.TotalStakingYield.String()))
+	tip := &Tip{
+		ContentID: sanitized,
+		Creator:   content.Creator,
+		Fan:       fan,
+		Amount:    newBigInt(amount),
+		TippedAt:  e.now(),
+	}
+	return tip, nil
+}
+
+// StakeCreator allows a fan to stake behind a creator and accrues a payout share.
+func (e *Engine) StakeCreator(fan [20]byte, creator [20]byte, amount *big.Int) (*Stake, *big.Int, error) {
+	if e == nil || e.state == nil {
+		return nil, nil, errNilState
+	}
+	if amount == nil || amount.Sign() <= 0 {
+		return nil, nil, errInvalidAmount
+	}
+	fanAccount, err := e.state.GetAccount(fan[:])
+	if err != nil {
+		return nil, nil, err
+	}
+	fanAccount = ensureAccount(fanAccount)
+	if fanAccount.BalanceNHB.Cmp(amount) < 0 {
+		return nil, nil, errInsufficientFunds
+	}
+	fanAccount.BalanceNHB = new(big.Int).Sub(fanAccount.BalanceNHB, amount)
+	if err := e.state.PutAccount(fan[:], fanAccount); err != nil {
+		return nil, nil, err
+	}
+	stake, ok, err := e.state.CreatorStakeGet(creator, fan)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !ok || stake == nil {
+		stake = &Stake{
+			Creator:     creator,
+			Fan:         fan,
+			Amount:      big.NewInt(0),
+			Shares:      big.NewInt(0),
+			StakedAt:    e.now(),
+			LastAccrual: e.now(),
+		}
+	}
+	stake.Amount = new(big.Int).Add(stake.Amount, amount)
+	stake.Shares = new(big.Int).Add(stake.Shares, amount)
+	stake.LastAccrual = e.now()
+	if err := e.state.CreatorStakePut(stake); err != nil {
+		return nil, nil, err
+	}
+	ledger, ok, err := e.state.CreatorPayoutLedgerGet(creator)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !ok || ledger == nil {
+		ledger = newLedger(creator)
+	}
+	reward := new(big.Int).Mul(amount, big.NewInt(stakingAccrualBps))
+	reward = reward.Div(reward, big.NewInt(10_000))
+	if reward.Sign() > 0 {
+		ledger.TotalStakingYield = new(big.Int).Add(ledger.TotalStakingYield, reward)
+		ledger.PendingDistribution = new(big.Int).Add(ledger.PendingDistribution, reward)
+	}
+	if err := e.state.CreatorPayoutLedgerPut(ledger); err != nil {
+		return nil, nil, err
+	}
+	e.emit(CreatorStakedEvent(hexAddr(creator), hexAddr(fan), amount.String(), stake.Shares.String()))
+	if reward.Sign() > 0 {
+		e.emit(CreatorPayoutAccruedEvent(hexAddr(creator), ledger.PendingDistribution.String(), ledger.TotalTips.String(), ledger.TotalStakingYield.String()))
+	}
+	return stake, reward, nil
+}
+
+// UnstakeCreator unlocks a fan stake and returns the funds back to the fan balance.
+func (e *Engine) UnstakeCreator(fan [20]byte, creator [20]byte, amount *big.Int) (*Stake, error) {
+	if e == nil || e.state == nil {
+		return nil, errNilState
+	}
+	if amount == nil || amount.Sign() <= 0 {
+		return nil, errInvalidAmount
+	}
+	stake, ok, err := e.state.CreatorStakeGet(creator, fan)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || stake == nil || stake.Amount.Cmp(amount) < 0 {
+		return nil, errStakeNotFound
+	}
+	stake.Amount = new(big.Int).Sub(stake.Amount, amount)
+	if stake.Shares == nil {
+		stake.Shares = big.NewInt(0)
+	}
+	if stake.Shares.Cmp(amount) >= 0 {
+		stake.Shares = new(big.Int).Sub(stake.Shares, amount)
+	} else {
+		stake.Shares = big.NewInt(0)
+	}
+	if stake.Amount.Sign() == 0 {
+		if err := e.state.CreatorStakeDelete(creator, fan); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := e.state.CreatorStakePut(stake); err != nil {
+			return nil, err
+		}
+	}
+	fanAccount, err := e.state.GetAccount(fan[:])
+	if err != nil {
+		return nil, err
+	}
+	fanAccount = ensureAccount(fanAccount)
+	fanAccount.BalanceNHB = new(big.Int).Add(fanAccount.BalanceNHB, amount)
+	if err := e.state.PutAccount(fan[:], fanAccount); err != nil {
+		return nil, err
+	}
+	e.emit(CreatorUnstakedEvent(hexAddr(creator), hexAddr(fan), amount.String()))
+	return stake, nil
+}
+
+// ClaimPayouts settles the pending distribution for the creator and credits their balance.
+func (e *Engine) ClaimPayouts(creator [20]byte) (*PayoutLedger, *big.Int, error) {
+	if e == nil || e.state == nil {
+		return nil, nil, errNilState
+	}
+	ledger, ok, err := e.state.CreatorPayoutLedgerGet(creator)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !ok || ledger == nil {
+		ledger = newLedger(creator)
+	}
+	pending := newBigInt(ledger.PendingDistribution)
+	if pending.Sign() == 0 {
+		return ledger.Clone(), big.NewInt(0), nil
+	}
+	creatorAccount, err := e.state.GetAccount(creator[:])
+	if err != nil {
+		return nil, nil, err
+	}
+	creatorAccount = ensureAccount(creatorAccount)
+	creatorAccount.BalanceNHB = new(big.Int).Add(creatorAccount.BalanceNHB, pending)
+	if err := e.state.PutAccount(creator[:], creatorAccount); err != nil {
+		return nil, nil, err
+	}
+	ledger.PendingDistribution = big.NewInt(0)
+	ledger.LastPayout = e.now()
+	if err := e.state.CreatorPayoutLedgerPut(ledger); err != nil {
+		return nil, nil, err
+	}
+	e.emit(CreatorPayoutAccruedEvent(hexAddr(creator), ledger.PendingDistribution.String(), ledger.TotalTips.String(), ledger.TotalStakingYield.String()))
+	return ledger.Clone(), pending, nil
+}
+
+// Payouts returns the payout ledger for the supplied creator without mutating state.
+func (e *Engine) Payouts(creator [20]byte) (*PayoutLedger, error) {
+	if e == nil || e.state == nil {
+		return nil, errNilState
+	}
+	ledger, ok, err := e.state.CreatorPayoutLedgerGet(creator)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || ledger == nil {
+		ledger = newLedger(creator)
+	}
+	return ledger.Clone(), nil
+}
+
+// DebugString returns a textual description of the engine state. Useful for tracing.
+func (e *Engine) DebugString() string {
+	if e == nil {
+		return "creator engine <nil>"
+	}
+	return fmt.Sprintf("creator engine emitter=%T", e.emitter)
+}

--- a/native/creator/events.go
+++ b/native/creator/events.go
@@ -1,0 +1,98 @@
+package creator
+
+import (
+	"nhbchain/core/events"
+	"nhbchain/core/types"
+)
+
+const (
+	// EventTypeContentPublished is emitted when a creator publishes new content.
+	EventTypeContentPublished = "creator.content.published"
+	// EventTypeContentTipped is emitted when a fan tips a piece of content.
+	EventTypeContentTipped = "creator.content.tipped"
+	// EventTypeCreatorStaked is emitted when a fan stakes behind a creator.
+	EventTypeCreatorStaked = "creator.fan.staked"
+	// EventTypeCreatorUnstaked is emitted when a fan unstakes from a creator.
+	EventTypeCreatorUnstaked = "creator.fan.unstaked"
+	// EventTypeCreatorPayoutAccrued is emitted when payouts accrue for a creator.
+	EventTypeCreatorPayoutAccrued = "creator.payout.accrued"
+)
+
+type eventEnvelope struct {
+	evt *types.Event
+}
+
+func (e eventEnvelope) EventType() string {
+	if e.evt == nil {
+		return ""
+	}
+	return e.evt.Type
+}
+
+func (e eventEnvelope) Event() *types.Event { return e.evt }
+
+// WrapEvent converts a raw event payload into the emitter-friendly envelope.
+func WrapEvent(evt *types.Event) events.Event { return eventEnvelope{evt: evt} }
+
+// ContentPublishedEvent returns the structured event payload for publication announcements.
+func ContentPublishedEvent(contentID string, creator string, uri string) *types.Event {
+	return &types.Event{
+		Type: EventTypeContentPublished,
+		Attributes: map[string]string{
+			"contentId": contentID,
+			"creator":   creator,
+			"uri":       uri,
+		},
+	}
+}
+
+// ContentTippedEvent returns the structured event payload for tip activity.
+func ContentTippedEvent(contentID string, creator string, fan string, amount string) *types.Event {
+	return &types.Event{
+		Type: EventTypeContentTipped,
+		Attributes: map[string]string{
+			"contentId": contentID,
+			"creator":   creator,
+			"fan":       fan,
+			"amount":    amount,
+		},
+	}
+}
+
+// CreatorStakedEvent captures when a fan stakes behind a creator.
+func CreatorStakedEvent(creator string, fan string, amount string, shares string) *types.Event {
+	return &types.Event{
+		Type: EventTypeCreatorStaked,
+		Attributes: map[string]string{
+			"creator": creator,
+			"fan":     fan,
+			"amount":  amount,
+			"shares":  shares,
+		},
+	}
+}
+
+// CreatorUnstakedEvent captures when a fan withdraws their stake.
+func CreatorUnstakedEvent(creator string, fan string, amount string) *types.Event {
+	return &types.Event{
+		Type: EventTypeCreatorUnstaked,
+		Attributes: map[string]string{
+			"creator": creator,
+			"fan":     fan,
+			"amount":  amount,
+		},
+	}
+}
+
+// CreatorPayoutAccruedEvent captures when a creator's pending payout balance changes.
+func CreatorPayoutAccruedEvent(creator string, pending string, totalTips string, totalYield string) *types.Event {
+	return &types.Event{
+		Type: EventTypeCreatorPayoutAccrued,
+		Attributes: map[string]string{
+			"creator":    creator,
+			"pending":    pending,
+			"totalTips":  totalTips,
+			"totalYield": totalYield,
+		},
+	}
+}

--- a/native/creator/types.go
+++ b/native/creator/types.go
@@ -1,0 +1,60 @@
+package creator
+
+import "math/big"
+
+// Content represents a piece of media or experience published by a creator.
+type Content struct {
+	ID          string   `json:"id"`
+	Creator     [20]byte `json:"creator"`
+	URI         string   `json:"uri"`
+	Metadata    string   `json:"metadata"`
+	PublishedAt int64    `json:"publishedAt"`
+	TotalTips   *big.Int `json:"totalTips"`
+	TotalStake  *big.Int `json:"totalStake"`
+}
+
+// Tip captures a fan contribution directed at a specific piece of content.
+type Tip struct {
+	ContentID string   `json:"contentId"`
+	Creator   [20]byte `json:"creator"`
+	Fan       [20]byte `json:"fan"`
+	Amount    *big.Int `json:"amount"`
+	TippedAt  int64    `json:"tippedAt"`
+}
+
+// Stake records a fan staking position that accrues payouts for the creator.
+type Stake struct {
+	Creator     [20]byte `json:"creator"`
+	Fan         [20]byte `json:"fan"`
+	Amount      *big.Int `json:"amount"`
+	Shares      *big.Int `json:"shares"`
+	StakedAt    int64    `json:"stakedAt"`
+	LastAccrual int64    `json:"lastAccrual"`
+}
+
+// PayoutLedger maintains the cumulative payout accounting for a creator.
+type PayoutLedger struct {
+	Creator             [20]byte `json:"creator"`
+	TotalTips           *big.Int `json:"totalTips"`
+	TotalStakingYield   *big.Int `json:"totalStakingYield"`
+	PendingDistribution *big.Int `json:"pendingDistribution"`
+	LastPayout          int64    `json:"lastPayout"`
+}
+
+// Clone returns a deep copy of the payout ledger.
+func (p *PayoutLedger) Clone() *PayoutLedger {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+	if p.TotalTips != nil {
+		clone.TotalTips = new(big.Int).Set(p.TotalTips)
+	}
+	if p.TotalStakingYield != nil {
+		clone.TotalStakingYield = new(big.Int).Set(p.TotalStakingYield)
+	}
+	if p.PendingDistribution != nil {
+		clone.PendingDistribution = new(big.Int).Set(p.PendingDistribution)
+	}
+	return &clone
+}

--- a/rpc/creator_handlers.go
+++ b/rpc/creator_handlers.go
@@ -1,0 +1,362 @@
+package rpc
+
+import (
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strings"
+
+	"nhbchain/crypto"
+	"nhbchain/native/creator"
+)
+
+type creatorPublishParams struct {
+	Caller    string `json:"caller"`
+	ContentID string `json:"contentId"`
+	URI       string `json:"uri"`
+	Metadata  string `json:"metadata"`
+}
+
+type creatorTipParams struct {
+	Caller    string `json:"caller"`
+	ContentID string `json:"contentId"`
+	Amount    string `json:"amount"`
+}
+
+type creatorStakeParams struct {
+	Caller  string `json:"caller"`
+	Creator string `json:"creator"`
+	Amount  string `json:"amount"`
+}
+
+type creatorUnstakeParams struct {
+	Caller  string `json:"caller"`
+	Creator string `json:"creator"`
+	Amount  string `json:"amount"`
+}
+
+type creatorPayoutsParams struct {
+	Caller string `json:"caller"`
+	Claim  bool   `json:"claim,omitempty"`
+}
+
+type creatorContentResult struct {
+	ID          string `json:"id"`
+	Creator     string `json:"creator"`
+	URI         string `json:"uri"`
+	Metadata    string `json:"metadata"`
+	PublishedAt int64  `json:"publishedAt"`
+	TotalTips   string `json:"totalTips"`
+	TotalStake  string `json:"totalStake"`
+}
+
+type creatorTipResult struct {
+	ContentID  string `json:"contentId"`
+	Creator    string `json:"creator"`
+	Fan        string `json:"fan"`
+	Amount     string `json:"amount"`
+	TippedAt   int64  `json:"tippedAt"`
+	Pending    string `json:"pending"`
+	TotalTips  string `json:"totalTips"`
+	TotalYield string `json:"totalYield"`
+}
+
+type creatorStakeResult struct {
+	Creator    string `json:"creator"`
+	Fan        string `json:"fan"`
+	Amount     string `json:"amount"`
+	Shares     string `json:"shares"`
+	StakedAt   int64  `json:"stakedAt"`
+	Reward     string `json:"reward"`
+	Pending    string `json:"pending"`
+	TotalTips  string `json:"totalTips"`
+	TotalYield string `json:"totalYield"`
+}
+
+type creatorUnstakeResult struct {
+	Creator   string `json:"creator"`
+	Fan       string `json:"fan"`
+	Amount    string `json:"amount"`
+	Remaining string `json:"remaining"`
+	Shares    string `json:"shares"`
+}
+
+type creatorPayoutsResult struct {
+	Creator    string `json:"creator"`
+	Pending    string `json:"pending"`
+	TotalTips  string `json:"totalTips"`
+	TotalYield string `json:"totalYield"`
+	LastPayout int64  `json:"lastPayout"`
+	Claimed    string `json:"claimed"`
+}
+
+func formatCreatorContent(addr string, content *creator.Content) creatorContentResult {
+	totalTips := "0"
+	if content.TotalTips != nil {
+		totalTips = content.TotalTips.String()
+	}
+	totalStake := "0"
+	if content.TotalStake != nil {
+		totalStake = content.TotalStake.String()
+	}
+	return creatorContentResult{
+		ID:          content.ID,
+		Creator:     addr,
+		URI:         content.URI,
+		Metadata:    content.Metadata,
+		PublishedAt: content.PublishedAt,
+		TotalTips:   totalTips,
+		TotalStake:  totalStake,
+	}
+}
+
+func bigString(v *big.Int) string {
+	if v == nil {
+		return "0"
+	}
+	return v.String()
+}
+
+func formatLedger(ledger *creator.PayoutLedger) (pending, totalTips, totalYield string, lastPayout int64) {
+	if ledger == nil {
+		return "0", "0", "0", 0
+	}
+	return bigString(ledger.PendingDistribution), bigString(ledger.TotalTips), bigString(ledger.TotalStakingYield), ledger.LastPayout
+}
+
+func formatAddress(addr [20]byte) string {
+	return crypto.NewAddress(crypto.NHBPrefix, addr[:]).String()
+}
+
+func (s *Server) handleCreatorPublish(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params creatorPublishParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	callerAddr, err := decodeBech32(params.Caller)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid caller address", err.Error())
+		return
+	}
+	trimmedID := strings.TrimSpace(params.ContentID)
+	if trimmedID == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "contentId is required", nil)
+		return
+	}
+	content, err := s.node.CreatorPublish(callerAddr, trimmedID, params.URI, params.Metadata)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "failed to publish content", err.Error())
+		return
+	}
+	result := formatCreatorContent(params.Caller, content)
+	writeResult(w, req.ID, result)
+}
+
+func (s *Server) handleCreatorTip(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params creatorTipParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	callerAddr, err := decodeBech32(params.Caller)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid caller address", err.Error())
+		return
+	}
+	amount, err := parseAmount(params.Amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	tip, ledger, err := s.node.CreatorTip(callerAddr, params.ContentID, amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "failed to apply tip", err.Error())
+		return
+	}
+	creatorAddr := ""
+	if tip != nil {
+		creatorAddr = formatAddress(tip.Creator)
+	}
+	pending, totalTips, totalYield, _ := formatLedger(ledger)
+	result := creatorTipResult{
+		ContentID:  params.ContentID,
+		Creator:    creatorAddr,
+		Fan:        params.Caller,
+		Amount:     amount.String(),
+		TippedAt:   0,
+		Pending:    pending,
+		TotalTips:  totalTips,
+		TotalYield: totalYield,
+	}
+	if tip != nil {
+		result.TippedAt = tip.TippedAt
+	}
+	writeResult(w, req.ID, result)
+}
+
+func (s *Server) handleCreatorStake(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params creatorStakeParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	callerAddr, err := decodeBech32(params.Caller)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid caller address", err.Error())
+		return
+	}
+	creatorAddr, err := decodeBech32(params.Creator)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid creator address", err.Error())
+		return
+	}
+	amount, err := parseAmount(params.Amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	stake, reward, ledger, err := s.node.CreatorStake(callerAddr, creatorAddr, amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "failed to stake", err.Error())
+		return
+	}
+	pending, totalTips, totalYield, _ := formatLedger(ledger)
+	result := creatorStakeResult{
+		Creator:    params.Creator,
+		Fan:        params.Caller,
+		Amount:     amount.String(),
+		Shares:     "0",
+		StakedAt:   0,
+		Reward:     bigString(reward),
+		Pending:    pending,
+		TotalTips:  totalTips,
+		TotalYield: totalYield,
+	}
+	if stake != nil {
+		result.Shares = bigString(stake.Shares)
+		result.StakedAt = stake.StakedAt
+		result.Amount = bigString(stake.Amount)
+	}
+	writeResult(w, req.ID, result)
+}
+
+func (s *Server) handleCreatorUnstake(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params creatorUnstakeParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	callerAddr, err := decodeBech32(params.Caller)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid caller address", err.Error())
+		return
+	}
+	creatorAddr, err := decodeBech32(params.Creator)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid creator address", err.Error())
+		return
+	}
+	amount, err := parseAmount(params.Amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	stake, err := s.node.CreatorUnstake(callerAddr, creatorAddr, amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "failed to unstake", err.Error())
+		return
+	}
+	result := creatorUnstakeResult{
+		Creator:   params.Creator,
+		Fan:       params.Caller,
+		Amount:    amount.String(),
+		Remaining: "0",
+		Shares:    "0",
+	}
+	if stake != nil {
+		result.Remaining = bigString(stake.Amount)
+		result.Shares = bigString(stake.Shares)
+	}
+	writeResult(w, req.ID, result)
+}
+
+func (s *Server) handleCreatorPayouts(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "exactly one parameter object expected", nil)
+		return
+	}
+	var params creatorPayoutsParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	callerAddr, err := decodeBech32(params.Caller)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid caller address", err.Error())
+		return
+	}
+	claimed := big.NewInt(0)
+	var ledger *creator.PayoutLedger
+	if params.Claim {
+		var amount *big.Int
+		ledger, amount, err = s.node.CreatorClaimPayouts(callerAddr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "failed to claim payouts", err.Error())
+			return
+		}
+		claimed = amount
+	} else {
+		ledger, err = s.node.CreatorPayouts(callerAddr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "failed to load payouts", err.Error())
+			return
+		}
+	}
+	pending, totalTips, totalYield, last := formatLedger(ledger)
+	result := creatorPayoutsResult{
+		Creator:    params.Caller,
+		Pending:    pending,
+		TotalTips:  totalTips,
+		TotalYield: totalYield,
+		LastPayout: last,
+		Claimed:    bigString(claimed),
+	}
+	writeResult(w, req.ID, result)
+}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -324,6 +324,16 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handleLoyaltyResolveUsername(w, r, req)
 	case "loyalty_userQR":
 		s.handleLoyaltyUserQR(w, r, req)
+	case "creator_publish":
+		s.handleCreatorPublish(w, r, req)
+	case "creator_tip":
+		s.handleCreatorTip(w, r, req)
+	case "creator_stake":
+		s.handleCreatorStake(w, r, req)
+	case "creator_unstake":
+		s.handleCreatorUnstake(w, r, req)
+	case "creator_payouts":
+		s.handleCreatorPayouts(w, r, req)
 	case "identity_setAlias":
 		s.handleIdentitySetAlias(w, r, req)
 	case "identity_setAvatar":


### PR DESCRIPTION
## Summary
- implement a native creator engine with state storage, events, and payout accounting for publish/tip/stake flows
- wire JSON-RPC handlers, documentation, and workspace docs for the new creator lifecycle
- add a Next.js creator-studio example showcasing publish → tip → stake → payout interactions

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d6d1da355c832db816eb2b27e52f2e