### PR TITLE
Implement lending RPC wiring and persistence

### DIFF
--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -16,6 +16,7 @@ import (
 	"nhbchain/consensus/bft"
 	"nhbchain/core"
 	"nhbchain/crypto"
+	"nhbchain/native/lending"
 	swap "nhbchain/native/swap"
 	"nhbchain/p2p"
 	"nhbchain/p2p/seeds"
@@ -108,6 +109,11 @@ func main() {
 	if err := node.SetPotsoWeightConfig(weightCfg); err != nil {
 		panic(fmt.Sprintf("Failed to apply POTSO weight config: %v", err))
 	}
+
+	node.SetLendingRiskParameters(lending.RiskParameters{
+		MaxLTV:               cfg.Lending.MaxLTVBps,
+		LiquidationThreshold: cfg.Lending.LiquidationThresholdBps,
+	})
 
 	swapCfg := cfg.SwapSettings()
 	node.SetSwapConfig(swapCfg)

--- a/crypto/keys.go
+++ b/crypto/keys.go
@@ -46,6 +46,11 @@ func (a Address) Bytes() []byte {
 	return a.bytes
 }
 
+// Prefix returns the human-readable prefix associated with the address.
+func (a Address) Prefix() AddressPrefix {
+	return a.prefix
+}
+
 func DecodeAddress(addrStr string) (Address, error) {
 	prefix, decoded, err := bech32.Decode(addrStr)
 	if err != nil {

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -290,25 +290,25 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleSwapVoucherReverse(w, r, req)
-	case "lend_getMarket":
+	case "lending_getMarket":
 		s.handleLendingGetMarket(w, r, req)
-	case "lend_getUserAccount":
+	case "lending_getUserAccount":
 		s.handleLendingGetUserAccount(w, r, req)
-	case "lend_supplyNHB":
+	case "lending_supplyNHB":
 		s.handleLendingSupplyNHB(w, r, req)
-	case "lend_withdrawNHB":
+	case "lending_withdrawNHB":
 		s.handleLendingWithdrawNHB(w, r, req)
-	case "lend_depositZNHB":
+	case "lending_depositZNHB":
 		s.handleLendingDepositZNHB(w, r, req)
-	case "lend_withdrawZNHB":
+	case "lending_withdrawZNHB":
 		s.handleLendingWithdrawZNHB(w, r, req)
-	case "lend_borrowNHB":
+	case "lending_borrowNHB":
 		s.handleLendingBorrowNHB(w, r, req)
-	case "lend_borrowNHBWithFee":
+	case "lending_borrowNHBWithFee":
 		s.handleLendingBorrowNHBWithFee(w, r, req)
-	case "lend_repayNHB":
+	case "lending_repayNHB":
 		s.handleLendingRepayNHB(w, r, req)
-	case "lend_liquidate":
+	case "lending_liquidate":
 		s.handleLendingLiquidate(w, r, req)
 	case "stake_delegate":
 		s.handleStakeDelegate(w, r, req)
@@ -523,6 +523,11 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeError(w, http.StatusNotFound, req.ID, codeMethodNotFound, fmt.Sprintf("unknown method %s", req.Method), nil)
 	}
+}
+
+// ServeHTTP allows the RPC server to satisfy the http.Handler interface for testing.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.handle(w, r)
 }
 
 // --- NEW HANDLER: Get Latest Blocks ---

--- a/rpc/modules/lending.go
+++ b/rpc/modules/lending.go
@@ -1,10 +1,19 @@
 package modules
 
 import (
+	"encoding/hex"
+	"fmt"
 	"math/big"
 	"net/http"
+	"strings"
+	"time"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	"nhbchain/core"
+	nhbstate "nhbchain/core/state"
+	"nhbchain/core/types"
+	"nhbchain/crypto"
 	"nhbchain/native/lending"
 )
 
@@ -17,45 +26,312 @@ func NewLendingModule(node *core.Node) *LendingModule {
 }
 
 func (m *LendingModule) moduleUnavailable() *ModuleError {
-	return &ModuleError{HTTPStatus: http.StatusNotImplemented, Code: codeServerError, Message: "lending module not available"}
+	return &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: "lending module not available"}
 }
 
 func (m *LendingModule) GetMarket() (*lending.Market, lending.RiskParameters, *ModuleError) {
-	return nil, lending.RiskParameters{}, m.moduleUnavailable()
+	if m == nil || m.node == nil {
+		return nil, lending.RiskParameters{}, m.moduleUnavailable()
+	}
+	params := m.node.LendingRiskParameters()
+	var market *lending.Market
+	err := m.node.WithState(func(manager *nhbstate.Manager) error {
+		stored, ok, err := manager.LendingGetMarket()
+		if err != nil {
+			return err
+		}
+		if ok {
+			market = stored
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, params, m.wrapError(err)
+	}
+	return market, params, nil
 }
 
-func (m *LendingModule) GetUserAccount(_ [20]byte) (*lending.UserAccount, *ModuleError) {
-	return nil, m.moduleUnavailable()
+func (m *LendingModule) GetUserAccount(addr [20]byte) (*lending.UserAccount, *ModuleError) {
+	if m == nil || m.node == nil {
+		return nil, m.moduleUnavailable()
+	}
+	var account *lending.UserAccount
+	err := m.node.WithState(func(manager *nhbstate.Manager) error {
+		stored, ok, err := manager.LendingGetUserAccount(addr)
+		if err != nil {
+			return err
+		}
+		if ok {
+			account = stored
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, m.wrapError(err)
+	}
+	return account, nil
 }
 
-func (m *LendingModule) SupplyNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
-	return "", m.moduleUnavailable()
+func (m *LendingModule) SupplyNHB(addr [20]byte, amount *big.Int) (string, *ModuleError) {
+	if m == nil || m.node == nil {
+		return "", m.moduleUnavailable()
+	}
+	var minted *big.Int
+	err := m.withEngine(func(engine *lending.Engine) error {
+		shares, err := engine.Supply(toCryptoAddress(addr), amount)
+		if err != nil {
+			return err
+		}
+		minted = shares
+		return nil
+	})
+	if err != nil {
+		return "", m.wrapError(err)
+	}
+	return m.makeTxHash("supply", formatHexAddress(addr), amount, minted), nil
 }
 
-func (m *LendingModule) WithdrawNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
-	return "", m.moduleUnavailable()
+func (m *LendingModule) WithdrawNHB(addr [20]byte, amount *big.Int) (string, *ModuleError) {
+	if m == nil || m.node == nil {
+		return "", m.moduleUnavailable()
+	}
+	var redeemed *big.Int
+	err := m.withEngine(func(engine *lending.Engine) error {
+		nhb, err := engine.Withdraw(toCryptoAddress(addr), amount)
+		if err != nil {
+			return err
+		}
+		redeemed = nhb
+		return nil
+	})
+	if err != nil {
+		return "", m.wrapError(err)
+	}
+	return m.makeTxHash("withdraw", formatHexAddress(addr), amount, redeemed), nil
 }
 
-func (m *LendingModule) DepositZNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
-	return "", m.moduleUnavailable()
+func (m *LendingModule) DepositZNHB(addr [20]byte, amount *big.Int) (string, *ModuleError) {
+	if m == nil || m.node == nil {
+		return "", m.moduleUnavailable()
+	}
+	err := m.withEngine(func(engine *lending.Engine) error {
+		return engine.DepositCollateral(toCryptoAddress(addr), amount)
+	})
+	if err != nil {
+		return "", m.wrapError(err)
+	}
+	return m.makeTxHash("deposit-collateral", formatHexAddress(addr), amount), nil
 }
 
-func (m *LendingModule) WithdrawZNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
-	return "", m.moduleUnavailable()
+func (m *LendingModule) WithdrawZNHB(addr [20]byte, amount *big.Int) (string, *ModuleError) {
+	if m == nil || m.node == nil {
+		return "", m.moduleUnavailable()
+	}
+	err := m.withEngine(func(engine *lending.Engine) error {
+		return engine.WithdrawCollateral(toCryptoAddress(addr), amount)
+	})
+	if err != nil {
+		return "", m.wrapError(err)
+	}
+	return m.makeTxHash("withdraw-collateral", formatHexAddress(addr), amount), nil
 }
 
-func (m *LendingModule) BorrowNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
-	return "", m.moduleUnavailable()
+func (m *LendingModule) BorrowNHB(addr [20]byte, amount *big.Int) (string, *ModuleError) {
+	if m == nil || m.node == nil {
+		return "", m.moduleUnavailable()
+	}
+	var fee *big.Int
+	err := m.withEngine(func(engine *lending.Engine) error {
+		paidFee, err := engine.Borrow(toCryptoAddress(addr), amount, toCryptoAddress(addr), 0)
+		if err != nil {
+			return err
+		}
+		fee = paidFee
+		return nil
+	})
+	if err != nil {
+		return "", m.wrapError(err)
+	}
+	return m.makeTxHash("borrow", formatHexAddress(addr), amount, fee), nil
 }
 
-func (m *LendingModule) BorrowNHBWithFee(_ [20]byte, _ *big.Int, _ [20]byte, _ uint64) (string, *ModuleError) {
-	return "", m.moduleUnavailable()
+func (m *LendingModule) BorrowNHBWithFee(borrower [20]byte, amount *big.Int, recipient [20]byte, feeBps uint64) (string, *ModuleError) {
+	if m == nil || m.node == nil {
+		return "", m.moduleUnavailable()
+	}
+	var fee *big.Int
+	err := m.withEngine(func(engine *lending.Engine) error {
+		paidFee, err := engine.Borrow(toCryptoAddress(borrower), amount, toCryptoAddress(recipient), feeBps)
+		if err != nil {
+			return err
+		}
+		fee = paidFee
+		return nil
+	})
+	if err != nil {
+		return "", m.wrapError(err)
+	}
+	primary := fmt.Sprintf("%s:%s", formatHexAddress(borrower), formatHexAddress(recipient))
+	return m.makeTxHash("borrow-with-fee", primary, amount, fee, big.NewInt(int64(feeBps))), nil
 }
 
-func (m *LendingModule) RepayNHB(_ [20]byte, _ *big.Int) (string, *ModuleError) {
-	return "", m.moduleUnavailable()
+func (m *LendingModule) RepayNHB(addr [20]byte, amount *big.Int) (string, *ModuleError) {
+	if m == nil || m.node == nil {
+		return "", m.moduleUnavailable()
+	}
+	var repaid *big.Int
+	err := m.withEngine(func(engine *lending.Engine) error {
+		settled, err := engine.Repay(toCryptoAddress(addr), amount)
+		if err != nil {
+			return err
+		}
+		repaid = settled
+		return nil
+	})
+	if err != nil {
+		return "", m.wrapError(err)
+	}
+	return m.makeTxHash("repay", formatHexAddress(addr), amount, repaid), nil
 }
 
-func (m *LendingModule) Liquidate(_ [20]byte, _ [20]byte) (string, *ModuleError) {
-	return "", m.moduleUnavailable()
+func (m *LendingModule) Liquidate(liquidator [20]byte, borrower [20]byte) (string, *ModuleError) {
+	if m == nil || m.node == nil {
+		return "", m.moduleUnavailable()
+	}
+	var repaid, seized *big.Int
+	err := m.withEngine(func(engine *lending.Engine) error {
+		debt, collateral, err := engine.Liquidate(toCryptoAddress(liquidator), toCryptoAddress(borrower))
+		if err != nil {
+			return err
+		}
+		repaid = debt
+		seized = collateral
+		return nil
+	})
+	if err != nil {
+		return "", m.wrapError(err)
+	}
+	primary := fmt.Sprintf("%s:%s", formatHexAddress(liquidator), formatHexAddress(borrower))
+	return m.makeTxHash("liquidate", primary, repaid, seized), nil
+}
+
+func (m *LendingModule) withEngine(fn func(*lending.Engine) error) error {
+	if fn == nil {
+		return fmt.Errorf("lending: callback required")
+	}
+	return m.node.WithState(func(manager *nhbstate.Manager) error {
+		engine := lending.NewEngine(m.node.LendingModuleAddress(), m.node.LendingCollateralAddress(), m.node.LendingRiskParameters())
+		engine.SetState(&lendingStateAdapter{manager: manager})
+		return fn(engine)
+	})
+}
+
+func (m *LendingModule) makeTxHash(kind, primary string, amount *big.Int, extras ...*big.Int) string {
+	parts := []string{kind, primary}
+	if amount != nil {
+		parts = append(parts, amount.String())
+	}
+	for _, extra := range extras {
+		if extra != nil {
+			parts = append(parts, extra.String())
+		}
+	}
+	parts = append(parts, fmt.Sprintf("%d", m.node.GetHeight()))
+	parts = append(parts, fmt.Sprintf("%d", time.Now().UTC().UnixNano()))
+	payload := strings.Join(parts, "|")
+	hash := ethcrypto.Keccak256([]byte(payload))
+	return "0x" + hex.EncodeToString(hash)
+}
+
+func (m *LendingModule) wrapError(err error) *ModuleError {
+	if err == nil {
+		return nil
+	}
+	status := http.StatusInternalServerError
+	code := codeServerError
+	message := err.Error()
+	if strings.HasPrefix(message, "lending engine:") {
+		status = http.StatusBadRequest
+		code = codeInvalidParams
+	}
+	return &ModuleError{HTTPStatus: status, Code: code, Message: message}
+}
+
+func toCryptoAddress(raw [20]byte) crypto.Address {
+	return crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), raw[:]...))
+}
+
+func formatHexAddress(raw [20]byte) string {
+	return hex.EncodeToString(raw[:])
+}
+
+type lendingStateAdapter struct {
+	manager *nhbstate.Manager
+}
+
+func (a *lendingStateAdapter) GetMarket() (*lending.Market, error) {
+	if a == nil || a.manager == nil {
+		return nil, fmt.Errorf("lending: state manager unavailable")
+	}
+	market, ok, err := a.manager.LendingGetMarket()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	return market, nil
+}
+
+func (a *lendingStateAdapter) PutMarket(market *lending.Market) error {
+	if a == nil || a.manager == nil {
+		return fmt.Errorf("lending: state manager unavailable")
+	}
+	return a.manager.LendingPutMarket(market)
+}
+
+func (a *lendingStateAdapter) GetUserAccount(addr crypto.Address) (*lending.UserAccount, error) {
+	if a == nil || a.manager == nil {
+		return nil, fmt.Errorf("lending: state manager unavailable")
+	}
+	var raw [20]byte
+	copy(raw[:], addr.Bytes())
+	account, ok, err := a.manager.LendingGetUserAccount(raw)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	if account.Address.Bytes() == nil {
+		account.Address = addr
+	}
+	return account, nil
+}
+
+func (a *lendingStateAdapter) PutUserAccount(account *lending.UserAccount) error {
+	if a == nil || a.manager == nil {
+		return fmt.Errorf("lending: state manager unavailable")
+	}
+	if account == nil {
+		return fmt.Errorf("lending: user account must not be nil")
+	}
+	return a.manager.LendingPutUserAccount(account)
+}
+
+func (a *lendingStateAdapter) GetAccount(addr crypto.Address) (*types.Account, error) {
+	if a == nil || a.manager == nil {
+		return nil, fmt.Errorf("lending: state manager unavailable")
+	}
+	return a.manager.GetAccount(addr.Bytes())
+}
+
+func (a *lendingStateAdapter) PutAccount(addr crypto.Address, account *types.Account) error {
+	if a == nil || a.manager == nil {
+		return fmt.Errorf("lending: state manager unavailable")
+	}
+	if account == nil {
+		return fmt.Errorf("lending: account must not be nil")
+	}
+	return a.manager.PutAccount(addr.Bytes(), account)
 }

--- a/tests/e2e/lending_rpc_test.go
+++ b/tests/e2e/lending_rpc_test.go
@@ -1,0 +1,277 @@
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"nhbchain/core"
+	nhbstate "nhbchain/core/state"
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	"nhbchain/native/lending"
+	"nhbchain/rpc"
+	"nhbchain/storage"
+)
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *rpcError       `json:"error"`
+}
+
+type rpcError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+func TestLendingRPCEndpoints(t *testing.T) {
+	token := "test-token"
+	t.Setenv("NHB_RPC_TOKEN", token)
+
+	db := storage.NewMemDB()
+	t.Cleanup(func() { db.Close() })
+
+	validatorKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key: %v", err)
+	}
+
+	node, err := core.NewNode(db, validatorKey, "", true)
+	if err != nil {
+		t.Fatalf("new node: %v", err)
+	}
+
+	risk := lending.RiskParameters{MaxLTV: 7500, LiquidationThreshold: 8000, LiquidationBonus: 500}
+	node.SetLendingRiskParameters(risk)
+
+	userKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("user key: %v", err)
+	}
+	userAddr := userKey.PubKey().Address()
+	feeKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("fee key: %v", err)
+	}
+	feeAddr := feeKey.PubKey().Address()
+
+	liquidatorKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("liquidator key: %v", err)
+	}
+	liquidatorAddr := liquidatorKey.PubKey().Address()
+
+	borrowerKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("borrower key: %v", err)
+	}
+	borrowerAddr := borrowerKey.PubKey().Address()
+
+	if err := seedLendingState(node, userAddr, liquidatorAddr, borrowerAddr); err != nil {
+		t.Fatalf("seed lending state: %v", err)
+	}
+
+	server := rpc.NewServer(node)
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+
+	client := ts.Client()
+
+	marketResp := callRPC(t, client, ts.URL, token, "lending_getMarket", nil)
+	var marketResult struct {
+		RiskParameters lending.RiskParameters `json:"riskParameters"`
+	}
+	if err := json.Unmarshal(marketResp.Result, &marketResult); err != nil {
+		t.Fatalf("decode market: %v", err)
+	}
+	if marketResult.RiskParameters.MaxLTV != risk.MaxLTV || marketResult.RiskParameters.LiquidationThreshold != risk.LiquidationThreshold {
+		t.Fatalf("unexpected risk parameters: %+v", marketResult.RiskParameters)
+	}
+
+	userAddrStr := userAddr.String()
+	feeAddrStr := feeAddr.String()
+
+	callRPC(t, client, ts.URL, token, "lending_supplyNHB", map[string]string{"from": userAddrStr, "amount": "1000"})
+	callRPC(t, client, ts.URL, token, "lending_depositZNHB", map[string]string{"from": userAddrStr, "amount": "600"})
+	callRPC(t, client, ts.URL, token, "lending_borrowNHB", map[string]string{"borrower": userAddrStr, "amount": "400"})
+	callRPC(t, client, ts.URL, token, "lending_repayNHB", map[string]string{"from": userAddrStr, "amount": "400"})
+	callRPC(t, client, ts.URL, token, "lending_borrowNHBWithFee", map[string]interface{}{"borrower": userAddrStr, "amount": "100", "feeRecipient": feeAddrStr, "feeBps": 100})
+	callRPC(t, client, ts.URL, token, "lending_repayNHB", map[string]string{"from": userAddrStr, "amount": "100"})
+	callRPC(t, client, ts.URL, token, "lending_withdrawNHB", map[string]string{"from": userAddrStr, "amount": "500"})
+	callRPC(t, client, ts.URL, token, "lending_withdrawZNHB", map[string]string{"from": userAddrStr, "amount": "300"})
+
+	accountResp := callRPC(t, client, ts.URL, token, "lending_getUserAccount", userAddrStr)
+	var accountResult struct {
+		Account struct {
+			CollateralZNHB *big.Int `json:"collateralZNHB"`
+			SupplyShares   *big.Int `json:"supplyShares"`
+			DebtNHB        *big.Int `json:"debtNHB"`
+		} `json:"account"`
+	}
+	if err := json.Unmarshal(accountResp.Result, &accountResult); err != nil {
+		t.Fatalf("decode account: %v", err)
+	}
+	if accountResult.Account.SupplyShares == nil || accountResult.Account.SupplyShares.String() != "500" {
+		t.Fatalf("unexpected supply shares: %v", accountResult.Account.SupplyShares)
+	}
+	if accountResult.Account.CollateralZNHB == nil || accountResult.Account.CollateralZNHB.String() != "300" {
+		t.Fatalf("unexpected collateral: %v", accountResult.Account.CollateralZNHB)
+	}
+	if accountResult.Account.DebtNHB == nil || accountResult.Account.DebtNHB.Sign() != 0 {
+		t.Fatalf("expected zero debt, got %v", accountResult.Account.DebtNHB)
+	}
+
+	callRPC(t, client, ts.URL, token, "lending_liquidate", map[string]string{"liquidator": liquidatorAddr.String(), "borrower": borrowerAddr.String()})
+
+	borrowerResp := callRPC(t, client, ts.URL, token, "lending_getUserAccount", borrowerAddr.String())
+	var borrowerResult struct {
+		Account struct {
+			CollateralZNHB *big.Int `json:"collateralZNHB"`
+			DebtNHB        *big.Int `json:"debtNHB"`
+		} `json:"account"`
+	}
+	if err := json.Unmarshal(borrowerResp.Result, &borrowerResult); err != nil {
+		t.Fatalf("decode borrower: %v", err)
+	}
+	if borrowerResult.Account.DebtNHB == nil || borrowerResult.Account.DebtNHB.Sign() != 0 {
+		t.Fatalf("expected borrower debt cleared, got %v", borrowerResult.Account.DebtNHB)
+	}
+	if borrowerResult.Account.CollateralZNHB == nil || borrowerResult.Account.CollateralZNHB.Cmp(big.NewInt(150)) >= 0 {
+		t.Fatalf("expected borrower collateral reduced, got %v", borrowerResult.Account.CollateralZNHB)
+	}
+
+	err = node.WithState(func(manager *nhbstate.Manager) error {
+		liquidatorAccount, accErr := manager.GetAccount(liquidatorAddr.Bytes())
+		if accErr != nil {
+			return accErr
+		}
+		if liquidatorAccount.BalanceZNHB.Sign() == 0 {
+			t.Fatalf("expected liquidator to receive collateral")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("verify liquidator: %v", err)
+	}
+}
+
+func seedLendingState(node *core.Node, userAddr, liquidatorAddr, borrowerAddr crypto.Address) error {
+	return node.WithState(func(manager *nhbstate.Manager) error {
+		userAccount := &types.Account{BalanceNHB: big.NewInt(2000), BalanceZNHB: big.NewInt(1000)}
+		if err := manager.PutAccount(userAddr.Bytes(), userAccount); err != nil {
+			return err
+		}
+
+		moduleAddr := node.LendingModuleAddress()
+		moduleAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0)}
+		if err := manager.PutAccount(moduleAddr.Bytes(), moduleAccount); err != nil {
+			return err
+		}
+
+		collateralAddr := node.LendingCollateralAddress()
+		collateralAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0)}
+		if err := manager.PutAccount(collateralAddr.Bytes(), collateralAccount); err != nil {
+			return err
+		}
+
+		liquidatorAccount := &types.Account{BalanceNHB: big.NewInt(500), BalanceZNHB: big.NewInt(0)}
+		if err := manager.PutAccount(liquidatorAddr.Bytes(), liquidatorAccount); err != nil {
+			return err
+		}
+
+		borrowerAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0)}
+		if err := manager.PutAccount(borrowerAddr.Bytes(), borrowerAccount); err != nil {
+			return err
+		}
+
+		market := &lending.Market{}
+		if err := manager.LendingPutMarket(market); err != nil {
+			return err
+		}
+
+		unhealthy := &lending.UserAccount{
+			Address:        borrowerAddr,
+			CollateralZNHB: big.NewInt(100),
+			DebtNHB:        big.NewInt(120),
+			ScaledDebt:     big.NewInt(120),
+		}
+		if err := manager.LendingPutUserAccount(unhealthy); err != nil {
+			return err
+		}
+
+		updatedMarket, ok, err := manager.LendingGetMarket()
+		if err != nil {
+			return err
+		}
+		if !ok || updatedMarket == nil {
+			updatedMarket = &lending.Market{}
+		}
+		updatedMarket.TotalNHBBorrowed = big.NewInt(120)
+		updatedMarket.TotalNHBSupplied = big.NewInt(500)
+		if err := manager.LendingPutMarket(updatedMarket); err != nil {
+			return err
+		}
+		collateralAccount.BalanceZNHB = new(big.Int).Add(collateralAccount.BalanceZNHB, big.NewInt(100))
+		if err := manager.PutAccount(collateralAddr.Bytes(), collateralAccount); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func callRPC(t *testing.T, client *http.Client, url, token, method string, params interface{}) rpcResponse {
+	t.Helper()
+	payload := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+		"params":  []interface{}{},
+	}
+	switch v := params.(type) {
+	case nil:
+	case string:
+		payload["params"] = []interface{}{v}
+	default:
+		payload["params"] = []interface{}{v}
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("rpc request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status %d for method %s: %s", resp.StatusCode, method, string(bodyBytes))
+	}
+
+	var parsed rpcResponse
+	if err := json.Unmarshal(bodyBytes, &parsed); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if parsed.Error != nil {
+		t.Fatalf("rpc error for %s: %+v", method, parsed.Error)
+	}
+	return parsed
+}


### PR DESCRIPTION
## Summary
- wire the lending RPC module into the native engine and expose deterministic module addresses
- persist lending market and user accounts via the state manager
- update lending documentation and add end-to-end RPC coverage

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d7498bf23c832d8365d33f4f652f33