### PR TITLE
Add lending JSON-RPC handlers

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -57,6 +57,7 @@ type Server struct {
 	potsoEvidence *modules.PotsoEvidenceModule
 	transactions  *modules.TransactionsModule
 	escrow        *modules.EscrowModule
+	lending       *modules.LendingModule
 }
 
 func NewServer(node *core.Node) *Server {
@@ -69,6 +70,7 @@ func NewServer(node *core.Node) *Server {
 		potsoEvidence: modules.NewPotsoEvidenceModule(node),
 		transactions:  modules.NewTransactionsModule(node),
 		escrow:        modules.NewEscrowModule(node),
+		lending:       modules.NewLendingModule(node),
 	}
 }
 
@@ -288,6 +290,26 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleSwapVoucherReverse(w, r, req)
+	case "lend_getMarket":
+		s.handleLendingGetMarket(w, r, req)
+	case "lend_getUserAccount":
+		s.handleLendingGetUserAccount(w, r, req)
+	case "lend_supplyNHB":
+		s.handleLendingSupplyNHB(w, r, req)
+	case "lend_withdrawNHB":
+		s.handleLendingWithdrawNHB(w, r, req)
+	case "lend_depositZNHB":
+		s.handleLendingDepositZNHB(w, r, req)
+	case "lend_withdrawZNHB":
+		s.handleLendingWithdrawZNHB(w, r, req)
+	case "lend_borrowNHB":
+		s.handleLendingBorrowNHB(w, r, req)
+	case "lend_borrowNHBWithFee":
+		s.handleLendingBorrowNHBWithFee(w, r, req)
+	case "lend_repayNHB":
+		s.handleLendingRepayNHB(w, r, req)
+	case "lend_liquidate":
+		s.handleLendingLiquidate(w, r, req)
 	case "stake_delegate":
 		s.handleStakeDelegate(w, r, req)
 	case "stake_undelegate":
@@ -372,22 +394,22 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handleEscrowRefund(w, r, req)
 	case "escrow_expire":
 		s.handleEscrowExpire(w, r, req)
-        case "escrow_dispute":
-                s.handleEscrowDispute(w, r, req)
-        case "escrow_resolve":
-                s.handleEscrowResolve(w, r, req)
-        case "escrow_milestoneCreate":
-                s.handleEscrowMilestoneCreate(w, r, req)
-        case "escrow_milestoneGet":
-                s.handleEscrowMilestoneGet(w, r, req)
-        case "escrow_milestoneFund":
-                s.handleEscrowMilestoneFund(w, r, req)
-        case "escrow_milestoneRelease":
-                s.handleEscrowMilestoneRelease(w, r, req)
-        case "escrow_milestoneCancel":
-                s.handleEscrowMilestoneCancel(w, r, req)
-        case "escrow_milestoneSubscriptionUpdate":
-                s.handleEscrowMilestoneSubscriptionUpdate(w, r, req)
+	case "escrow_dispute":
+		s.handleEscrowDispute(w, r, req)
+	case "escrow_resolve":
+		s.handleEscrowResolve(w, r, req)
+	case "escrow_milestoneCreate":
+		s.handleEscrowMilestoneCreate(w, r, req)
+	case "escrow_milestoneGet":
+		s.handleEscrowMilestoneGet(w, r, req)
+	case "escrow_milestoneFund":
+		s.handleEscrowMilestoneFund(w, r, req)
+	case "escrow_milestoneRelease":
+		s.handleEscrowMilestoneRelease(w, r, req)
+	case "escrow_milestoneCancel":
+		s.handleEscrowMilestoneCancel(w, r, req)
+	case "escrow_milestoneSubscriptionUpdate":
+		s.handleEscrowMilestoneSubscriptionUpdate(w, r, req)
 	case "net_info":
 		s.handleNetInfo(w, r, req)
 	case "net_peers":
@@ -492,15 +514,15 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handleGovernanceList(w, r, req)
 	case "gov_finalize":
 		s.handleGovernanceFinalize(w, r, req)
-        case "gov_queue":
-                s.handleGovernanceQueue(w, r, req)
-        case "gov_execute":
-                s.handleGovernanceExecute(w, r, req)
-        case "reputation_verifySkill":
-                s.handleReputationVerifySkill(w, r, req)
-        default:
-                writeError(w, http.StatusNotFound, req.ID, codeMethodNotFound, fmt.Sprintf("unknown method %s", req.Method), nil)
-        }
+	case "gov_queue":
+		s.handleGovernanceQueue(w, r, req)
+	case "gov_execute":
+		s.handleGovernanceExecute(w, r, req)
+	case "reputation_verifySkill":
+		s.handleReputationVerifySkill(w, r, req)
+	default:
+		writeError(w, http.StatusNotFound, req.ID, codeMethodNotFound, fmt.Sprintf("unknown method %s", req.Method), nil)
+	}
 }
 
 // --- NEW HANDLER: Get Latest Blocks ---

--- a/rpc/lending_handlers.go
+++ b/rpc/lending_handlers.go
@@ -1,0 +1,264 @@
+package rpc
+
+import (
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strings"
+
+	"nhbchain/native/lending"
+	"nhbchain/rpc/modules"
+)
+
+type lendingAccountParams struct {
+	Address string `json:"address"`
+}
+
+type lendingAmountParams struct {
+	From   string `json:"from"`
+	Amount string `json:"amount"`
+}
+
+type lendingBorrowParams struct {
+	Borrower string `json:"borrower"`
+	Amount   string `json:"amount"`
+}
+
+type lendingBorrowWithFeeParams struct {
+	Borrower     string `json:"borrower"`
+	Amount       string `json:"amount"`
+	FeeRecipient string `json:"feeRecipient"`
+	FeeBps       uint64 `json:"feeBps"`
+}
+
+type lendingLiquidateParams struct {
+	Liquidator string `json:"liquidator"`
+	Borrower   string `json:"borrower"`
+}
+
+type lendingTxResult struct {
+	TxHash string `json:"txHash"`
+}
+
+type lendingMarketResult struct {
+	Market         *lending.Market        `json:"market,omitempty"`
+	RiskParameters lending.RiskParameters `json:"riskParameters"`
+}
+
+type lendingUserAccountResult struct {
+	Account *lending.UserAccount `json:"account"`
+}
+
+func (s *Server) handleLendingGetMarket(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 0 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "no parameters expected", nil)
+		return
+	}
+	market, params, moduleErr := s.lending.GetMarket()
+	if moduleErr != nil {
+		writeError(w, moduleErr.HTTPStatus, req.ID, moduleErr.Code, moduleErr.Message, moduleErr.Data)
+		return
+	}
+	result := lendingMarketResult{RiskParameters: params}
+	if market != nil {
+		result.Market = market
+	}
+	writeResult(w, req.ID, result)
+}
+
+func (s *Server) handleLendingGetUserAccount(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected address parameter", nil)
+		return
+	}
+	var addressParam string
+	if err := json.Unmarshal(req.Params[0], &addressParam); err != nil {
+		var wrapped lendingAccountParams
+		if err := json.Unmarshal(req.Params[0], &wrapped); err != nil {
+			writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid address parameter", err.Error())
+			return
+		}
+		addressParam = wrapped.Address
+	}
+	trimmed := strings.TrimSpace(addressParam)
+	if trimmed == "" {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "address required", nil)
+		return
+	}
+	addr, err := decodeBech32(trimmed)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid address", err.Error())
+		return
+	}
+	account, moduleErr := s.lending.GetUserAccount(addr)
+	if moduleErr != nil {
+		writeError(w, moduleErr.HTTPStatus, req.ID, moduleErr.Code, moduleErr.Message, moduleErr.Data)
+		return
+	}
+	if account == nil {
+		writeError(w, http.StatusNotFound, req.ID, codeInvalidParams, "account not found", trimmed)
+		return
+	}
+	writeResult(w, req.ID, lendingUserAccountResult{Account: account})
+}
+
+func (s *Server) handleLendingSupplyNHB(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	s.handleLendingAmountTx(w, r, req, s.lending.SupplyNHB)
+}
+
+func (s *Server) handleLendingWithdrawNHB(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	s.handleLendingAmountTx(w, r, req, s.lending.WithdrawNHB)
+}
+
+func (s *Server) handleLendingDepositZNHB(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	s.handleLendingAmountTx(w, r, req, s.lending.DepositZNHB)
+}
+
+func (s *Server) handleLendingWithdrawZNHB(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	s.handleLendingAmountTx(w, r, req, s.lending.WithdrawZNHB)
+}
+
+func (s *Server) handleLendingBorrowNHB(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	addr, amount, ok := s.parseBorrowParams(w, req)
+	if !ok {
+		return
+	}
+	txHash, moduleErr := s.lending.BorrowNHB(addr, amount)
+	if moduleErr != nil {
+		writeError(w, moduleErr.HTTPStatus, req.ID, moduleErr.Code, moduleErr.Message, moduleErr.Data)
+		return
+	}
+	writeResult(w, req.ID, lendingTxResult{TxHash: txHash})
+}
+
+func (s *Server) handleLendingBorrowNHBWithFee(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected parameter object", nil)
+		return
+	}
+	var params lendingBorrowWithFeeParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	borrower, err := decodeBech32(params.Borrower)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid borrower", err.Error())
+		return
+	}
+	amount, err := parseAmount(params.Amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	recipient, err := decodeBech32(params.FeeRecipient)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid feeRecipient", err.Error())
+		return
+	}
+	txHash, moduleErr := s.lending.BorrowNHBWithFee(borrower, amount, recipient, params.FeeBps)
+	if moduleErr != nil {
+		writeError(w, moduleErr.HTTPStatus, req.ID, moduleErr.Code, moduleErr.Message, moduleErr.Data)
+		return
+	}
+	writeResult(w, req.ID, lendingTxResult{TxHash: txHash})
+}
+
+func (s *Server) handleLendingRepayNHB(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	s.handleLendingAmountTx(w, r, req, s.lending.RepayNHB)
+}
+
+func (s *Server) handleLendingLiquidate(w http.ResponseWriter, r *http.Request, req *RPCRequest) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected parameter object", nil)
+		return
+	}
+	var params lendingLiquidateParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	liquidator, err := decodeBech32(params.Liquidator)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid liquidator", err.Error())
+		return
+	}
+	borrower, err := decodeBech32(params.Borrower)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid borrower", err.Error())
+		return
+	}
+	txHash, moduleErr := s.lending.Liquidate(liquidator, borrower)
+	if moduleErr != nil {
+		writeError(w, moduleErr.HTTPStatus, req.ID, moduleErr.Code, moduleErr.Message, moduleErr.Data)
+		return
+	}
+	writeResult(w, req.ID, lendingTxResult{TxHash: txHash})
+}
+
+func (s *Server) handleLendingAmountTx(w http.ResponseWriter, r *http.Request, req *RPCRequest, fn func([20]byte, *big.Int) (string, *modules.ModuleError)) {
+	if authErr := s.requireAuth(r); authErr != nil {
+		writeError(w, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+		return
+	}
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected parameter object", nil)
+		return
+	}
+	var params lendingAmountParams
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return
+	}
+	addr, err := decodeBech32(params.From)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid from", err.Error())
+		return
+	}
+	amount, err := parseAmount(params.Amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return
+	}
+	txHash, moduleErr := fn(addr, amount)
+	if moduleErr != nil {
+		writeError(w, moduleErr.HTTPStatus, req.ID, moduleErr.Code, moduleErr.Message, moduleErr.Data)
+		return
+	}
+	writeResult(w, req.ID, lendingTxResult{TxHash: txHash})
+}
+
+func (s *Server) parseBorrowParams(w http.ResponseWriter, req *RPCRequest) ([20]byte, *big.Int, bool) {
+	var params lendingBorrowParams
+	if len(req.Params) != 1 {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "expected parameter object", nil)
+		return [20]byte{}, nil, false
+	}
+	if err := json.Unmarshal(req.Params[0], &params); err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid parameter object", err.Error())
+		return [20]byte{}, nil, false
+	}
+	borrower, err := decodeBech32(params.Borrower)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "invalid borrower", err.Error())
+		return [20]byte{}, nil, false
+	}
+	amount, err := parseAmount(params.Amount)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
+		return [20]byte{}, nil, false
+	}
+	return borrower, amount, true
+}

--- a/rpc/modules/lending.go
+++ b/rpc/modules/lending.go
@@ -1,0 +1,61 @@
+package modules
+
+import (
+	"math/big"
+	"net/http"
+
+	"nhbchain/core"
+	"nhbchain/native/lending"
+)
+
+type LendingModule struct {
+	node *core.Node
+}
+
+func NewLendingModule(node *core.Node) *LendingModule {
+	return &LendingModule{node: node}
+}
+
+func (m *LendingModule) moduleUnavailable() *ModuleError {
+	return &ModuleError{HTTPStatus: http.StatusNotImplemented, Code: codeServerError, Message: "lending module not available"}
+}
+
+func (m *LendingModule) GetMarket() (*lending.Market, lending.RiskParameters, *ModuleError) {
+	return nil, lending.RiskParameters{}, m.moduleUnavailable()
+}
+
+func (m *LendingModule) GetUserAccount(_ [20]byte) (*lending.UserAccount, *ModuleError) {
+	return nil, m.moduleUnavailable()
+}
+
+func (m *LendingModule) SupplyNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
+	return "", m.moduleUnavailable()
+}
+
+func (m *LendingModule) WithdrawNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
+	return "", m.moduleUnavailable()
+}
+
+func (m *LendingModule) DepositZNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
+	return "", m.moduleUnavailable()
+}
+
+func (m *LendingModule) WithdrawZNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
+	return "", m.moduleUnavailable()
+}
+
+func (m *LendingModule) BorrowNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
+	return "", m.moduleUnavailable()
+}
+
+func (m *LendingModule) BorrowNHBWithFee(_ [20]byte, _ *big.Int, _ [20]byte, _ uint64) (string, *ModuleError) {
+	return "", m.moduleUnavailable()
+}
+
+func (m *LendingModule) RepayNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
+	return "", m.moduleUnavailable()
+}
+
+func (m *LendingModule) Liquidate(_ [20]byte, _ [20]byte) (string, *ModuleError) {
+	return "", m.moduleUnavailable()
+}

--- a/rpc/modules/module.go
+++ b/rpc/modules/module.go
@@ -1,0 +1,20 @@
+package modules
+
+const (
+	codeInvalidParams = -32602
+	codeServerError   = -32000
+)
+
+type ModuleError struct {
+	HTTPStatus int
+	Code       int
+	Message    string
+	Data       interface{}
+}
+
+func (e *ModuleError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}

--- a/rpc/modules/potso_evidence.go
+++ b/rpc/modules/potso_evidence.go
@@ -12,25 +12,6 @@ import (
 	"nhbchain/crypto"
 )
 
-const (
-	codeInvalidParams = -32602
-	codeServerError   = -32000
-)
-
-type ModuleError struct {
-	HTTPStatus int
-	Code       int
-	Message    string
-	Data       interface{}
-}
-
-func (e *ModuleError) Error() string {
-	if e == nil {
-		return ""
-	}
-	return e.Message
-}
-
 type PotsoEvidenceModule struct {
 	node *core.Node
 }


### PR DESCRIPTION
## Summary
- centralize module error helpers shared across RPC modules
- add a placeholder lending module with RPC handlers covering market, account, and transaction flows
- wire the new lending methods into the JSON-RPC server routing

## Testing
- `go test ./...` *(hangs, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d740ce7c14832d92c15cb394a38c7d