### PR TITLE
Enforce configured developer fees for lending borrows

### DIFF
--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -113,7 +113,21 @@ func main() {
 	node.SetLendingRiskParameters(lending.RiskParameters{
 		MaxLTV:               cfg.Lending.MaxLTVBps,
 		LiquidationThreshold: cfg.Lending.LiquidationThresholdBps,
+		DeveloperFeeCapBps:   cfg.Lending.DeveloperFeeBps,
 	})
+
+	devCollectorStr := strings.TrimSpace(cfg.Lending.DeveloperFeeCollector)
+	var devCollector crypto.Address
+	if devCollectorStr != "" {
+		decoded, err := crypto.DecodeAddress(devCollectorStr)
+		if err != nil {
+			panic(fmt.Sprintf("Failed to decode lending developer fee collector: %v", err))
+		}
+		devCollector = decoded
+	} else if cfg.Lending.DeveloperFeeBps > 0 {
+		panic("Lending DeveloperFeeCollector must be configured when DeveloperFeeBps is non-zero")
+	}
+	node.SetLendingDeveloperFee(cfg.Lending.DeveloperFeeBps, devCollector)
 
 	swapCfg := cfg.SwapSettings()
 	node.SetSwapConfig(swapCfg)

--- a/docs/finance/lending/developer-guide.md
+++ b/docs/finance/lending/developer-guide.md
@@ -47,9 +47,12 @@ NHBChain using the JSON-RPC endpoints exposed by the node.
 - Compute projected health factors client-side before calling
   [`lending_borrowNHB`](rpc-api.md#lending_borrownhb). Block requests that would
   drive HF below 1.0 and warn users when the buffer is thin.
-- If your application charges a fee, route the borrow through
-  `lending_borrowNHBWithFee` and display the fee and net amount in the
-  confirmation modal. Fees are specified in basis points.
+- If your application charges a fee, coordinate with the node operator to set
+  `DeveloperFeeBps` and `DeveloperFeeCollector` in `config.toml`. The
+  `lending_borrowNHBWithFee` RPC automatically applies those trusted settings,
+  rejects caller-supplied fee parameters, and adds the deducted fee to the
+  borrower’s outstanding debt. Surface the configured fee rate in your UI so
+  borrowers understand the total obligation.
 
 ## 6. Repayment and Upkeep
 

--- a/docs/finance/lending/rpc-api.md
+++ b/docs/finance/lending/rpc-api.md
@@ -151,7 +151,8 @@ Borrow NHB against enabled collateral.
 
 ### `lending_borrowNHBWithFee`
 
-Borrow NHB while routing a fee (in basis points) to a third-party address.
+Borrow NHB while routing a governance-approved developer fee to the collector
+configured in the node’s `lending` settings.
 
 ```json
 {
@@ -159,16 +160,17 @@ Borrow NHB while routing a fee (in basis points) to a third-party address.
   "params": [
     {
       "borrower": "nhb1qyexample...",
-      "amount": "100000000000000000",
-      "feeRecipient": "nhb1qpartner...",
-      "feeBps": 100
+      "amount": "100000000000000000"
     }
   ]
 }
 ```
 
-The node transfers `amount * feeBps / 10_000` NHB to `feeRecipient` as part of
-the action.
+The endpoint rejects caller-supplied fee configuration. Instead, the node reads
+`DeveloperFeeBps` and `DeveloperFeeCollector` from `config.toml` and validates
+the collector against the governance treasury allow list. The fee amount is
+computed as `amount * DeveloperFeeBps / 10_000`, forwarded to the configured
+collector, and added to the borrower’s outstanding debt.
 
 ### `lending_repayNHB`
 

--- a/native/lending/types.go
+++ b/native/lending/types.go
@@ -67,4 +67,7 @@ type RiskParameters struct {
 	// CircuitBreakerActive signals whether new borrowing should be halted due
 	// to oracle issues or governance intervention.
 	CircuitBreakerActive bool
+	// DeveloperFeeCapBps bounds the developer fee that may be charged on
+	// `BorrowNHBWithFee` operations. A zero value disables developer fees.
+	DeveloperFeeCapBps uint64
 }

--- a/tests/e2e/lending_rpc_test.go
+++ b/tests/e2e/lending_rpc_test.go
@@ -48,7 +48,7 @@ func TestLendingRPCEndpoints(t *testing.T) {
 		t.Fatalf("new node: %v", err)
 	}
 
-	risk := lending.RiskParameters{MaxLTV: 7500, LiquidationThreshold: 8000, LiquidationBonus: 500}
+	risk := lending.RiskParameters{MaxLTV: 7500, LiquidationThreshold: 8000, LiquidationBonus: 500, DeveloperFeeCapBps: 100}
 	node.SetLendingRiskParameters(risk)
 
 	userKey, err := crypto.GeneratePrivateKey()
@@ -61,6 +61,7 @@ func TestLendingRPCEndpoints(t *testing.T) {
 		t.Fatalf("fee key: %v", err)
 	}
 	feeAddr := feeKey.PubKey().Address()
+	node.SetLendingDeveloperFee(100, feeAddr)
 
 	liquidatorKey, err := crypto.GeneratePrivateKey()
 	if err != nil {
@@ -96,14 +97,13 @@ func TestLendingRPCEndpoints(t *testing.T) {
 	}
 
 	userAddrStr := userAddr.String()
-	feeAddrStr := feeAddr.String()
 
 	callRPC(t, client, ts.URL, token, "lending_supplyNHB", map[string]string{"from": userAddrStr, "amount": "1000"})
 	callRPC(t, client, ts.URL, token, "lending_depositZNHB", map[string]string{"from": userAddrStr, "amount": "600"})
 	callRPC(t, client, ts.URL, token, "lending_borrowNHB", map[string]string{"borrower": userAddrStr, "amount": "400"})
 	callRPC(t, client, ts.URL, token, "lending_repayNHB", map[string]string{"from": userAddrStr, "amount": "400"})
-	callRPC(t, client, ts.URL, token, "lending_borrowNHBWithFee", map[string]interface{}{"borrower": userAddrStr, "amount": "100", "feeRecipient": feeAddrStr, "feeBps": 100})
-	callRPC(t, client, ts.URL, token, "lending_repayNHB", map[string]string{"from": userAddrStr, "amount": "100"})
+	callRPC(t, client, ts.URL, token, "lending_borrowNHBWithFee", map[string]interface{}{"borrower": userAddrStr, "amount": "100"})
+	callRPC(t, client, ts.URL, token, "lending_repayNHB", map[string]string{"from": userAddrStr, "amount": "101"})
 	callRPC(t, client, ts.URL, token, "lending_withdrawNHB", map[string]string{"from": userAddrStr, "amount": "500"})
 	callRPC(t, client, ts.URL, token, "lending_withdrawZNHB", map[string]string{"from": userAddrStr, "amount": "300"})
 


### PR DESCRIPTION
## Summary
- load the lending developer fee configuration from trusted settings and expose it through the node API with allow-list validation
- enforce governance fee caps inside the lending engine, add the developer fee to borrower debt, and reject user-supplied fee parameters
- refresh the lending RPC docs, developer guide, and end-to-end test to cover the new behaviour

## Testing
- go test ./...
- go test ./cmd/nhb ./core ./native/... ./rpc ./tests/e2e


------
https://chatgpt.com/codex/tasks/task_e_68d74e82a904832da29b809afc6b2571