### PR TITLE
Add lending dApp reference implementation

### DIFF
--- a/examples/lending-dapp/.gitignore
+++ b/examples/lending-dapp/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+.DS_Store

--- a/examples/lending-dapp/README.md
+++ b/examples/lending-dapp/README.md
@@ -1,0 +1,42 @@
+# NHBChain Lending dApp Example
+
+This example showcases how to build a lending interface on top of the NHBChain developer APIs. It is intentionally lightweight so it can act as a copy-and-paste starting point for experimentation, hackathons, or production prototypes.
+
+## Features
+
+- **Earn**: Supply and withdraw NHB liquidity using the UI patterns from CODEx — LEND-UI-2.
+- **Borrow**: Deposit ZNHB as collateral, borrow NHB, repay loans, and experiment with developer fees using CODEx — LEND-UI-1.
+- **Fee Recipient Demo**: Demonstrates how a developer can monetize their local deployment via the `lend_borrowNHBWithFee` RPC endpoint.
+- **Empowerment Narrative**: Includes messaging that connects the protocol to NHBChain's mission of expanding access to credit for unbanked communities.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+Visit http://localhost:3000 to explore the landing page, and use the navigation to jump between the Earn and Borrow flows.
+
+> **Tip:** The component structure mirrors the walkthrough in the [NHBChain Lending developer guide](../../docs/), making it easy to align the UI with the accompanying documentation and RPC examples.
+
+## Project Structure
+
+- `pages/index.tsx` — Landing page with a summary, call to action, and links to docs.
+- `pages/earn.tsx` — Earn flow with mock state management for supply and withdraw actions.
+- `pages/borrow.tsx` — Borrow flow demonstrating collateral, borrowing, repayment, and fee recipient entry.
+- `components/` — Reusable UI primitives (cards, layout, and forms).
+- `lib/mockData.ts` — Mock data to make the example interactive without deploying contracts.
+
+The mock state flows can be swapped for real NHBChain RPC calls when you are ready to integrate with the chain.
+
+## Production Considerations
+
+- Integrate real wallet authentication (e.g., WalletConnect or custom NHBChain wallets).
+- Replace the mock state hooks with real calls to the NHBChain RPC endpoints found in `/docs`.
+- Validate addresses before accepting them as developer fee recipients.
+- Add analytics to capture supply/borrow events and monitor liquidity health.
+
+## License
+
+This example inherits the root repository license.

--- a/examples/lending-dapp/components/BorrowForm.tsx
+++ b/examples/lending-dapp/components/BorrowForm.tsx
@@ -1,0 +1,116 @@
+import { FormEvent, useState } from 'react';
+import { formatNumber } from '../lib/utils';
+
+type Props = {
+  collateral: number;
+  debt: number;
+  healthFactor: number;
+  onDeposit(amount: number): void;
+  onBorrow(amount: number, feeRecipient: string): void;
+  onRepay(amount: number): void;
+};
+
+export function BorrowForm({ collateral, debt, healthFactor, onDeposit, onBorrow, onRepay }: Props) {
+  const [znHBAmount, setZnHBAmount] = useState('');
+  const [nhbAmount, setNhbAmount] = useState('');
+  const [feeRecipient, setFeeRecipient] = useState('');
+
+  const handleDeposit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsed = Number(znHBAmount);
+    if (!Number.isFinite(parsed) || parsed <= 0) return;
+    onDeposit(parsed);
+    setZnHBAmount('');
+  };
+
+  const handleBorrow = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsed = Number(nhbAmount);
+    if (!Number.isFinite(parsed) || parsed <= 0) return;
+    onBorrow(parsed, feeRecipient);
+    setNhbAmount('');
+  };
+
+  const handleRepay = () => {
+    const parsed = Number(nhbAmount);
+    if (!Number.isFinite(parsed) || parsed <= 0) return;
+    onRepay(parsed);
+    setNhbAmount('');
+  };
+
+  return (
+    <div className="card-grid">
+      <form className="form-card" onSubmit={handleDeposit}>
+        <div className="page-heading">
+          <span>Collateral</span>
+          <h1>Deposit ZNHB to unlock borrowing</h1>
+        </div>
+        <div className="form-section">
+          <label htmlFor="deposit">Deposit amount (ZNHB)</label>
+          <input
+            id="deposit"
+            placeholder="0.00"
+            type="number"
+            min="0"
+            step="0.01"
+            value={znHBAmount}
+            onChange={(event) => setZnHBAmount(event.target.value)}
+          />
+          <p className="helper-text">
+            Current collateral: <strong>{formatNumber(collateral)} ZNHB</strong>
+          </p>
+        </div>
+        <button className="button-primary" type="submit">
+          Deposit Collateral
+        </button>
+      </form>
+
+      <form className="form-card" onSubmit={handleBorrow}>
+        <div className="page-heading">
+          <span>Borrow</span>
+          <h1>Access NHB liquidity</h1>
+        </div>
+        <div className="form-section">
+          <label htmlFor="borrow">Borrow amount (NHB)</label>
+          <input
+            id="borrow"
+            placeholder="0.00"
+            type="number"
+            min="0"
+            step="0.01"
+            value={nhbAmount}
+            onChange={(event) => setNhbAmount(event.target.value)}
+          />
+        </div>
+        <div className="form-section">
+          <label htmlFor="feeRecipient">Developer fee recipient</label>
+          <input
+            id="feeRecipient"
+            placeholder="0x..."
+            value={feeRecipient}
+            onChange={(event) => setFeeRecipient(event.target.value)}
+          />
+          <p className="helper-text">
+            Demonstrates how the `lend_borrowNHBWithFee` endpoint shares revenue with your application.
+          </p>
+        </div>
+        <div className="stat-row">
+          <span>Health factor</span>
+          <strong>{healthFactor.toFixed(2)}</strong>
+        </div>
+        <div className="stat-row">
+          <span>Outstanding debt</span>
+          <strong>{formatNumber(debt)} NHB</strong>
+        </div>
+        <div className="inline-actions">
+          <button className="button-primary" type="submit">
+            Borrow with Fee
+          </button>
+          <button className="button-secondary" type="button" onClick={handleRepay}>
+            Repay Loan
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/examples/lending-dapp/components/EarnForm.tsx
+++ b/examples/lending-dapp/components/EarnForm.tsx
@@ -1,0 +1,69 @@
+import { FormEvent, useState } from 'react';
+import { formatNumber } from '../lib/utils';
+
+type Props = {
+  availableBalance: number;
+  suppliedBalance: number;
+  onSupply(amount: number): void;
+  onWithdraw(amount: number): void;
+};
+
+export function EarnForm({ availableBalance, suppliedBalance, onSupply, onWithdraw }: Props) {
+  const [amount, setAmount] = useState('');
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsed = Number(amount);
+    if (!Number.isFinite(parsed) || parsed <= 0) return;
+
+    const nativeEvent = event.nativeEvent as SubmitEvent;
+    const action = (nativeEvent.submitter as HTMLButtonElement | null)?.dataset.action;
+
+    if (action === 'supply') {
+      onSupply(parsed);
+    } else {
+      onWithdraw(parsed);
+    }
+    setAmount('');
+  };
+
+  return (
+    <form className="form-card" onSubmit={handleSubmit}>
+      <div className="page-heading">
+        <span>Earn Yield</span>
+        <h1>Supply NHB and accrue returns</h1>
+      </div>
+
+      <div className="form-section">
+        <label htmlFor="amount">Amount (NHB)</label>
+        <input
+          id="amount"
+          placeholder="0.00"
+          value={amount}
+          onChange={(event) => setAmount(event.target.value)}
+          type="number"
+          min="0"
+          step="0.01"
+        />
+        <p className="helper-text">
+          Available balance: <strong>{formatNumber(availableBalance)} NHB</strong>
+        </p>
+      </div>
+
+      <div className="form-section">
+        <p className="helper-text">
+          Total supplied to the pool: <strong>{formatNumber(suppliedBalance)} NHB</strong>
+        </p>
+      </div>
+
+      <div className="inline-actions">
+        <button className="button-primary" type="submit" data-action="supply">
+          Supply
+        </button>
+        <button className="button-secondary" type="submit" data-action="withdraw">
+          Withdraw
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/examples/lending-dapp/components/Layout.tsx
+++ b/examples/lending-dapp/components/Layout.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { ReactNode } from 'react';
+
+const navLinks = [
+  { href: '/', label: 'Overview' },
+  { href: '/earn', label: 'Earn' },
+  { href: '/borrow', label: 'Borrow' }
+];
+
+export default function Layout({ children }: { children: ReactNode }) {
+  const router = useRouter();
+
+  return (
+    <>
+      <nav className="navbar">
+        <Link href="/">
+          <strong>NHBChain Lending</strong>
+        </Link>
+        <div className="nav-links">
+          {navLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`nav-link${router.pathname === link.href ? ' active' : ''}`}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </nav>
+      <main>{children}</main>
+    </>
+  );
+}

--- a/examples/lending-dapp/components/StatCard.tsx
+++ b/examples/lending-dapp/components/StatCard.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+type StatCardProps = {
+  label: string;
+  value: ReactNode;
+  helper?: string;
+};
+
+export function StatCard({ label, value, helper }: StatCardProps) {
+  return (
+    <div className="info-card">
+      <h3>{label}</h3>
+      <div style={{ fontSize: '1.5rem', fontWeight: 700 }}>{value}</div>
+      {helper && <p>{helper}</p>}
+    </div>
+  );
+}

--- a/examples/lending-dapp/lib/mockData.ts
+++ b/examples/lending-dapp/lib/mockData.ts
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { clamp } from './utils';
+
+const MAX_UTILIZATION = 0.75;
+const LIQUIDATION_THRESHOLD = 0.85;
+
+export function useEarnState() {
+  const [availableBalance, setAvailableBalance] = useState(5400);
+  const [suppliedBalance, setSuppliedBalance] = useState(2600);
+
+  const supply = (amount: number) => {
+    setAvailableBalance((prev) => clamp(prev - amount, 0, Number.MAX_SAFE_INTEGER));
+    setSuppliedBalance((prev) => prev + amount);
+  };
+
+  const withdraw = (amount: number) => {
+    setSuppliedBalance((prev) => clamp(prev - amount, 0, Number.MAX_SAFE_INTEGER));
+    setAvailableBalance((prev) => prev + amount);
+  };
+
+  return { availableBalance, suppliedBalance, supply, withdraw };
+}
+
+export function useBorrowState() {
+  const [collateral, setCollateral] = useState(1200);
+  const [debt, setDebt] = useState(420);
+
+  const deposit = (amount: number) => {
+    setCollateral((prev) => prev + amount);
+  };
+
+  const borrow = (amount: number) => {
+    setDebt((prev) => prev + amount);
+  };
+
+  const repay = (amount: number) => {
+    setDebt((prev) => clamp(prev - amount, 0, Number.MAX_SAFE_INTEGER));
+  };
+
+  const healthFactor = calculateHealthFactor(collateral, debt);
+
+  return { collateral, debt, deposit, borrow, repay, healthFactor };
+}
+
+function calculateHealthFactor(collateral: number, debt: number) {
+  if (debt === 0) return 5;
+  const utilization = debt / Math.max(collateral, 1);
+  const ratio = 1 - utilization / MAX_UTILIZATION;
+  const score = 2 + ratio * 2;
+  return clamp(score, 0.1, 5);
+}
+
+export function getBorrowInsights(collateral: number) {
+  const maxBorrow = collateral * MAX_UTILIZATION;
+  const liquidationPrice = collateral * LIQUIDATION_THRESHOLD;
+  return {
+    maxBorrow,
+    liquidationPrice
+  };
+}

--- a/examples/lending-dapp/lib/utils.ts
+++ b/examples/lending-dapp/lib/utils.ts
@@ -1,0 +1,10 @@
+export function formatNumber(value: number) {
+  return value.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+}
+
+export function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}

--- a/examples/lending-dapp/next-env.d.ts
+++ b/examples/lending-dapp/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/lending-dapp/next.config.js
+++ b/examples/lending-dapp/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/examples/lending-dapp/package-lock.json
+++ b/examples/lending-dapp/package-lock.json
@@ -1,0 +1,514 @@
+{
+  "name": "nhb-lending-dapp-example",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nhb-lending-dapp-example",
+      "version": "0.1.0",
+      "dependencies": {
+        "next": "13.5.6",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "20.11.19",
+        "@types/react": "18.2.42",
+        "@types/react-dom": "18.2.17",
+        "typescript": "5.3.3"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
+      "integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz",
+      "integrity": "sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz",
+      "integrity": "sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz",
+      "integrity": "sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz",
+      "integrity": "sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
+      "integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz",
+      "integrity": "sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz",
+      "integrity": "sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz",
+      "integrity": "sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz",
+      "integrity": "sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
+      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.42",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.42.tgz",
+      "integrity": "sha512-c1zEr96MjakLYus/wPnuWDo1/zErfdU9rNsIGmE+NV71nx88FG9Ttgo5dqorXTu/LImX2f63WBP986gJkMPNbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
+      "integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001745",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
+      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.5.6.tgz",
+      "integrity": "sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "13.5.6",
+        "@swc/helpers": "0.5.2",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001406",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "13.5.6",
+        "@next/swc-darwin-x64": "13.5.6",
+        "@next/swc-linux-arm64-gnu": "13.5.6",
+        "@next/swc-linux-arm64-musl": "13.5.6",
+        "@next/swc-linux-x64-gnu": "13.5.6",
+        "@next/swc-linux-x64-musl": "13.5.6",
+        "@next/swc-win32-arm64-msvc": "13.5.6",
+        "@next/swc-win32-ia32-msvc": "13.5.6",
+        "@next/swc-win32-x64-msvc": "13.5.6"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  }
+}

--- a/examples/lending-dapp/package.json
+++ b/examples/lending-dapp/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "nhb-lending-dapp-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.19",
+    "@types/react": "18.2.42",
+    "@types/react-dom": "18.2.17",
+    "typescript": "5.3.3"
+  }
+}

--- a/examples/lending-dapp/pages/_app.tsx
+++ b/examples/lending-dapp/pages/_app.tsx
@@ -1,0 +1,18 @@
+import type { AppProps } from 'next/app';
+import Head from 'next/head';
+import Layout from '../components/Layout';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <Head>
+        <title>NHBChain Lending Example</title>
+        <meta name="description" content="Reference implementation for the NHBChain lending flows." />
+      </Head>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </>
+  );
+}

--- a/examples/lending-dapp/pages/borrow.tsx
+++ b/examples/lending-dapp/pages/borrow.tsx
@@ -1,0 +1,83 @@
+import Head from 'next/head';
+import { BorrowForm } from '../components/BorrowForm';
+import { StatCard } from '../components/StatCard';
+import { getBorrowInsights, useBorrowState } from '../lib/mockData';
+import { formatNumber } from '../lib/utils';
+
+export default function BorrowPage() {
+  const { collateral, debt, deposit, borrow, repay, healthFactor } = useBorrowState();
+  const insights = getBorrowInsights(collateral);
+
+  return (
+    <>
+      <Head>
+        <title>Borrow | NHBChain Lending</title>
+      </Head>
+      <section className="page-heading">
+        <span>Access Credit</span>
+        <h1>Borrow NHB against your ZNHB</h1>
+        <p className="section-description">
+          CODEx — LEND-UI-1 maps directly to this page. Use the developer fee recipient field to wire your monetization strategy
+          into the `lend_borrowNHBWithFee` endpoint and ship a sustainable lending product.
+        </p>
+      </section>
+
+      <BorrowForm
+        collateral={collateral}
+        debt={debt}
+        healthFactor={healthFactor}
+        onDeposit={deposit}
+        onBorrow={(amount, feeRecipient) => {
+          console.info('Borrow with fee', { amount, feeRecipient });
+          borrow(amount);
+        }}
+        onRepay={(amount) => {
+          console.info('Repay loan', { amount });
+          repay(amount);
+        }}
+      />
+
+      <section style={{ marginTop: 48 }}>
+        <h2 className="section-title">Borrower insights</h2>
+        <div className="info-grid">
+          <StatCard
+            label="Maximum borrowable NHB"
+            value={`${formatNumber(insights.maxBorrow)} NHB`}
+            helper="Calculated from the 75% utilization target."
+          />
+          <StatCard
+            label="Liquidation threshold"
+            value={`${formatNumber(insights.liquidationPrice)} ZNHB`}
+            helper="If collateral falls below this level you should prompt the borrower to top up."
+          />
+          <StatCard
+            label="Mission impact"
+            value="Empowering the Unbanked"
+            helper="Your app can extend fair, permissionless credit rails to local communities who lack traditional banking."
+          />
+        </div>
+      </section>
+
+      <section style={{ marginTop: 48 }}>
+        <h2 className="section-title">Implementation notes</h2>
+        <div className="info-grid">
+          <StatCard
+            label="Borrow with fee"
+            value={<code>lend_borrowNHBWithFee</code>}
+            helper="Send the developer's fee recipient address along with the borrow transaction."
+          />
+          <StatCard
+            label="Collateral management"
+            value={<code>lend_depositZNHB</code>}
+            helper="Track the borrower's ZNHB collateralization level to protect against liquidation."
+          />
+          <StatCard
+            label="Risk monitoring"
+            value={<code>lend_getHealthFactor</code>}
+            helper="Surface proactive alerts and educational content when the health factor drops."
+          />
+        </div>
+      </section>
+    </>
+  );
+}

--- a/examples/lending-dapp/pages/earn.tsx
+++ b/examples/lending-dapp/pages/earn.tsx
@@ -1,0 +1,73 @@
+import Head from 'next/head';
+import { EarnForm } from '../components/EarnForm';
+import { StatCard } from '../components/StatCard';
+import { useEarnState } from '../lib/mockData';
+import { formatNumber } from '../lib/utils';
+
+export default function EarnPage() {
+  const { availableBalance, suppliedBalance, supply, withdraw } = useEarnState();
+
+  return (
+    <>
+      <Head>
+        <title>Earn | NHBChain Lending</title>
+      </Head>
+      <section className="page-heading">
+        <span>Provide Liquidity</span>
+        <h1>Earn sustainable NHB yield</h1>
+        <p className="section-description">
+          CODEx — LEND-UI-2 demonstrates how lenders supply and withdraw liquidity. Swap the mock state in this component for
+          real RPC calls to connect with NHBChain pool contracts.
+        </p>
+      </section>
+
+      <div className="card-grid">
+        <EarnForm
+          availableBalance={availableBalance}
+          suppliedBalance={suppliedBalance}
+          onSupply={supply}
+          onWithdraw={withdraw}
+        />
+        <div className="form-card" style={{ gap: '16px' }}>
+          <h2>Your pool position</h2>
+          <div className="stat-row">
+            <span>Wallet balance</span>
+            <strong>{formatNumber(availableBalance)} NHB</strong>
+          </div>
+          <div className="stat-row">
+            <span>Supplied to pool</span>
+            <strong>{formatNumber(suppliedBalance)} NHB</strong>
+          </div>
+          <div className="stat-row">
+            <span>Projected APY</span>
+            <strong>8.4%</strong>
+          </div>
+          <p className="helper-text">
+            This mock APY is configurable. In production, derive it from pool utilization or on-chain interest rate models.
+          </p>
+        </div>
+      </div>
+
+      <section style={{ marginTop: 48 }}>
+        <h2 className="section-title">Implementation notes</h2>
+        <div className="info-grid">
+          <StatCard
+            label="Supply RPC"
+            value={<code>lend_supplyNHB</code>}
+            helper="Invoke after wallet signature to increase pool liquidity."
+          />
+          <StatCard
+            label="Withdraw RPC"
+            value={<code>lend_withdrawNHB</code>}
+            helper="Subtracts liquidity from the pool while updating the lender share index."
+          />
+          <StatCard
+            label="Accounting"
+            value={<code>lend_getPosition</code>}
+            helper="Fetch balances and APY information to render this dashboard."
+          />
+        </div>
+      </section>
+    </>
+  );
+}

--- a/examples/lending-dapp/pages/index.tsx
+++ b/examples/lending-dapp/pages/index.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link';
+import { StatCard } from '../components/StatCard';
+
+const documentationLinks = [
+  {
+    label: 'Lending Developer Guide',
+    href: '/docs',
+    helper: 'Walkthrough of the lend, borrow, and repay RPC endpoints.'
+  },
+  {
+    label: 'RPC Reference',
+    href: '/docs/rpc',
+    helper: 'Complete API surface for interacting with NHBChain from custom dApps.'
+  },
+  {
+    label: 'Observability Playbooks',
+    href: '/observability',
+    helper: 'Monitor liquidity and borrower health across your deployment.'
+  }
+];
+
+export default function HomePage() {
+  return (
+    <>
+      <section className="hero">
+        <div className="hero-card">
+          <div className="tag">Phase 4 Reference Implementation</div>
+          <h1 className="hero-title">Empowering the unbanked with permissionless credit rails</h1>
+          <p className="hero-subtitle">
+            This lending protocol, built on NHBCoin, creates a transparent and inclusive credit system. Anyone with internet
+            access and ZNHB collateral can unlock NHB liquidity to grow their business, weather emergencies, or seize new
+            opportunities.
+          </p>
+          <div className="hero-actions">
+            <Link className="button-primary" href="/borrow">
+              Explore Borrow Flow
+            </Link>
+            <Link className="button-secondary" href="/earn">
+              Provide Liquidity
+            </Link>
+          </div>
+        </div>
+        <div className="hero-card" style={{ background: 'rgba(15, 23, 42, 0.86)' }}>
+          <h2>Why it matters</h2>
+          <p>
+            By leveraging non-traditional collateral and the `lend_borrowNHBWithFee` endpoint, developers can build local lending
+            desks that serve unbanked communities. Gig workers and creators turn their ZNHB stake into productive capital while
+            developers capture sustainable fees.
+          </p>
+          <ul style={{ paddingLeft: 20, color: 'var(--color-text-muted)' }}>
+            <li>Create access to credit without traditional banks or credit scores.</li>
+            <li>Accept ZNHB as collateral to unlock liquidity from network participation.</li>
+            <li>Launch permissionless lending businesses from anywhere in the world.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section style={{ marginTop: 60 }}>
+        <h2 className="section-title">Developer quick start</h2>
+        <p className="section-description">
+          Pair this Next.js project with the NHBChain docs to move from prototype to production. The code mirrors the structure of
+          the developer guide so you can swap mock state for real RPC calls as you integrate wallets and backend services.
+        </p>
+        <div className="info-grid">
+          {documentationLinks.map((link) => (
+            <StatCard
+              key={link.label}
+              label={link.label}
+              value={<Link href={link.href}>{link.href}</Link>}
+              helper={link.helper}
+            />
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/examples/lending-dapp/styles/globals.css
+++ b/examples/lending-dapp/styles/globals.css
@@ -1,0 +1,272 @@
+:root {
+  --color-bg: #0f172a;
+  --color-bg-muted: #1e293b;
+  --color-accent: #22d3ee;
+  --color-accent-strong: #0ea5e9;
+  --color-text: #f8fafc;
+  --color-text-muted: #cbd5f5;
+  --color-border: rgba(148, 163, 184, 0.4);
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+  --shadow-soft: 0 20px 45px rgba(15, 23, 42, 0.35);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  background: radial-gradient(circle at top left, rgba(34, 211, 238, 0.1), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.1), transparent 45%),
+    var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 24px 80px 24px;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px;
+}
+
+.nav-links {
+  display: flex;
+  gap: 16px;
+}
+
+.nav-link {
+  padding: 10px 18px;
+  border-radius: var(--radius-sm);
+  background: rgba(148, 163, 184, 0.12);
+  transition: background 0.2s ease;
+  font-weight: 500;
+}
+
+.nav-link:hover,
+.nav-link.active {
+  background: rgba(34, 211, 238, 0.2);
+  color: var(--color-text);
+}
+
+.hero {
+  margin-top: 48px;
+  display: grid;
+  gap: 32px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.hero-card {
+  background: linear-gradient(160deg, rgba(34, 211, 238, 0.18), rgba(14, 165, 233, 0.05));
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-title {
+  font-size: 2.6rem;
+  line-height: 1.1;
+  margin-bottom: 18px;
+}
+
+.hero-subtitle {
+  font-size: 1.1rem;
+  color: var(--color-text-muted);
+  margin-bottom: 32px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.button-primary,
+.button-secondary {
+  padding: 14px 26px;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button-primary {
+  background: linear-gradient(120deg, var(--color-accent-strong), var(--color-accent));
+  color: var(--color-bg);
+  box-shadow: 0 10px 25px rgba(14, 165, 233, 0.4);
+}
+
+.button-secondary {
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.button-primary:hover,
+.button-secondary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 25px rgba(14, 165, 233, 0.25);
+}
+
+.section-title {
+  font-size: 1.7rem;
+  margin-bottom: 12px;
+}
+
+.section-description {
+  color: var(--color-text-muted);
+  max-width: 720px;
+  margin-bottom: 28px;
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+}
+
+.info-card {
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.info-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.info-card p {
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.page-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 28px;
+}
+
+.page-heading span {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.75rem;
+  color: var(--color-accent);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.form-card {
+  background: rgba(15, 23, 42, 0.82);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.form-card h2 {
+  margin: 0;
+}
+
+.form-section {
+  display: grid;
+  gap: 12px;
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+input,
+select {
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.95);
+  color: var(--color-text);
+  font-size: 1rem;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.16);
+}
+
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.stat-row strong {
+  font-size: 1rem;
+}
+
+.inline-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(34, 211, 238, 0.16);
+  color: var(--color-accent);
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.helper-text {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 600px) {
+  .navbar {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .hero-title {
+    font-size: 2.2rem;
+  }
+}

--- a/examples/lending-dapp/tsconfig.json
+++ b/examples/lending-dapp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Next.js lending reference application in `examples/lending-dapp`
- implement CODEx earn and borrow flows with mock state, developer fee demo, and empowerment messaging
- document project setup and link back to NHBChain docs for integration guidance

## Testing
- npm run dev -- --hostname 0.0.0.0

------
https://chatgpt.com/codex/tasks/task_e_68d74541e8e0832db8e95e3619907f00