### PR TITLE
Align BFT engine height with node height on restart

### DIFF
--- a/consensus/bft/interface.go
+++ b/consensus/bft/interface.go
@@ -13,4 +13,5 @@ type NodeInterface interface {
 	GetValidatorSet() map[string]*big.Int
 	GetAccount(addr []byte) (*types.Account, error)
 	GetLastCommitHash() []byte
+	GetHeight() uint64
 }

--- a/docs/consensus/bft-height-sync.md
+++ b/docs/consensus/bft-height-sync.md
@@ -1,0 +1,36 @@
+# BFT Height Synchronisation
+
+The BFT engine now aligns its internal height with the node's committed chain
+height whenever it boots or resets a round. This prevents validators from
+replaying proposals for heights that have already been finalised and ensures the
+next proposal always targets `chain height + 1`.
+
+## Interface contract
+
+Consensus nodes must implement `NodeInterface.GetHeight()` alongside the
+existing methods. The return value represents the latest block height that has
+been durably committed to the local chain. The engine consumes this method in
+three places:
+
+- **Engine construction:** `NewEngine` seeds `currentState.Height` to
+  `node.GetHeight() + 1` so a restarted validator immediately targets the next
+  block height.
+- **Round transitions:** `startNewRound` prunes any stale `committedBlocks`
+  entries and fast-forwards to `node.GetHeight() + 1` when the cached state falls
+  behind the node.
+- **Post-commit cleanup:** `commit` re-runs the synchronisation helper to clear
+  out entries for heights that have been finalised on the node.
+
+## Operational impact
+
+- **Restarts:** Validators that restart after falling behind no longer need to
+  manually advance their consensus height. As soon as the engine enters the next
+  round it observes the node height and jumps ahead automatically.
+- **State safety:** Stale `committedBlocks` entries are pruned on every
+  synchronisation pass, preventing spurious short-circuiting of later rounds.
+- **Testing:** `consensus/bft/bft_test.go` now seeds a non-zero node height to
+  ensure proposals targeting the resynchronised height are accepted after a
+  simulated restart.
+
+This behaviour keeps consensus progress aligned with the canonical chain without
+requiring additional coordination from operators.

--- a/docs/potso/consensus-integration.md
+++ b/docs/potso/consensus-integration.md
@@ -11,7 +11,9 @@ Each consensus node implements `NodeInterface.GetValidatorSet()` which returns a
 map keyed by validator address. The value is the validator's deterministic
 weight derived from the sum of bonded stake and the current POTSO engagement
 score. The engine caches this map at the beginning of every round and
-recomputes the **total voting power** by summing all entries.
+recomputes the **total voting power** by summing all entries. Nodes must also
+expose `NodeInterface.GetHeight()` so the engine can synchronise its internal
+height with the committed chain height during restarts or catch-up scenarios.
 
 If a validator appears in the set with a nil weight the engine treats its power
 as zero. Validators missing from the set are ignored entirely.


### PR DESCRIPTION
## Summary
- extend the BFT node interface with GetHeight and seed the engine state from the node's committed height
- prune stale committed block markers, fast-forward consensus height when the node is ahead, and cover restart behaviour in tests
- document the height resynchronisation workflow for operators and update existing integration guidance

## Testing
- go test ./consensus/bft

------
https://chatgpt.com/codex/tasks/task_e_68d729ef9660832d90eb298d6b3f6452