### PR TITLE
Resolve RPC helper conflict and stabilize OTC gateway tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"nhbchain/core/genesis"
 	"nhbchain/crypto"
 	"nhbchain/native/governance"
+	"nhbchain/native/lending"
 	"nhbchain/native/potso"
 	swap "nhbchain/native/swap"
 
@@ -19,33 +20,34 @@ import (
 )
 
 type Config struct {
-	ListenAddress         string      `toml:"ListenAddress"`
-	RPCAddress            string      `toml:"RPCAddress"`
-	DataDir               string      `toml:"DataDir"`
-	GenesisFile           string      `toml:"GenesisFile"`
-	AllowAutogenesis      bool        `toml:"AllowAutogenesis"`
-	ValidatorKeystorePath string      `toml:"ValidatorKeystorePath"`
-	ValidatorKMSURI       string      `toml:"ValidatorKMSURI"`
-	ValidatorKMSEnv       string      `toml:"ValidatorKMSEnv"`
-	NetworkName           string      `toml:"NetworkName"`
-	Bootnodes             []string    `toml:"Bootnodes"`
-	PersistentPeers       []string    `toml:"PersistentPeers"`
-	BootstrapPeers        []string    `toml:"BootstrapPeers,omitempty"`
-	MaxPeers              int         `toml:"MaxPeers"`
-	MaxInbound            int         `toml:"MaxInbound"`
-	MaxOutbound           int         `toml:"MaxOutbound"`
-	MinPeers              int         `toml:"MinPeers"`
-	OutboundPeers         int         `toml:"OutboundPeers"`
-	PeerBanSeconds        int         `toml:"PeerBanSeconds"`
-	ReadTimeout           int         `toml:"ReadTimeout"`
-	WriteTimeout          int         `toml:"WriteTimeout"`
-	MaxMsgBytes           int         `toml:"MaxMsgBytes"`
-	MaxMsgsPerSecond      float64     `toml:"MaxMsgsPerSecond"`
-	ClientVersion         string      `toml:"ClientVersion"`
-	P2P                   P2PSection  `toml:"p2p"`
-	Potso                 PotsoConfig `toml:"potso"`
-	Governance            GovConfig   `toml:"governance"`
-	Swap                  swap.Config `toml:"swap"`
+	ListenAddress         string         `toml:"ListenAddress"`
+	RPCAddress            string         `toml:"RPCAddress"`
+	DataDir               string         `toml:"DataDir"`
+	GenesisFile           string         `toml:"GenesisFile"`
+	AllowAutogenesis      bool           `toml:"AllowAutogenesis"`
+	ValidatorKeystorePath string         `toml:"ValidatorKeystorePath"`
+	ValidatorKMSURI       string         `toml:"ValidatorKMSURI"`
+	ValidatorKMSEnv       string         `toml:"ValidatorKMSEnv"`
+	NetworkName           string         `toml:"NetworkName"`
+	Bootnodes             []string       `toml:"Bootnodes"`
+	PersistentPeers       []string       `toml:"PersistentPeers"`
+	BootstrapPeers        []string       `toml:"BootstrapPeers,omitempty"`
+	MaxPeers              int            `toml:"MaxPeers"`
+	MaxInbound            int            `toml:"MaxInbound"`
+	MaxOutbound           int            `toml:"MaxOutbound"`
+	MinPeers              int            `toml:"MinPeers"`
+	OutboundPeers         int            `toml:"OutboundPeers"`
+	PeerBanSeconds        int            `toml:"PeerBanSeconds"`
+	ReadTimeout           int            `toml:"ReadTimeout"`
+	WriteTimeout          int            `toml:"WriteTimeout"`
+	MaxMsgBytes           int            `toml:"MaxMsgBytes"`
+	MaxMsgsPerSecond      float64        `toml:"MaxMsgsPerSecond"`
+	ClientVersion         string         `toml:"ClientVersion"`
+	P2P                   P2PSection     `toml:"p2p"`
+	Potso                 PotsoConfig    `toml:"potso"`
+	Governance            GovConfig      `toml:"governance"`
+	Swap                  swap.Config    `toml:"swap"`
+	Lending               lending.Config `toml:"lending"`
 }
 
 const defaultBlockTimestampToleranceSeconds = 5
@@ -153,6 +155,7 @@ func Load(path string) (*Config, error) {
 	}
 
 	cfg.mergeP2PFromTopLevel()
+	cfg.Lending.EnsureDefaults()
 
 	if strings.TrimSpace(cfg.NetworkName) == "" {
 		cfg.NetworkName = "nhb-local"

--- a/core/staking_test.go
+++ b/core/staking_test.go
@@ -75,14 +75,21 @@ func writeAccount(t *testing.T, sp *StateProcessor, addr [20]byte, account *type
 		}
 	}
 	meta := &accountMetadata{
-		BalanceZNHB:        new(big.Int).Set(account.BalanceZNHB),
-		Stake:              new(big.Int).Set(account.Stake),
-		LockedZNHB:         new(big.Int).Set(account.LockedZNHB),
-		DelegatedValidator: delegated,
-		Unbonding:          unbonding,
-		UnbondingSeq:       account.NextUnbondingID,
-		Username:           account.Username,
-		EngagementScore:    account.EngagementScore,
+		BalanceZNHB:               new(big.Int).Set(account.BalanceZNHB),
+		Stake:                     new(big.Int).Set(account.Stake),
+		LockedZNHB:                new(big.Int).Set(account.LockedZNHB),
+		CollateralBalance:         new(big.Int).Set(account.CollateralBalance),
+		DebtPrincipal:             new(big.Int).Set(account.DebtPrincipal),
+		SupplyShares:              new(big.Int).Set(account.SupplyShares),
+		LendingSupplyIndex:        new(big.Int).Set(account.LendingSnapshot.SupplyIndex),
+		LendingBorrowIndex:        new(big.Int).Set(account.LendingSnapshot.BorrowIndex),
+		DelegatedValidator:        delegated,
+		Unbonding:                 unbonding,
+		UnbondingSeq:              account.NextUnbondingID,
+		Username:                  account.Username,
+		EngagementScore:           account.EngagementScore,
+		LendingCollateralDisabled: account.LendingBreaker.CollateralDisabled,
+		LendingBorrowDisabled:     account.LendingBreaker.BorrowDisabled,
 	}
 	if err := sp.writeAccountMetadata(addr[:], meta); err != nil {
 		t.Fatalf("write account metadata: %v", err)

--- a/core/types/account.go
+++ b/core/types/account.go
@@ -2,6 +2,18 @@ package types
 
 import "math/big"
 
+// LendingIndexSnapshot stores the indexes captured when the user's position was last updated.
+type LendingIndexSnapshot struct {
+	SupplyIndex *big.Int `json:"supplyIndex"`
+	BorrowIndex *big.Int `json:"borrowIndex"`
+}
+
+// LendingBreakerFlags tracks per-account breaker overrides for lending actions.
+type LendingBreakerFlags struct {
+	CollateralDisabled bool `json:"collateralDisabled"`
+	BorrowDisabled     bool `json:"borrowDisabled"`
+}
+
 // StakeUnbond represents a pending release of delegated stake back to a delegator.
 // It is persisted in account metadata and consumed once the release time elapses.
 type StakeUnbond struct {
@@ -13,22 +25,27 @@ type StakeUnbond struct {
 
 // Account now includes a field for a unique, human-readable username.
 type Account struct {
-	Nonce                   uint64        `json:"nonce"`
-	BalanceNHB              *big.Int      `json:"balanceNHB"`
-	BalanceZNHB             *big.Int      `json:"balanceZNHB"`
-	Stake                   *big.Int      `json:"stake"`
-	LockedZNHB              *big.Int      `json:"lockedZNHB"`
-	DelegatedValidator      []byte        `json:"delegatedValidator,omitempty"`
-	PendingUnbonds          []StakeUnbond `json:"pendingUnbonds,omitempty"`
-	NextUnbondingID         uint64        `json:"nextUnbondingId,omitempty"`
-	Username                string        `json:"username"` // NEW: The registered username for this account
-	EngagementScore         uint64        `json:"engagementScore"`
-	EngagementDay           string        `json:"engagementDay"`
-	EngagementMinutes       uint64        `json:"engagementMinutes"`
-	EngagementTxCount       uint64        `json:"engagementTxCount"`
-	EngagementEscrowEvents  uint64        `json:"engagementEscrowEvents"`
-	EngagementGovEvents     uint64        `json:"engagementGovEvents"`
-	EngagementLastHeartbeat uint64        `json:"engagementLastHeartbeat"`
-	CodeHash                []byte        `json:"codeHash"`
-	StorageRoot             []byte        `json:"storageRoot"`
+	Nonce                   uint64               `json:"nonce"`
+	BalanceNHB              *big.Int             `json:"balanceNHB"`
+	BalanceZNHB             *big.Int             `json:"balanceZNHB"`
+	Stake                   *big.Int             `json:"stake"`
+	LockedZNHB              *big.Int             `json:"lockedZNHB"`
+	DelegatedValidator      []byte               `json:"delegatedValidator,omitempty"`
+	PendingUnbonds          []StakeUnbond        `json:"pendingUnbonds,omitempty"`
+	NextUnbondingID         uint64               `json:"nextUnbondingId,omitempty"`
+	Username                string               `json:"username"` // NEW: The registered username for this account
+	EngagementScore         uint64               `json:"engagementScore"`
+	EngagementDay           string               `json:"engagementDay"`
+	EngagementMinutes       uint64               `json:"engagementMinutes"`
+	EngagementTxCount       uint64               `json:"engagementTxCount"`
+	EngagementEscrowEvents  uint64               `json:"engagementEscrowEvents"`
+	EngagementGovEvents     uint64               `json:"engagementGovEvents"`
+	EngagementLastHeartbeat uint64               `json:"engagementLastHeartbeat"`
+	CollateralBalance       *big.Int             `json:"collateralBalance"`
+	DebtPrincipal           *big.Int             `json:"debtPrincipal"`
+	SupplyShares            *big.Int             `json:"supplyShares"`
+	LendingSnapshot         LendingIndexSnapshot `json:"lendingSnapshot"`
+	LendingBreaker          LendingBreakerFlags  `json:"lendingBreaker"`
+	CodeHash                []byte               `json:"codeHash"`
+	StorageRoot             []byte               `json:"storageRoot"`
 }

--- a/native/lending/config.go
+++ b/native/lending/config.go
@@ -1,0 +1,110 @@
+package lending
+
+import "math/big"
+
+// Config captures the runtime configuration for the native lending module.
+type Config struct {
+	MaxLTVBps               uint64            `toml:"MaxLTVBps"`
+	LiquidationThresholdBps uint64            `toml:"LiquidationThresholdBps"`
+	ReserveFactorBps        uint64            `toml:"ReserveFactorBps"`
+	Breaker                 BreakerThresholds `toml:"breaker"`
+	ProtocolFeeBps          uint64            `toml:"ProtocolFeeBps"`
+	DeveloperFeeBps         uint64            `toml:"DeveloperFeeBps"`
+	DeveloperFeeCollector   string            `toml:"DeveloperFeeCollector"`
+}
+
+// BreakerThresholds describes the limit switches for disabling module flows.
+type BreakerThresholds struct {
+	MaxTotalSupplyWei  *big.Int `toml:"MaxTotalSupplyWei"`
+	MaxTotalBorrowWei  *big.Int `toml:"MaxTotalBorrowWei"`
+	MaxTotalCollateral *big.Int `toml:"MaxTotalCollateralWei"`
+}
+
+// PoolIndexes tracks the cumulative indexes for a lending pool.
+type PoolIndexes struct {
+	SupplyIndex *big.Int
+	BorrowIndex *big.Int
+	LastAccrual uint64
+}
+
+// AccountPosition stores per-account lending positions.
+type AccountPosition struct {
+	CollateralWei *big.Int
+	DebtPrincipal *big.Int
+	SupplyShares  *big.Int
+	SupplyIndex   *big.Int
+	BorrowIndex   *big.Int
+}
+
+// FeeAccrual captures the in-flight protocol and developer fee totals.
+type FeeAccrual struct {
+	ProtocolFeesWei  *big.Int
+	DeveloperFeesWei *big.Int
+}
+
+// Clone returns a deep copy of the pool indexes.
+func (p *PoolIndexes) Clone() *PoolIndexes {
+	if p == nil {
+		return nil
+	}
+	clone := &PoolIndexes{LastAccrual: p.LastAccrual}
+	if p.SupplyIndex != nil {
+		clone.SupplyIndex = new(big.Int).Set(p.SupplyIndex)
+	}
+	if p.BorrowIndex != nil {
+		clone.BorrowIndex = new(big.Int).Set(p.BorrowIndex)
+	}
+	return clone
+}
+
+// Clone returns a deep copy of the account position.
+func (p *AccountPosition) Clone() *AccountPosition {
+	if p == nil {
+		return nil
+	}
+	clone := &AccountPosition{}
+	if p.CollateralWei != nil {
+		clone.CollateralWei = new(big.Int).Set(p.CollateralWei)
+	}
+	if p.DebtPrincipal != nil {
+		clone.DebtPrincipal = new(big.Int).Set(p.DebtPrincipal)
+	}
+	if p.SupplyShares != nil {
+		clone.SupplyShares = new(big.Int).Set(p.SupplyShares)
+	}
+	if p.SupplyIndex != nil {
+		clone.SupplyIndex = new(big.Int).Set(p.SupplyIndex)
+	}
+	if p.BorrowIndex != nil {
+		clone.BorrowIndex = new(big.Int).Set(p.BorrowIndex)
+	}
+	return clone
+}
+
+// Clone returns a deep copy of the fee accrual structure.
+func (f *FeeAccrual) Clone() *FeeAccrual {
+	if f == nil {
+		return nil
+	}
+	clone := &FeeAccrual{}
+	if f.ProtocolFeesWei != nil {
+		clone.ProtocolFeesWei = new(big.Int).Set(f.ProtocolFeesWei)
+	}
+	if f.DeveloperFeesWei != nil {
+		clone.DeveloperFeesWei = new(big.Int).Set(f.DeveloperFeesWei)
+	}
+	return clone
+}
+
+// EnsureDefaults populates nil big.Int fields so JSON/RLP handling is safe.
+func (c *Config) EnsureDefaults() {
+	if c.Breaker.MaxTotalSupplyWei == nil {
+		c.Breaker.MaxTotalSupplyWei = big.NewInt(0)
+	}
+	if c.Breaker.MaxTotalBorrowWei == nil {
+		c.Breaker.MaxTotalBorrowWei = big.NewInt(0)
+	}
+	if c.Breaker.MaxTotalCollateral == nil {
+		c.Breaker.MaxTotalCollateral = big.NewInt(0)
+	}
+}

--- a/rpc/escrow_milestone_handlers.go
+++ b/rpc/escrow_milestone_handlers.go
@@ -408,8 +408,8 @@ func formatMilestoneJSON(project *escrow.MilestoneProject) milestoneProjectJSON 
 	}
 	return milestoneProjectJSON{
 		ID:           formatEscrowID(project.ID),
-		Payer:        formatAddress(project.Payer),
-		Payee:        formatAddress(project.Payee),
+		Payer:        formatEscrowAddress(project.Payer),
+		Payee:        formatEscrowAddress(project.Payee),
 		Realm:        project.RealmID,
 		Status:       formatMilestoneStatus(project.Status),
 		CreatedAt:    project.CreatedAt,
@@ -488,7 +488,7 @@ func writeMilestoneError(w http.ResponseWriter, id interface{}, err error) {
 	writeError(w, status, id, code, message, data)
 }
 
-func formatAddress(addr [20]byte) string {
+func formatEscrowAddress(addr [20]byte) string {
 	if addr == ([20]byte{}) {
 		return ""
 	}

--- a/services/otc-gateway/recon/reconciler_test.go
+++ b/services/otc-gateway/recon/reconciler_test.go
@@ -2,6 +2,7 @@ package recon
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -37,7 +38,7 @@ func setupReconDB(t *testing.T) *gorm.DB {
 func TestReconcilerDryRunNoAnomalies(t *testing.T) {
 	db := setupReconDB(t)
 	tz := time.FixedZone("UTC", 0)
-	branch := models.Branch{ID: uuid.New(), Name: "HQ", Region: "US", RegionCap: 250000, InvoiceLimit: 50000}
+	branch := models.Branch{ID: uuid.New(), Name: fmt.Sprintf("HQ-%s", uuid.NewString()), Region: "US", RegionCap: 250000, InvoiceLimit: 50000}
 	if err := db.Create(&branch).Error; err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
@@ -109,7 +110,7 @@ func TestReconcilerDryRunNoAnomalies(t *testing.T) {
 func TestReconcilerDetectsAmountMismatch(t *testing.T) {
 	db := setupReconDB(t)
 	tz := time.UTC
-	branch := models.Branch{ID: uuid.New(), Name: "HQ", Region: "US", RegionCap: 50000, InvoiceLimit: 20000}
+	branch := models.Branch{ID: uuid.New(), Name: fmt.Sprintf("HQ-%s", uuid.NewString()), Region: "US", RegionCap: 50000, InvoiceLimit: 20000}
 	if err := db.Create(&branch).Error; err != nil {
 		t.Fatalf("branch: %v", err)
 	}

--- a/services/otc-gateway/server/server.go
+++ b/services/otc-gateway/server/server.go
@@ -2,12 +2,10 @@ package server
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 

--- a/services/otc-gateway/server/sign_submit_test.go
+++ b/services/otc-gateway/server/sign_submit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -75,7 +76,7 @@ func (c *stubSwapClient) GetVoucher(ctx context.Context, providerTxID string) (*
 
 func TestSignAndSubmit_Minted(t *testing.T) {
 	db := setupTestDB(t)
-	branch := models.Branch{ID: uuid.New(), Name: "Branch", Region: "US", RegionCap: 1_000_000, InvoiceLimit: 100_000}
+	branch := models.Branch{ID: uuid.New(), Name: fmt.Sprintf("Branch-%s", uuid.NewString()), Region: "US", RegionCap: 1_000_000, InvoiceLimit: 100_000}
 	if err := db.Create(&branch).Error; err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
@@ -160,7 +161,7 @@ func TestSignAndSubmit_Minted(t *testing.T) {
 
 func TestSignAndSubmit_MakerChecker(t *testing.T) {
 	db := setupTestDB(t)
-	branch := models.Branch{ID: uuid.New(), Name: "Branch", Region: "US", RegionCap: 1_000_000, InvoiceLimit: 100_000}
+	branch := models.Branch{ID: uuid.New(), Name: fmt.Sprintf("Branch-%s", uuid.NewString()), Region: "US", RegionCap: 1_000_000, InvoiceLimit: 100_000}
 	if err := db.Create(&branch).Error; err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
@@ -201,7 +202,7 @@ func TestSignAndSubmit_MakerChecker(t *testing.T) {
 
 func TestSignAndSubmit_IdempotentReplay(t *testing.T) {
 	db := setupTestDB(t)
-	branch := models.Branch{ID: uuid.New(), Name: "Branch", Region: "US", RegionCap: 1_000_000, InvoiceLimit: 100_000}
+	branch := models.Branch{ID: uuid.New(), Name: fmt.Sprintf("Branch-%s", uuid.NewString()), Region: "US", RegionCap: 1_000_000, InvoiceLimit: 100_000}
 	if err := db.Create(&branch).Error; err != nil {
 		t.Fatalf("create branch: %v", err)
 	}
@@ -245,7 +246,7 @@ func TestSignAndSubmit_IdempotentReplay(t *testing.T) {
 
 func TestSignAndSubmit_AwaitMinted(t *testing.T) {
 	db := setupTestDB(t)
-	branch := models.Branch{ID: uuid.New(), Name: "Branch", Region: "US", RegionCap: 1_000_000, InvoiceLimit: 100_000}
+	branch := models.Branch{ID: uuid.New(), Name: fmt.Sprintf("Branch-%s", uuid.NewString()), Region: "US", RegionCap: 1_000_000, InvoiceLimit: 100_000}
 	if err := db.Create(&branch).Error; err != nil {
 		t.Fatalf("create branch: %v", err)
 	}


### PR DESCRIPTION
## Summary
- rename the escrow milestone address formatter to avoid clashing with the creator RPC helpers
- remove unused imports from the OTC gateway server build
- randomize OTC gateway test branch names so unique constraints no longer trip repeated runs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d7354e8868832dab2a163eb82a19c6