### PR TITLE
Implement weighted voting power tracking for BFT votes

### DIFF
--- a/consensus/bft/bft_test.go
+++ b/consensus/bft/bft_test.go
@@ -36,6 +36,29 @@ func (r *recordingBroadcaster) Broadcast(msg *p2p.Message) error {
 	return nil
 }
 
+type trackingNode struct {
+	validatorSet map[string]*big.Int
+	committed    []*types.Block
+}
+
+func (n *trackingNode) GetMempool() []*types.Transaction { return nil }
+func (n *trackingNode) CreateBlock(txs []*types.Transaction) (*types.Block, error) {
+	return nil, nil
+}
+func (n *trackingNode) CommitBlock(block *types.Block) error {
+	n.committed = append(n.committed, block)
+	return nil
+}
+func (n *trackingNode) GetValidatorSet() map[string]*big.Int { return n.validatorSet }
+func (n *trackingNode) GetAccount(addr []byte) (*types.Account, error) {
+	weight := n.validatorSet[string(addr)]
+	if weight == nil {
+		weight = big.NewInt(0)
+	}
+	return &types.Account{Stake: new(big.Int).Set(weight)}, nil
+}
+func (n *trackingNode) GetLastCommitHash() []byte { return nil }
+
 func TestCommitBroadcastsPrevoteNilOnExecutionFailure(t *testing.T) {
 	validatorKey, err := crypto.GeneratePrivateKey()
 	if err != nil {
@@ -69,6 +92,7 @@ func TestCommitBroadcastsPrevoteNilOnExecutionFailure(t *testing.T) {
 			Validator: validatorAddr,
 		},
 	}
+	engine.receivedPower[Precommit] = new(big.Int).Set(node.validatorSet[string(validatorAddr)])
 	engine.mu.Unlock()
 
 	engine.commit()
@@ -140,6 +164,7 @@ func TestCommitBroadcastsPrevoteNilOnTimestampViolation(t *testing.T) {
 			Validator: validatorAddr,
 		},
 	}
+	engine.receivedPower[Precommit] = new(big.Int).Set(node.validatorSet[string(validatorAddr)])
 	engine.mu.Unlock()
 
 	engine.commit()
@@ -172,5 +197,179 @@ func TestCommitBroadcastsPrevoteNilOnTimestampViolation(t *testing.T) {
 	}
 	if engine.committedBlocks[engine.currentState.Height] {
 		t.Fatalf("block should not be marked committed on timestamp violation")
+	}
+}
+
+func TestAddVoteIfRelevantUsesVotingPower(t *testing.T) {
+	keyA, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key A: %v", err)
+	}
+	keyB, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key B: %v", err)
+	}
+	keyC, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key C: %v", err)
+	}
+
+	addrA := keyA.PubKey().Address().Bytes()
+	addrB := keyB.PubKey().Address().Bytes()
+	addrC := keyC.PubKey().Address().Bytes()
+
+	weights := map[string]*big.Int{
+		string(addrA): big.NewInt(5),
+		string(addrB): big.NewInt(3),
+		string(addrC): big.NewInt(2),
+	}
+
+	node := &trackingNode{validatorSet: weights}
+	engine := NewEngine(node, keyA, &recordingBroadcaster{})
+
+	block := types.NewBlock(&types.BlockHeader{Height: 1, Validator: addrA}, nil)
+
+	engine.mu.Lock()
+	engine.currentState = State{Height: 1, Round: 0}
+	engine.activeProposal = &SignedProposal{Proposal: &Proposal{Block: block, Round: 0}}
+	engine.resetVoteTrackingLocked()
+	engine.mu.Unlock()
+
+	blockHash, err := block.Header.Hash()
+	if err != nil {
+		t.Fatalf("hash block: %v", err)
+	}
+
+	added, reachedPrevote, reachedPrecommit := engine.addVoteIfRelevant(&SignedVote{
+		Vote:      &Vote{BlockHash: blockHash, Round: 0, Type: Prevote, Height: 1},
+		Validator: addrA,
+	})
+	if !added {
+		t.Fatalf("expected to record validator A prevote")
+	}
+	if reachedPrevote {
+		t.Fatalf("prevote quorum should require more power")
+	}
+	if reachedPrecommit {
+		t.Fatalf("precommit quorum should not trigger on prevote")
+	}
+
+	added, reachedPrevote, _ = engine.addVoteIfRelevant(&SignedVote{
+		Vote:      &Vote{BlockHash: blockHash, Round: 0, Type: Prevote, Height: 1},
+		Validator: addrB,
+	})
+	if !added {
+		t.Fatalf("expected to record validator B prevote")
+	}
+	if !reachedPrevote {
+		t.Fatalf("expected prevote quorum once power exceeds two-thirds")
+	}
+
+	added, _, _ = engine.addVoteIfRelevant(&SignedVote{
+		Vote:      &Vote{BlockHash: blockHash, Round: 0, Type: Prevote, Height: 1},
+		Validator: addrB,
+	})
+	if added {
+		t.Fatalf("duplicate prevote should not be accepted")
+	}
+
+	added, _, reachedPrecommit = engine.addVoteIfRelevant(&SignedVote{
+		Vote:      &Vote{BlockHash: blockHash, Round: 0, Type: Precommit, Height: 1},
+		Validator: addrA,
+	})
+	if !added {
+		t.Fatalf("expected to record validator A precommit")
+	}
+	if reachedPrecommit {
+		t.Fatalf("precommit quorum should require additional power")
+	}
+
+	_, _, reachedPrecommit = engine.addVoteIfRelevant(&SignedVote{
+		Vote:      &Vote{BlockHash: blockHash, Round: 0, Type: Precommit, Height: 1},
+		Validator: addrB,
+	})
+	if !reachedPrecommit {
+		t.Fatalf("expected precommit quorum once power exceeds two-thirds")
+	}
+}
+
+func TestCommitSucceedsWithWeightedQuorum(t *testing.T) {
+	keyA, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key A: %v", err)
+	}
+	keyB, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key B: %v", err)
+	}
+	keyC, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key C: %v", err)
+	}
+
+	addrA := keyA.PubKey().Address().Bytes()
+	addrB := keyB.PubKey().Address().Bytes()
+	addrC := keyC.PubKey().Address().Bytes()
+
+	weights := map[string]*big.Int{
+		string(addrA): big.NewInt(5),
+		string(addrB): big.NewInt(3),
+		string(addrC): big.NewInt(2),
+	}
+
+	node := &trackingNode{validatorSet: weights}
+	engine := NewEngine(node, keyA, &recordingBroadcaster{})
+
+	block := types.NewBlock(&types.BlockHeader{Height: 1, Validator: addrA}, nil)
+	blockHash, err := block.Header.Hash()
+	if err != nil {
+		t.Fatalf("hash block: %v", err)
+	}
+
+	engine.mu.Lock()
+	engine.currentState = State{Height: 1, Round: 0}
+	engine.activeProposal = &SignedProposal{Proposal: &Proposal{Block: block, Round: 0}}
+	engine.resetVoteTrackingLocked()
+	engine.mu.Unlock()
+
+	// Precommit power should not reach quorum with only validator A.
+	added, _, reachedPrecommit := engine.addVoteIfRelevant(&SignedVote{
+		Vote:      &Vote{BlockHash: blockHash, Round: 0, Type: Precommit, Height: 1},
+		Validator: addrA,
+	})
+	if !added {
+		t.Fatalf("expected to record validator A precommit")
+	}
+	if reachedPrecommit {
+		t.Fatalf("precommit quorum should require more than one validator")
+	}
+
+	if engine.commit() {
+		t.Fatalf("commit should fail without two-thirds voting power")
+	}
+
+	// Adding validator B's vote should satisfy the weighted quorum (5 + 3 > 2/3 * 10).
+	_, _, reachedPrecommit = engine.addVoteIfRelevant(&SignedVote{
+		Vote:      &Vote{BlockHash: blockHash, Round: 0, Type: Precommit, Height: 1},
+		Validator: addrB,
+	})
+	if !reachedPrecommit {
+		t.Fatalf("expected precommit quorum with validators A and B")
+	}
+
+	if !engine.commit() {
+		t.Fatalf("expected commit to succeed once weighted quorum is reached")
+	}
+	if len(node.committed) != 1 {
+		t.Fatalf("expected exactly one block to be committed, got %d", len(node.committed))
+	}
+	if node.committed[0].Header.Height != 1 {
+		t.Fatalf("expected committed block height 1, got %d", node.committed[0].Header.Height)
+	}
+	if engine.currentState.Height != 2 {
+		t.Fatalf("expected engine to advance to height 2, got %d", engine.currentState.Height)
+	}
+	if engine.activeProposal != nil {
+		t.Fatalf("expected active proposal to be cleared after commit")
 	}
 }

--- a/docs/potso/README.md
+++ b/docs/potso/README.md
@@ -43,4 +43,6 @@ These records are deterministic and do not alter consensus semantics beyond addi
 - `potso_userMeters` – returns the meter for a given user and optional day (defaults to current UTC day).
 - `potso_top` – returns the highest scoring participants for a day, sorted by score, raw score, uptime, and address.
 
-Refer to the companion documents for payload shapes and integration guidance.
+Refer to the companion documents for payload shapes, integration guidance, and
+the [consensus integration](consensus-integration.md) notes explaining how
+POTSO-derived weights influence validator selection and quorum thresholds.

--- a/docs/potso/consensus-integration.md
+++ b/docs/potso/consensus-integration.md
@@ -1,0 +1,71 @@
+# POTSO Consensus Integration
+
+The BFT engine now consumes the composite weights that POTSO exposes for
+validators. This document details how those weights feed into proposer
+selection and quorum checks so operators can reason about liveness under mixed
+stake and engagement scores.
+
+## Weight source
+
+Each consensus node implements `NodeInterface.GetValidatorSet()` which returns a
+map keyed by validator address. The value is the validator's deterministic
+weight derived from the sum of bonded stake and the current POTSO engagement
+score. The engine caches this map at the beginning of every round and
+recomputes the **total voting power** by summing all entries.
+
+If a validator appears in the set with a nil weight the engine treats its power
+as zero. Validators missing from the set are ignored entirely.
+
+## Round initialisation
+
+`startNewRound` refreshes the validator set, recalculates the total voting
+power, and zeroes per-vote accumulators before any proposal processing begins.
+This guarantees that recycled votes from prior rounds cannot contribute toward
+quorums in the new round and that weight changes are respected immediately.
+
+## Vote accumulation
+
+The engine tracks votes by type (prevote and precommit) and also maintains a
+parallel map of accumulated power per type. When `addVoteIfRelevant` accepts a
+vote it looks up the validator's weight and adds it to the appropriate
+accumulator. Duplicate votes from the same validator are ignored so a single
+validator cannot contribute more than its declared weight.
+
+## Quorum thresholds
+
+Threshold checks now compare the accumulated weight against a two-thirds power
+threshold:
+
+```
+threshold = floor((2 * totalVotingPower) / 3)
+reached   = accumulatedPower > threshold
+```
+
+The strict comparison (`>`, not `>=`) ensures the engine only advances once
+more than two thirds of the known voting power backs the vote type. The commit
+step reuses the precommit accumulator and does not recalculate totals again.
+
+If the total voting power is zero or undefined the engine will never cross the
+threshold, preventing empty validator sets from producing commits.
+
+## Proposer selection
+
+Proposers are still selected deterministically but now weight each validator by
+`stake + engagement`. The selection seed uses the last commit hash and round
+number, then consumes the combined weights as buckets when picking the winner.
+If all weights are zero the engine falls back to round-robin across validators.
+
+## Operational guidance
+
+- **Monitoring:** Operators should alert on scenarios where accumulated power
+  stalls below the two-thirds threshold despite a majority of validators
+  signing, as this likely indicates stale or mismatched POTSO engagement data.
+- **Weight changes:** Because the engine refreshes weights every round, any
+  update propagated through `GetValidatorSet()` immediately impacts proposer
+  probability and quorum calculations at the next round transition.
+- **Testing:** Weighted quorum behaviour is covered by `consensus/bft/bft_test`
+  which now includes scenarios exercising uneven stake and engagement mixes.
+
+By aligning proposer selection and quorum formation with POTSO-derived weights,
+the network maintains deterministic safety guarantees while reflecting
+real-world validator performance metrics in consensus outcomes.


### PR DESCRIPTION
## Summary
- cache validator voting power in the BFT engine and track weighted vote accumulation per round
- gate prevote, precommit, and commit transitions on two-thirds voting power thresholds
- exercise weighted quorum behaviour in new and existing unit tests

## Testing
- go test ./consensus/bft

------
https://chatgpt.com/codex/tasks/task_e_68d72772ad58832d93c05bcff53a141c