### PR TITLE
Implement interest accrual and fee tracking in lending engine

### DIFF
--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -116,6 +116,8 @@ func main() {
 		DeveloperFeeCapBps:   cfg.Lending.DeveloperFeeBps,
 	})
 
+	node.SetLendingAccrualConfig(cfg.Lending.ReserveFactorBps, cfg.Lending.ProtocolFeeBps, lending.DefaultInterestModel)
+
 	devCollectorStr := strings.TrimSpace(cfg.Lending.DeveloperFeeCollector)
 	var devCollector crypto.Address
 	if devCollectorStr != "" {

--- a/docs/finance/lending/on-chain.md
+++ b/docs/finance/lending/on-chain.md
@@ -18,10 +18,11 @@ protocol applies a piecewise-linear interest rate curve:
   discourage further borrowing and incentivize more supply.
 
 Borrow interest is compounded each block by updating the borrow index. The
-supply rate is derived from the borrow rate using the reserve factor `r`:
+supply rate is derived from the borrow rate using the reserve factor `r` and the
+protocol fee share `p`:
 
 ```
-supplyRate = borrowRate * U * (1 - r)
+supplyRate = borrowRate * U * (1 - r - p)
 ```
 
 All rates are quoted per-second but can be accumulated to APRs for user-facing
@@ -30,16 +31,21 @@ interfaces.
 ## Interest Accrual Mechanics
 
 1. **Accrual Trigger:** Every market accrues interest during state-changing
-   operations (supply, redeem, borrow, repay, liquidation) or through explicit
-   `lend_accrueInterest` RPC calls.
+   operations (supply, withdraw, borrow, repay, liquidation, and collateral
+   withdrawals).
 2. **Borrow Index Update:** The protocol calculates the time delta since the
    last accrual and multiplies it by the current borrow rate to update the
    borrow index.
 3. **Reserve Growth:** A portion of the interest (based on the reserve factor)
-   is redirected to the protocol treasury account.
+   and the configured protocol fee share is redirected to the protocol fee
+   accrual.
 4. **Supplier Yield:** The remaining interest is distributed proportionally to
    suppliers by increasing the exchange rate between deposit receipts and the
    underlying asset.
+
+The protocol tracks protocol and developer fees in a `FeeAccrual` structure.
+Those balances can be withdrawn to external accounts, reducing the pool's
+reported liquidity while keeping historical accounting intact.
 
 ## Collateral Evaluation
 

--- a/native/lending/engine_accrual_test.go
+++ b/native/lending/engine_accrual_test.go
@@ -1,0 +1,174 @@
+package lending
+
+import (
+	"math/big"
+	"testing"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+type mockEngineState struct {
+	market   *Market
+	users    map[string]*UserAccount
+	accounts map[string]*types.Account
+	fees     *FeeAccrual
+}
+
+func newMockEngineState() *mockEngineState {
+	return &mockEngineState{
+		users:    make(map[string]*UserAccount),
+		accounts: make(map[string]*types.Account),
+	}
+}
+
+func (m *mockEngineState) key(addr crypto.Address) string {
+	return string(addr.Bytes())
+}
+
+func (m *mockEngineState) GetMarket() (*Market, error) {
+	return m.market, nil
+}
+
+func (m *mockEngineState) PutMarket(market *Market) error {
+	m.market = market
+	return nil
+}
+
+func (m *mockEngineState) GetUserAccount(addr crypto.Address) (*UserAccount, error) {
+	if acc, ok := m.users[m.key(addr)]; ok {
+		return acc, nil
+	}
+	return nil, nil
+}
+
+func (m *mockEngineState) PutUserAccount(account *UserAccount) error {
+	if account == nil {
+		return nil
+	}
+	m.users[m.key(account.Address)] = account
+	return nil
+}
+
+func (m *mockEngineState) GetAccount(addr crypto.Address) (*types.Account, error) {
+	if acc, ok := m.accounts[m.key(addr)]; ok {
+		if acc.BalanceNHB == nil {
+			acc.BalanceNHB = big.NewInt(0)
+		}
+		if acc.BalanceZNHB == nil {
+			acc.BalanceZNHB = big.NewInt(0)
+		}
+		return acc, nil
+	}
+	return nil, errInsufficientBalance
+}
+
+func (m *mockEngineState) PutAccount(addr crypto.Address, account *types.Account) error {
+	m.accounts[m.key(addr)] = account
+	return nil
+}
+
+func (m *mockEngineState) GetFeeAccrual() (*FeeAccrual, error) {
+	return m.fees, nil
+}
+
+func (m *mockEngineState) PutFeeAccrual(fees *FeeAccrual) error {
+	m.fees = fees
+	return nil
+}
+
+func makeAddress(prefix crypto.AddressPrefix, suffix byte) crypto.Address {
+	raw := make([]byte, 20)
+	raw[len(raw)-1] = suffix
+	return crypto.NewAddress(prefix, raw)
+}
+
+func TestAccrueInterestUpdatesIndexesAndFees(t *testing.T) {
+	moduleAddr := makeAddress(crypto.NHBPrefix, 0x01)
+	collateralAddr := makeAddress(crypto.ZNHBPrefix, 0x02)
+
+	engine := NewEngine(moduleAddr, collateralAddr, RiskParameters{})
+	engine.SetInterestModel(NewInterestModel(0, 1, 0, 1))
+	engine.SetReserveFactor(2000)
+	engine.SetProtocolFeeBps(1000)
+	engine.SetBlockHeight(blocksPerYear)
+
+	state := newMockEngineState()
+	market := &Market{
+		TotalNHBSupplied:  big.NewInt(1000),
+		TotalSupplyShares: big.NewInt(1000),
+		TotalNHBBorrowed:  big.NewInt(500),
+		SupplyIndex:       new(big.Int).Set(ray),
+		BorrowIndex:       new(big.Int).Set(ray),
+	}
+	state.market = market
+	engine.SetState(state)
+
+	fees, changed, err := engine.accrueInterest(market)
+	if err != nil {
+		t.Fatalf("accrue interest: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected accrual to change state")
+	}
+
+	expectedBorrowIndex := new(big.Int).Mul(ray, big.NewInt(3))
+	expectedBorrowIndex = expectedBorrowIndex.Quo(expectedBorrowIndex, big.NewInt(2))
+	if market.BorrowIndex.Cmp(expectedBorrowIndex) != 0 {
+		t.Fatalf("unexpected borrow index: got %s want %s", market.BorrowIndex, expectedBorrowIndex)
+	}
+
+	expectedSupplyIndex := new(big.Int).Mul(ray, big.NewInt(1175))
+	expectedSupplyIndex = expectedSupplyIndex.Quo(expectedSupplyIndex, big.NewInt(1000))
+	if market.SupplyIndex.Cmp(expectedSupplyIndex) != 0 {
+		t.Fatalf("unexpected supply index: got %s want %s", market.SupplyIndex, expectedSupplyIndex)
+	}
+
+	if market.TotalNHBBorrowed.Cmp(big.NewInt(750)) != 0 {
+		t.Fatalf("unexpected total borrowed: got %s", market.TotalNHBBorrowed)
+	}
+	if market.TotalNHBSupplied.Cmp(big.NewInt(1250)) != 0 {
+		t.Fatalf("unexpected total supplied: got %s", market.TotalNHBSupplied)
+	}
+
+	if fees == nil || fees.ProtocolFeesWei.Cmp(big.NewInt(75)) != 0 {
+		t.Fatalf("unexpected protocol fees: got %v", fees)
+	}
+}
+
+func TestWithdrawProtocolFees(t *testing.T) {
+	moduleAddr := makeAddress(crypto.NHBPrefix, 0x03)
+	collateralAddr := makeAddress(crypto.ZNHBPrefix, 0x04)
+	recipient := makeAddress(crypto.NHBPrefix, 0x05)
+
+	engine := NewEngine(moduleAddr, collateralAddr, RiskParameters{})
+	state := newMockEngineState()
+	state.market = &Market{TotalNHBSupplied: big.NewInt(500)}
+	state.accounts[state.key(moduleAddr)] = &types.Account{BalanceNHB: big.NewInt(400)}
+	state.accounts[state.key(recipient)] = &types.Account{BalanceNHB: big.NewInt(0)}
+	state.fees = &FeeAccrual{ProtocolFeesWei: big.NewInt(150), DeveloperFeesWei: big.NewInt(10)}
+	engine.SetState(state)
+
+	withdrawn, err := engine.WithdrawProtocolFees(recipient, big.NewInt(100))
+	if err != nil {
+		t.Fatalf("withdraw protocol fees: %v", err)
+	}
+	if withdrawn.Cmp(big.NewInt(100)) != 0 {
+		t.Fatalf("unexpected withdrawn amount: %s", withdrawn)
+	}
+
+	moduleAcc := state.accounts[state.key(moduleAddr)]
+	if moduleAcc.BalanceNHB.Cmp(big.NewInt(300)) != 0 {
+		t.Fatalf("unexpected module balance: %s", moduleAcc.BalanceNHB)
+	}
+	recipientAcc := state.accounts[state.key(recipient)]
+	if recipientAcc.BalanceNHB.Cmp(big.NewInt(100)) != 0 {
+		t.Fatalf("unexpected recipient balance: %s", recipientAcc.BalanceNHB)
+	}
+	if state.market.TotalNHBSupplied.Cmp(big.NewInt(400)) != 0 {
+		t.Fatalf("unexpected total supplied after withdraw: %s", state.market.TotalNHBSupplied)
+	}
+	if state.fees == nil || state.fees.ProtocolFeesWei.Cmp(big.NewInt(50)) != 0 {
+		t.Fatalf("unexpected protocol fees after withdraw: %v", state.fees)
+	}
+}

--- a/native/lending/interest.go
+++ b/native/lending/interest.go
@@ -18,6 +18,32 @@ type InterestModel struct {
 	Kink *big.Rat
 }
 
+// Clone returns a deep copy of the interest model.
+func (m *InterestModel) Clone() *InterestModel {
+	if m == nil {
+		return nil
+	}
+	clone := &InterestModel{
+		BaseRate: new(big.Rat),
+		Slope1:   new(big.Rat),
+		Slope2:   new(big.Rat),
+		Kink:     new(big.Rat),
+	}
+	if m.BaseRate != nil {
+		clone.BaseRate.Set(m.BaseRate)
+	}
+	if m.Slope1 != nil {
+		clone.Slope1.Set(m.Slope1)
+	}
+	if m.Slope2 != nil {
+		clone.Slope2.Set(m.Slope2)
+	}
+	if m.Kink != nil {
+		clone.Kink.Set(m.Kink)
+	}
+	return clone
+}
+
 // NewInterestModel constructs an interest model from floating point inputs.
 //
 // The parameters should be provided as decimals, e.g. a 2% base rate is


### PR DESCRIPTION
## Summary
- add an accrual routine that updates supply/borrow indexes, tracks protocol/developer fees, and supports withdrawing accrued protocol fees
- persist lending fee accruals in state, expose accrual configuration through the node and RPC adapter, and cover the new logic with unit tests
- document the revised accrual triggers and formulas in the lending guide

## Testing
- go test ./native/lending


------
https://chatgpt.com/codex/tasks/task_e_68d752ad5094832d8778c4164137d14d