### PR TITLE
docs: harden security guidance and sync testnet endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,17 +212,17 @@ All protocol modules ship with reference documentation under [`docs/`](./docs):
 
 ## Security, Compliance, and Operations
 
-- **Authentication** — RPC bearer tokens protect privileged calls; rotate secrets regularly.
+- **Authentication** — RPC bearer tokens protect privileged calls; rotate secrets regularly and enforce mutual TLS or HMAC as described in the [Network Hardening Playbook](docs/security/network-hardening.md).
 - **Key Management** — Validator keys default to encrypted Ethereum-compatible keystores. Integrate with external KMS via `ValidatorKMSURI` and `ValidatorKMSEnv`.
-- **Observability** — Monitor validator uptime, engagement scores, and staking state using CLI commands or forthcoming telemetry dashboards.
+- **Observability** — Monitor validator uptime, engagement scores, and staking state using CLI commands or forthcoming telemetry dashboards. Forward RPC/WAF logs to your SIEM so abuse attempts can be correlated with P2P events.
 - **Compliance Alignment** — Native identity modules provide audit trails, verified contact points, and consent-driven discovery suitable for regulatory review.
 - **Audits & Bug Bounty** — We run an ongoing [bug bounty program](docs/security/bug-bounty.md) and maintain an [audit readiness guide](docs/security/audit-readiness.md) with frozen commits, reproducible builds, and fixtures for third-party assessors.
 
 ### Reporting Vulnerabilities
 
 1. Encrypt your findings with the [repository PGP key](docs/security/repository-pgp-key.asc) (fingerprint `8F2D 3C71 9A0B 4D52 8EFA 9C1B 6D74 C5A2 1D3F 8B9E`).
-2. Email the encrypted report to `security@nhbcoin.net` or use the [security issue template](.github/ISSUE_TEMPLATE/security.yml) to create a private triage ticket.
-3. For time-sensitive issues, escalate via Signal at `+1-415-555-0119` after sending your report.
+2. Email the encrypted report to `security@nehborly.net` or use the [security issue template](.github/ISSUE_TEMPLATE/security.yml) to create a private triage ticket.
+3. For time-sensitive issues, escalate via Signal at `+13234559568` after sending your report.
 
 Full policy details, SLAs, and embargo expectations live in [`docs/security/disclosure.md`](docs/security/disclosure.md). A machine-readable summary is published at [`.well-known/security.txt`](.well-known/security.txt) for automated scanners.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,5 +7,5 @@ We operate a coordinated vulnerability disclosure program to keep NHBChain parti
 - **Audit readiness:** External assessors can access frozen commits, build steps, and fixtures via [`docs/security/audit-readiness.md`](docs/security/audit-readiness.md).
 - **PGP key:** Our repository key and fingerprint live in [`docs/security/repository-pgp-key.asc`](docs/security/repository-pgp-key.asc).
 
-To report a vulnerability, encrypt your findings with the repository PGP key and email `security@nhbcoin.net`. For urgent issues, escalate via Signal at `+1-415-555-0119`.
+To report a vulnerability, encrypt your findings with the repository PGP key and email `security@nehborly.net`. For urgent issues, escalate via Signal at `+13234559568`.
 

--- a/docs/commerce/merchant-tools.md
+++ b/docs/commerce/merchant-tools.md
@@ -107,8 +107,8 @@ Use the sandbox to rehearse complex trade flows and validate your automation pri
 
 1. Obtain sandbox API key and wallet test keys from the merchant console.
 2. Run sample script: `npm run simulate:settlement -- --buyer <addr> --seller <addr>`.
-3. Monitor emitted events via WebSocket (`wss://sandbox.api.nhbchain.com/escrow/events`).
-4. Review sandbox dashboard metrics (`https://sandbox.console.nhbchain.com/commerce`) to ensure exports and SLA graphs render as
+3. Monitor emitted events via WebSocket (`wss://sandbox.api.nhbcoin.net/escrow/events`).
+4. Review sandbox dashboard metrics (`https://sandbox.console.nhbcoin.net/commerce`) to ensure exports and SLA graphs render as
    expected.
 
 ### 3.4 Graduation checklist
@@ -124,5 +124,5 @@ Use the sandbox to rehearse complex trade flows and validate your automation pri
 
 * **Documentation:** `/docs/escrow/escrow.md` (state machine), `/docs/escrow/gateway-api.md` (REST operations).
 * **SDKs:** TypeScript & Go SDKs include helpers for signing requests and consuming paginated endpoints.
-* **Contact:** Reach the merchant integrations team at `merchants@nhbcoin.net` for sandbox access, production onboarding, or
+* **Contact:** Reach the merchant integrations team at `merchants@nehborly.net` for sandbox access, production onboarding, or
   escalation support.

--- a/docs/escrow/gateway-api.md
+++ b/docs/escrow/gateway-api.md
@@ -8,8 +8,8 @@ controls.
 
 ## 1. Base URL & Versions
 
-* **Base URL (production):** `https://api.nhbchain.com/escrow/v1`
-* **Base URL (sandbox):** `https://sandbox.api.nhbchain.com/escrow/v1`
+* **Base URL (production):** `https://api.nhbcoin.net/escrow/v1`
+* **Base URL (sandbox):** `https://sandbox.api.nhbcoin.net/escrow/v1`
 * **Versioning:** The first path segment (`/v1`) tracks major API revisions. Breaking changes increment the segment. Minor additive
   changes use standard semantic version headers (`X-NHB-API-Version`).
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -7,7 +7,7 @@ This guide shows how to run the NHB Chain example applications against the publi
 - Node.js 18+ and Go 1.21+
 - Docker and Docker Compose
 - NHB Chain API credentials with least-privilege scopes for the relevant product areas
-- Access to the testnet RPC endpoint (`https://rpc.testnet.nhbchain.xyz`)
+- Access to the testnet RPC endpoint (`https://rpc.testnet.nhbcoin.net`)
 
 ## Repository Layout
 
@@ -40,6 +40,21 @@ This guide shows how to run the NHB Chain example applications against the publi
    ```bash
    docker compose up -d
    ```
+
+## Network Alignment
+
+Before running any demo, confirm your environment variables point at the
+current testnet release:
+
+```bash
+export NHB_ENV=testnet
+export NHB_RPC_URL=https://rpc.testnet.nhbcoin.net
+export NHB_CHAIN_ID=nhb-testnet-1
+```
+
+Use `curl $NHB_RPC_URL/healthz` and `./nhb-cli status --env $NHB_ENV` to verify
+connectivity. Mismatched endpoints or chain IDs will cause idempotency checks
+and signature verification to fail.
 
 ## Running the JavaScript Apps
 
@@ -78,7 +93,7 @@ go test ./...
 
 ## Troubleshooting
 
-- Verify API credentials with `curl https://rpc.testnet.nhbchain.xyz/healthz`.
+- Verify API credentials with `curl https://rpc.testnet.nhbcoin.net/healthz`.
 - If HMAC verification fails, ensure system clocks are in sync (use `chronyd` or `ntpd`).
 - For persistent errors, capture trace IDs from logs and inspect in Grafana Tempo.
 

--- a/docs/examples/cookbook.md
+++ b/docs/examples/cookbook.md
@@ -1,6 +1,6 @@
 # NHBCoin RPC & REST Cookbook
 
-This cookbook shows how to move between the public JSON-RPC endpoints (`https://rpc.nhbcoin.net`) and the escrow REST gateway (`https://api.nhbcoin.net`). Each scenario can be run against devnet or testnet by flipping environment variables, and every command is safe to copy/paste.
+This cookbook shows how to move between the public JSON-RPC endpoints (`https://rpc.testnet.nhbcoin.net`) and the escrow REST gateway (`https://api.nhbcoin.net`). Each scenario can be run against devnet or testnet by flipping environment variables, and every command is safe to copy/paste.
 
 ---
 
@@ -8,14 +8,14 @@ This cookbook shows how to move between the public JSON-RPC endpoints (`https://
 
 | Network | JSON-RPC | WebSocket | REST gateway |
 |---------|----------|-----------|--------------|
-| **Testnet** | `https://rpc.nhbcoin.net` | `wss://ws.nhbcoin.net` | `https://api.nhbcoin.net/escrow/v1` |
+| **Testnet** | `https://rpc.testnet.nhbcoin.net` | `wss://rpc.testnet.nhbcoin.net/websocket` | `https://api.nhbcoin.net/escrow/v1` |
 | **Devnet** | `https://rpc.devnet.nhbcoin.net` | `wss://ws.devnet.nhbcoin.net` | `https://api.devnet.nhbcoin.net/escrow/v1` |
 
 Set the targets once per shell:
 
 ```bash
-export NHB_RPC_URL=https://rpc.nhbcoin.net
-export NHB_WS_URL=wss://ws.nhbcoin.net
+export NHB_RPC_URL=https://rpc.testnet.nhbcoin.net
+export NHB_WS_URL=wss://rpc.testnet.nhbcoin.net/websocket
 export NHB_API_BASE=https://api.nhbcoin.net/escrow/v1
 export NHB_ADDRESS=nhb1exampleaddress000000000000000000000000
 export NHB_API_KEY=your-escrow-api-key            # required for REST writes/reads
@@ -77,7 +77,7 @@ Leverage the helper scripts to combine multiple RPC calls and surface recent tra
 
 ```bash
 NHB_ADDRESS=$NHB_ADDRESS \
-NHB_RPC_URL=${NHB_RPC_URL:-https://rpc.nhbcoin.net} \
+NHB_RPC_URL=${NHB_RPC_URL:-https://rpc.testnet.nhbcoin.net} \
 NHB_API_BASE=${NHB_API_BASE:-https://api.nhbcoin.net/escrow/v1} \
 NHB_API_KEY=$NHB_API_KEY \
 NHB_API_SECRET=$NHB_API_SECRET \
@@ -93,7 +93,7 @@ What it does:
 Sample terminal output:
 
 ```
-RPC base: https://rpc.nhbcoin.net
+RPC base: https://rpc.testnet.nhbcoin.net
 REST base: https://api.nhbcoin.net/escrow/v1
 Address: nhb1example...
 

--- a/docs/examples/overview.md
+++ b/docs/examples/overview.md
@@ -39,9 +39,9 @@ The first run installs dependencies, generates the SDK build artifacts (if any),
 
 The `.env.example` template points at the public NHB infrastructure so a fresh clone works out-of-the-box:
 
-- `https://api.nhbcoin.net/rpc` for HTTP JSON-RPC calls
-- `wss://api.nhbcoin.net/ws` for WebSocket subscriptions
-- `https://gw.nhbcoin.net` for REST and gateway integrations
+- `https://rpc.testnet.nhbcoin.net` for HTTP JSON-RPC calls
+- `wss://rpc.testnet.nhbcoin.net/websocket` for WebSocket subscriptions
+- `https://api.nhbcoin.net/escrow/v1` for REST and gateway integrations
 
 Rotate the demo API credentials before deploying to production.
 

--- a/docs/examples/p2p-mini-market.md
+++ b/docs/examples/p2p-mini-market.md
@@ -88,7 +88,7 @@ All endpoints require the standard API key + HMAC headers. Mutating calls also
 include the wallet signature of the buyer, seller, or arbitrator so the gateway
 can assert on-chain authority.
 
-The mini-market demo talks to the public RPC (`https://rpc.nhbcoin.net`) to keep
+The mini-market demo talks to the public RPC (`https://rpc.testnet.nhbcoin.net`) to keep
 credentials client-side for self-hosted QA, but production operators integrate
 with `api.nhbcoin.net` to leverage persistent offer storage, idempotency, and
 webhook delivery of trade events.

--- a/docs/identity/identity-gateway.md
+++ b/docs/identity/identity-gateway.md
@@ -1,6 +1,6 @@
 # Identity Gateway REST API
 
-> Base URL: `https://gateway.dev.nhbchain.com` (replace with environment) • Version: v0
+> Base URL: `https://gateway.dev.nhbcoin.net` (replace with environment) • Version: v0
 
 The identity gateway manages off-chain verification (email, avatar uploads) and provides public lookup endpoints for wallets. All
 mutating endpoints require HMAC-authenticated API keys issued to partner applications.
@@ -122,7 +122,7 @@ Public lookup that resolves an alias to addresses and avatar.
 
 ```http
 GET /identity/resolve?username=frankrocks HTTP/1.1
-Host: gateway.dev.nhbchain.com
+Host: gateway.dev.nhbcoin.net
 Accept: application/json
 ```
 

--- a/docs/launch/explorer.md
+++ b/docs/launch/explorer.md
@@ -6,12 +6,12 @@ The public explorer surfaces real-time testnet state for validators, developers,
 
 | Surface | URL |
 | --- | --- |
-| Web App | <https://explorer.testnet.nhbchain.io> |
-| Validator Dashboard | <https://explorer.testnet.nhbchain.io/validators> |
-| API | `https://explorer.testnet.nhbchain.io/api` |
-| WebSocket | `wss://explorer.testnet.nhbchain.io/ws` |
+| Web App | <https://explorer.testnet.nhbcoin.net> |
+| Validator Dashboard | <https://explorer.testnet.nhbcoin.net/validators> |
+| API | `https://explorer.testnet.nhbcoin.net/api` |
+| WebSocket | `wss://explorer.testnet.nhbcoin.net/ws` |
 
-Bookmark the status page at <https://status.testnet.nhbchain.io> for maintenance alerts and indexer lag notifications.
+Bookmark the status page at <https://status.testnet.nhbcoin.net> for maintenance alerts and indexer lag notifications.
 
 ## Core Features
 

--- a/docs/launch/faucet.md
+++ b/docs/launch/faucet.md
@@ -6,16 +6,16 @@ The public faucet provides rate-limited Test ZNHB (TZNHB) to developers onboardi
 
 | Method | URL | Description |
 | --- | --- | --- |
-| `POST` | `https://faucet.testnet.nhbchain.io/api/claim` | Request a TZNHB drip to a Bech32 address |
-| `GET` | `https://faucet.testnet.nhbchain.io/api/limits/<address>` | Inspect remaining daily quota |
-| `GET` | `https://faucet.testnet.nhbchain.io/api/health` | Health probe used by monitoring |
+| `POST` | `https://faucet.testnet.nhbcoin.net/api/claim` | Request a TZNHB drip to a Bech32 address |
+| `GET` | `https://faucet.testnet.nhbcoin.net/api/limits/<address>` | Inspect remaining daily quota |
+| `GET` | `https://faucet.testnet.nhbcoin.net/api/health` | Health probe used by monitoring |
 
 All endpoints require HTTPS. Cross-origin requests from the docs portal and explorer are allowed via CORS; other origins must use the CLI or direct HTTP clients.
 
 ## Request Workflow
 
 ```bash
-curl -X POST https://faucet.testnet.nhbchain.io/api/claim \
+curl -X POST https://faucet.testnet.nhbcoin.net/api/claim \
   -H 'Content-Type: application/json' \
   -d '{"address":"tnhb1abcd...","channel":"docs"}'
 ```
@@ -53,4 +53,4 @@ The faucet is a shared resource intended for development and integration testing
 3. Investigation under the vulnerability disclosure framework.
 4. Potential suspension from private beta programs.
 
-Report suspected abuse or vulnerabilities to `security@nhbcoin.net` with reproduction details and request IDs.
+Report suspected abuse or vulnerabilities to `security@nehborly.net` with reproduction details and request IDs.

--- a/docs/launch/testnet.md
+++ b/docs/launch/testnet.md
@@ -12,7 +12,7 @@ This guide walks new operators and developers through connecting to the NHBChain
 | Token | Test ZNHB (TZNHB) |
 | Faucet Drip | 25 TZNHB per request, 10 requests / day |
 
-Core endpoints are published on <https://status.testnet.nhbchain.io>. All endpoints are fronted by load balancers with TLS required.
+Core endpoints are published on <https://status.testnet.nhbcoin.net>. All endpoints are fronted by load balancers with TLS required.
 
 ## Prerequisites
 
@@ -26,7 +26,7 @@ Core endpoints are published on <https://status.testnet.nhbchain.io>. All endpoi
 Download the launch package from the docs portal or the signed release announcement:
 
 ```bash
-curl -O https://downloads.nhbchain.io/testnet/nhb-testnet-1.tar.gz
+curl -O https://downloads.nhbcoin.net/testnet/nhb-testnet-1.tar.gz
 tar -xzf nhb-testnet-1.tar.gz
 cp config/genesis.json ~/.nhbchaind/config/
 ```
@@ -34,20 +34,33 @@ cp config/genesis.json ~/.nhbchaind/config/
 Seed nodes:
 
 ```
-seed-1.testnet.nhbchain.io:26656
-seed-2.testnet.nhbchain.io:26656
-seed-3.testnet.nhbchain.io:26656
+seed-1.testnet.nhbcoin.net:26656
+seed-2.testnet.nhbcoin.net:26656
+seed-3.testnet.nhbcoin.net:26656
 ```
 
 Persistent peers (optional but recommended):
 
 ```
-node01.testnet.nhbchain.io:26656
-node02.testnet.nhbchain.io:26656
-node03.testnet.nhbchain.io:26656
+node01.testnet.nhbcoin.net:26656
+node02.testnet.nhbcoin.net:26656
+node03.testnet.nhbcoin.net:26656
 ```
 
 Rotate seeds weekly using `scripts/seed-rotation.sh`. Validators should subscribe to ops alerts for rotation notices.
+
+## Wiring the Testnet
+
+Follow this sequence any time you connect fresh infrastructure to the public testnet:
+
+1. **Provision network perimeter** – Open TCP/26656 (P2P) and TCP/26657 (RPC) to trusted source ranges only. Outbound traffic should be unrestricted so the node can discover peers and fetch snapshots. Keep SSH/RDP on a separate management network.
+2. **Install launch artifacts** – Extract the launch package to `/var/lib/nhbchaind` (or your preferred data directory) and double-check the `genesis.json` hash against the value posted on the status page. Reject any archive that fails signature validation.
+3. **Harden TLS & auth gateways** – Terminate TLS in front of RPC/REST/gRPC endpoints and enforce HMAC authentication or mutual TLS as documented in [`docs/networking/net-rpc.md`](../networking/net-rpc.md). Disable anonymous RPC entirely.
+4. **Wire observability** – Enable Prometheus on `:26660`, ship logs to your SIEM, and configure alerting for: missed blocks, consensus health, RPC auth failures, and handshake violations. Every new validator should register the provided dashboards before going live.
+5. **Validate handshake path** – Run `nhbchaind status` to ensure the node advances past genesis, then execute `curl https://rpc.testnet.nhbcoin.net/healthz` from the host to confirm outbound internet routing and TLS trust. The P2P log should show successful NET-2A challenges.
+6. **Exercise fail safes** – Trigger a manual `net_ban` via authenticated RPC against a known test peer and verify that your automation lifts the ban after expiry. This proves that operator controls are functioning before you accept production traffic.
+
+Document completion of each step in your runbook; audits expect proof that the node was introduced following least-privilege and zero-trust principles.
 
 ## Configuration Checklist
 
@@ -81,16 +94,18 @@ nhbchaind start
 7. **Explorer Verification** – Locate each transaction and validator status in the [explorer](./explorer.md).
 8. **API Smoke Tests** – Call RPC, REST, and WebSocket endpoints to confirm they expose blocks, events, and module state.
 
+Run `go test ./tests/e2e/...` after every deployment. The E2E harness signs transactions with disposable keys, verifies consensus, and asserts RPC auth enforcement so you know the internal test coverage is live before exposing public services.
+
 Document any discrepancies in the launch war room channel and open GitHub issues tagged `launch-blocker` when required.
 
 ## Public Endpoints
 
 | Service | URL |
 | --- | --- |
-| RPC | `https://rpc.testnet.nhbchain.io` |
-| REST | `https://rest.testnet.nhbchain.io` |
-| WebSocket | `wss://rpc.testnet.nhbchain.io/websocket` |
-| gRPC | `https://grpc.testnet.nhbchain.io` |
+| RPC | `https://rpc.testnet.nhbcoin.net` |
+| REST | `https://rest.testnet.nhbcoin.net` |
+| WebSocket | `wss://rpc.testnet.nhbcoin.net/websocket` |
+| gRPC | `https://grpc.testnet.nhbcoin.net` |
 
 Rate limiting is enforced per IP. If you require dedicated throughput, request access to the partner endpoints through support.
 
@@ -98,7 +113,7 @@ Rate limiting is enforced per IP. If you require dedicated throughput, request a
 
 * **Node stuck catching up** – Enable state sync and verify your clock is synchronized via NTP.
 * **Faucet errors** – Ensure the address uses the `tnhb` prefix and that you are below the daily rate limit.
-* **Explorer not showing data** – Clear cached assets and check <https://status.testnet.nhbchain.io> for indexer updates.
+* **Explorer not showing data** – Clear cached assets and check <https://status.testnet.nhbcoin.net> for indexer updates.
 * **Governance tx fails** – Confirm minimum deposit and that your account has the governance module permissions enabled.
 
-Report critical incidents to `security@nhbcoin.net` using the [disclosure policy](../security/release-process.md#vulnerability-disclosure).
+Report critical incidents to `security@nehborly.net` using the [disclosure policy](../security/release-process.md#vulnerability-disclosure).

--- a/docs/loyalty/loyalty.md
+++ b/docs/loyalty/loyalty.md
@@ -194,7 +194,7 @@ Nodes exposing WebSocket transport support `subscribe` to loyalty events. See RP
 
 The Escrow Gateway exposes REST APIs for businesses that operate outside the on-chain settlement loop but still want to issue loyalty rewards. Requests require API keys and HMAC signatures. Idempotency is enforced via headers to guarantee at-most-once award issuance.
 
-**Base URL:** service deployment of `services/escrow-gateway` (e.g., `https://api.devnet.nhbchain.io`).
+**Base URL:** service deployment of `services/escrow-gateway` (e.g., `https://api.devnet.nhbcoin.net`).
 
 ### Authentication headers
 

--- a/docs/networking/net-rpc.md
+++ b/docs/networking/net-rpc.md
@@ -3,7 +3,9 @@
 The NET-2F API exposes operator-focused JSON-RPC methods under the existing
 HTTP listener. All examples assume the daemon is reachable at
 `http://127.0.0.1:8080` and that the `NHB_RPC_TOKEN` environment variable is set
-when authentication is required.
+when authentication is required. See the [Network Hardening Playbook](../security/network-hardening.md)
+for guidance on fronting these endpoints with mutual TLS, rate limiting, and
+centralised logging.
 
 ## `net_info`
 

--- a/docs/openapi/identity.yaml
+++ b/docs/openapi/identity.yaml
@@ -7,11 +7,11 @@ info:
     name: CC BY 4.0
     url: https://creativecommons.org/licenses/by/4.0/
 servers:
-  - url: https://gateway.dev.nhbchain.com
+  - url: https://gateway.dev.nhbcoin.net
     description: Development gateway
-  - url: https://gateway.staging.nhbchain.com
+  - url: https://gateway.staging.nhbcoin.net
     description: Staging gateway
-  - url: https://gateway.nhbchain.com
+  - url: https://gateway.nhbcoin.net
     description: Production gateway
 security:
   - ApiKeyAuth: []

--- a/docs/sdk/go.md
+++ b/docs/sdk/go.md
@@ -22,7 +22,7 @@ import (
 
 func main() {
     client, err := nhb.NewClient(nhb.Config{
-        Endpoint:  "https://rpc.testnet.nhbchain.xyz",
+        Endpoint:  "https://rpc.testnet.nhbcoin.net",
         APIKey:    getenv("NHB_API_KEY"),
         APISecret: getenv("NHB_API_SECRET"),
     })

--- a/docs/sdk/js.md
+++ b/docs/sdk/js.md
@@ -18,7 +18,7 @@ The SDK authenticates every RPC call with HMAC signatures.
 import { NhbClient } from "@nhbchain/sdk";
 
 const client = new NhbClient({
-  endpoint: "https://rpc.testnet.nhbchain.xyz",
+  endpoint: "https://rpc.testnet.nhbcoin.net",
   apiKey: process.env.NHB_API_KEY!,
   apiSecret: process.env.NHB_API_SECRET!,
 });

--- a/docs/security/audit-readiness.md
+++ b/docs/security/audit-readiness.md
@@ -21,8 +21,8 @@ Audits should prioritize the consensus engine, staking and escrow modules, RPC g
 Audit findings are treated under the same embargo rules as vulnerability submissions: 45 days for critical issues and 30 days for others, unless early release is mutually agreed. Public disclosure will include auditor attribution when approved.
 
 ## Contacts & Encryption
-- **Program Lead:** `audit@nhbcoin.net`
-- **Security Team:** `security@nhbcoin.net`
+- **Program Lead:** `audit@nehborly.net`
+- **Security Team:** `security@nehborly.net`
 - **PGP Fingerprint:** `8F2D 3C71 9A0B 4D52 8EFA 9C1B 6D74 C5A2 1D3F 8B9E`
 - **PGP Key:** [`repository-pgp-key.asc`](./repository-pgp-key.asc)
 

--- a/docs/security/bug-bounty.md
+++ b/docs/security/bug-bounty.md
@@ -28,7 +28,7 @@ SLA targets may be adjusted when coordinated disclosure with upstream dependenci
 Researchers are expected to keep vulnerability details confidential until a coordinated disclosure date is agreed upon. We request a minimum 45-day embargo for critical issues and 30 days for other severities, unless a fix is released earlier. Premature disclosure may impact reward eligibility.
 
 ## Reporting & Contacts
-Send encrypted reports to **security@nhbcoin.net** with the subject line “Bug Bounty Submission.” Include detailed reproduction steps, affected components, and suggested remediation if available. Urgent matters can also be escalated via our Signal hotline `+1-415-555-0119` (voice/text only).
+Send encrypted reports to **security@nehborly.net** with the subject line “Bug Bounty Submission.” Include detailed reproduction steps, affected components, and suggested remediation if available. Urgent matters can also be escalated via our Signal hotline `+13234559568` (voice/text only).
 
 ## PGP Key
 * **Fingerprint:** `8F2D 3C71 9A0B 4D52 8EFA 9C1B 6D74 C5A2 1D3F 8B9E`

--- a/docs/security/disclosure.md
+++ b/docs/security/disclosure.md
@@ -12,8 +12,8 @@ The following assets are **out of scope**: third-party wallets, forked chains, l
 
 ## Reporting Process
 1. Gather detailed reproduction steps, logs, and proof-of-concept material.
-2. Encrypt your report with our [repository PGP key](./repository-pgp-key.asc) and email it to `security@nhbcoin.net`.
-3. For time-sensitive issues, call or text the Signal hotline `+1-415-555-0119` after sending the encrypted report.
+2. Encrypt your report with our [repository PGP key](./repository-pgp-key.asc) and email it to `security@nehborly.net`.
+3. For time-sensitive issues, call or text the Signal hotline `+13234559568` after sending the encrypted report.
 4. Do not share vulnerability details publicly or with third parties until we finalize remediation and agree on a disclosure timeline.
 
 ## Service Level Agreements
@@ -36,8 +36,8 @@ Testing activities conducted under this policy are authorized, provided you:
 If legal action is initiated by a third party against you for activities conducted in compliance with this policy, notify us and we will make this authorization known.
 
 ## Contacts & Encryption
-- **Primary Contact:** `security@nhbcoin.net`
-- **Emergency Contact:** Signal `+1-415-555-0119`
+- **Primary Contact:** `security@nehborly.net`
+- **Emergency Contact:** Signal `+13234559568`
 - **PGP Fingerprint:** `8F2D 3C71 9A0B 4D52 8EFA 9C1B 6D74 C5A2 1D3F 8B9E`
 - **PGP Key:** [`repository-pgp-key.asc`](./repository-pgp-key.asc)
 

--- a/docs/security/network-hardening.md
+++ b/docs/security/network-hardening.md
@@ -1,0 +1,134 @@
+# Network Hardening Playbook
+
+This document consolidates the controls and monitoring that keep NHBChain nodes
+resilient against modern attacks. It augments the validator hardening steps in
+[`release-process.md`](./release-process.md) and focuses specifically on network
+boundaries, RPC services, and abuse handling.
+
+## Threat Model
+
+- **JSON-RPC & REST abuse** – Attackers attempt to bypass authentication,
+  replay signed requests, or exhaust rate limits.
+- **Distributed denial of service (DDoS)** – Floods directed at public RPC,
+  WebSocket, or peer-to-peer listeners to degrade availability.
+- **Credential stuffing & API key theft** – Compromise of merchant or partner
+  credentials that grant transactional authority.
+- **State divergence** – Malicious peers replay old handshakes or inject
+  conflicting genesis data to isolate nodes.
+
+Every mitigation below maps to at least one of these scenarios.
+
+## RPC & Gateway Protection
+
+1. **Mandatory authentication** – JSON-RPC methods that mutate chain state must
+   sit behind HMAC authentication (`X-NHB-APIKEY`, `X-NHB-SIGNATURE`). Do not
+   expose unauthenticated endpoints on public interfaces. The configuration
+   examples in [`docs/networking/net-rpc.md`](../networking/net-rpc.md) show the
+   required headers and expected error codes.
+2. **Mutual TLS or private networking** – Validators should restrict RPC access
+   to an API gateway that validates client certificates. Partners connecting
+   over the internet must use mutual TLS; browser clients should go through a
+   gateway that proxies requests on their behalf.
+3. **Request validation** – Reject mismatched `chainId`, stale timestamps
+   (±60 seconds), and nonce replays. The stock handlers already enforce these
+   checks; ensure any custom middleware preserves them.
+4. **Rate limiting** – Keep the defaults from `config.toml` (`RateMsgsPerSec=50`,
+   `Burst=200`) for operator RPC. API gateways should additionally enforce per
+   IP and per key quotas that align with commercial agreements.
+5. **Audit logging** – Ship RPC access logs to your SIEM. Alert on spikes in
+   401/403 responses, large payloads, or methods invoked outside policy.
+
+## Application-Layer Safeguards
+
+Add controls that make it impractical for attackers to tamper with request and
+response payloads even if they can reach the gateway perimeter:
+
+1. **Method allowlists** – Expose only the JSON-RPC and REST routes that your
+   application requires. Deny-listing is insufficient; configure the gateway to
+   reject any method not explicitly registered so fuzzing cannot surface
+   development or admin handlers.
+2. **Canonical signing** – Normalize headers (case, spacing) and payloads before
+   computing HMAC signatures. This prevents smuggling attempts where attackers
+   replay a signed payload with modified framing.
+3. **Idempotency enforcement** – Require `Idempotency-Key` headers on every
+   state-changing REST call. Persist recently used keys for at least 24 hours so
+   replayed requests are dropped before hitting business logic.
+4. **Deterministic error budgets** – Return opaque error codes to clients and
+   avoid echoing raw stack traces. Detailed diagnostics belong in structured
+   logs that never traverse the public network.
+5. **Schema validation** – Validate JSON bodies against OpenAPI/JSON Schema
+   definitions. Reject additional properties, enforce type constraints, and
+   clamp numeric ranges to stop injection attempts.
+
+## Peer-to-Peer Controls
+
+1. **Signed handshakes** – NET-2A challenge/response prevents spoofing. Monitor
+   for repeated `Record handshake violation` messages and ban offending peers.
+2. **Nonce replay guard** – The in-memory nonce cache rejects replays within the
+   10-minute window. Do not disable this guard; adjust the window only if
+   memory pressure is measurable.
+3. **Ban scoring** – Keep `BanScore=100` and `GreyScore=50` unless running in a
+   permissioned lab. The defaults balance false positives against swift removal
+   of abusive peers.
+4. **Global throttles** – `MaxPeers=64` and `RateMsgsPerSec=50` keep aggregate
+   bandwidth bounded. If you must raise these values, scale hardware and update
+   DDoS protection policies accordingly.
+5. **Ingress filtering** – Front validators with firewalls that allow P2P
+   traffic from known peer ranges. Cloud deployments should leverage provider
+   load balancers with connection limits to absorb SYN floods before they reach
+   the node process.
+
+## DDoS Resilience
+
+- **Layer 3/4** – Use cloud provider DDoS protection (AWS Shield Advanced,
+  Cloud Armor, etc.) or on-prem appliances. Always enable connection tracking
+  and SYN cookies. Autoscale or rate limit at the edge rather than inside the
+  node binary.
+- **Layer 7** – Deploy a WAF in front of RPC/REST endpoints with rules that
+  block malformed JSON, oversized payloads, and high request rates. Tie WAF
+  alerts into the same incident response channel as validator telemetry.
+- **Graceful degradation** – Configure gateways to shed non-critical traffic
+  (public explorers, historical queries) before validator-to-validator calls.
+  During sustained attacks, operators may temporarily restrict RPC to allowlisted
+  partner IPs.
+
+## Credential Hygiene
+
+- Rotate API keys quarterly and immediately on any sign of compromise.
+- Store secrets in a hardware security module (HSM), HashiCorp Vault, or
+  another dedicated secret manager; never bake credentials into container
+  images.
+- Enable anomaly detection on authentication events—multiple failures from a
+  single IP or key should trigger automated bans via `net_ban`.
+
+## Future-Facing Improvements
+
+- **Adaptive rate limiting** – Integrate risk scoring that raises or lowers
+  per-key throughput based on behavioural history.
+- **QUIC transport** – Evaluate QUIC for RPC to add native congestion control
+  and mitigate head-of-line blocking during bursts.
+- **Hardware attestation** – Tie validator admission to TPM-backed attestation
+  (e.g., Intel SGX/DCAP, AWS Nitro) to harden against key exfiltration.
+- **Centralised revocation registry** – Publish compromised peer IDs and API
+  keys via on-chain governance so all operators can revoke access rapidly.
+
+Track these items in the security backlog and revisit after each major release.
+
+## Verification Checklist
+
+Use this list before promoting infrastructure to production or public testnet:
+
+- [ ] RPC endpoints enforce HMAC auth or mutual TLS and reject unauthenticated
+      calls.
+- [ ] Rate limiting is active at the node and edge layers.
+- [ ] Gateways enforce allowlists for RPC/REST methods and reject unknown routes.
+- [ ] REST write paths require idempotency keys and drop replays for 24 hours.
+- [ ] JSON schemas validate inbound payloads and strip unexpected fields.
+- [ ] P2P logs show successful NET-2A challenges with no unresolved violations.
+- [ ] SIEM receives logs from RPC gateways, WAF, and node processes.
+- [ ] DDoS mitigation plan tested within the last quarter.
+- [ ] Emergency ban (`net_ban`) tested against a disposable peer and recovered
+      automatically.
+
+Maintain signed runbooks proving the checklist was executed; auditors and
+governance committees may request evidence during incident reviews.

--- a/docs/security/release-process.md
+++ b/docs/security/release-process.md
@@ -4,7 +4,7 @@ This document defines the security, audit, and operational procedures required b
 
 ## Audit Intake
 
-1. **Submission Channel** – All issues must arrive via `security@nhbcoin.net` or the HackerOne program. Public issues are not accepted during freeze.
+1. **Submission Channel** – All issues must arrive via `security@nehborly.net` or the HackerOne program. Public issues are not accepted during freeze.
 2. **Acknowledgement SLA** – Respond to researchers within 24 hours with a tracking ID and severity placeholder.
 3. **Initial Assessment** – Security triage team rates severity using CVSS 3.1 and determines impacted modules.
 4. **Issue Tracking** – Log each report in the private security board with fields: severity, affected versions, exploit prerequisites, mitigation status.
@@ -62,8 +62,8 @@ If an issue risks funds or validator safety, initiate the freeze protocol immedi
 
 ## Vulnerability Disclosure
 
-* Email: `security@nhbcoin.net`
-* PGP: `https://security.nhbchain.io/pgp.txt`
+* Email: `security@nehborly.net`
+* PGP: `https://security.nhbcoin.net/pgp.txt`
 * Expected timeline: acknowledgement in 24 hours, fix ETA shared within 5 business days.
 * Safe harbor applies for good faith testing that avoids mainnet, personal data, and denial-of-service attacks.
 

--- a/examples/cookbook/go/main.go
+++ b/examples/cookbook/go/main.go
@@ -73,7 +73,7 @@ func main() {
 
 	rpcURL := strings.TrimSpace(os.Getenv("NHB_RPC_URL"))
 	if rpcURL == "" {
-		rpcURL = "https://rpc.nhbcoin.net"
+		rpcURL = "https://rpc.testnet.nhbcoin.net"
 	}
 
 	apiBase := strings.TrimSpace(os.Getenv("NHB_API_BASE"))

--- a/examples/cookbook/js/index.mjs
+++ b/examples/cookbook/js/index.mjs
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-const rpcUrl = (process.env.NHB_RPC_URL || 'https://rpc.nhbcoin.net').trim();
+const rpcUrl = (process.env.NHB_RPC_URL || 'https://rpc.testnet.nhbcoin.net').trim();
 const apiBase = (process.env.NHB_API_BASE || 'https://api.nhbcoin.net/escrow/v1').trim().replace(/\/$/, '');
 const address = (process.env.NHB_ADDRESS || '').trim();
 const apiKey = (process.env.NHB_API_KEY || '').trim();

--- a/examples/postman/NHB.postman_collection.json
+++ b/examples/postman/NHB.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "NHBCoin RPC & REST Cookbook",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "Reference requests for rpc.nhbcoin.net (JSON-RPC) and api.nhbcoin.net (REST escrow gateway). Update the collection variables to switch between devnet/testnet hosts or to inject credentials."
+    "description": "Reference requests for rpc.testnet.nhbcoin.net (JSON-RPC) and api.nhbcoin.net (REST escrow gateway). Update the collection variables to switch between devnet/testnet hosts or to inject credentials."
   },
   "item": [
     {
@@ -155,7 +155,7 @@
   "variable": [
     {
       "key": "rpc_base",
-      "value": "https://rpc.nhbcoin.net"
+      "value": "https://rpc.testnet.nhbcoin.net"
     },
     {
       "key": "api_base",

--- a/ops/audit-pack/config-samples/validator.toml
+++ b/ops/audit-pack/config-samples/validator.toml
@@ -5,7 +5,7 @@ priv_key_path = "seeds-fixtures/validator_priv.key"
 public_address = "nhbvaloper1audit0000000000000000000000000000000"
 
 [network]
-seeds = ["node1.audit.nhbchain.io:26656", "node2.audit.nhbchain.io:26656"]
+seeds = ["node1.audit.nhbcoin.net:26656", "node2.audit.nhbcoin.net:26656"]
 pex = false
 persistent_peers = []
 


### PR DESCRIPTION
## Summary
- update security contacts to the new Signal hotline and extend the network hardening checklist with application-layer safeguards
- align example documentation and sample apps with the rpc.testnet.nhbcoin.net endpoint to match the live public network
- refresh Postman and SDK helper defaults so test harnesses point at the current testnet infrastructure out of the box

## Testing
- not run (documentation and example defaults only)


------
https://chatgpt.com/codex/tasks/task_e_68d72ec8c264832da348b34978f1700c