### PR TITLE
Configure collateral routing for lending liquidations

### DIFF
--- a/docs/finance/lending/on-chain.md
+++ b/docs/finance/lending/on-chain.md
@@ -68,6 +68,25 @@ reported liquidity while keeping historical accounting intact.
 4. **Close Factor:** A maximum percentage of the outstanding borrow can be
    liquidated in a single transaction to prevent full wipeouts in thin markets.
 
+### Collateral Distribution
+
+Liquidation collateral is routed to multiple parties based on the node's
+`[lending.collateralRouting]` configuration. Operators can split the seized
+collateral between the liquidator, a developer recovery wallet, and a protocol
+reserve address:
+
+- `LiquidatorBps` — basis points paid to the liquidator.
+- `DeveloperBps` / `DeveloperAddress` — optional share routed to the
+  developer-controlled treasury. An address is required when the share is
+  non-zero.
+- `ProtocolBps` / `ProtocolAddress` — optional share allocated to the
+  protocol reserve wallet.
+
+The configured basis points must sum to at most 10,000 (100%). Any remainder is
+credited to the liquidator, ensuring they always receive the incentive bonus.
+If a share is non-zero but the destination address is missing, liquidations are
+rejected to avoid burning collateral.
+
 ## Risk Parameters
 
 All risk parameters (LTV, liquidation threshold, reserve factor, close factor,

--- a/native/lending/config.go
+++ b/native/lending/config.go
@@ -4,13 +4,24 @@ import "math/big"
 
 // Config captures the runtime configuration for the native lending module.
 type Config struct {
-	MaxLTVBps               uint64            `toml:"MaxLTVBps"`
-	LiquidationThresholdBps uint64            `toml:"LiquidationThresholdBps"`
-	ReserveFactorBps        uint64            `toml:"ReserveFactorBps"`
-	Breaker                 BreakerThresholds `toml:"breaker"`
-	ProtocolFeeBps          uint64            `toml:"ProtocolFeeBps"`
-	DeveloperFeeBps         uint64            `toml:"DeveloperFeeBps"`
-	DeveloperFeeCollector   string            `toml:"DeveloperFeeCollector"`
+	MaxLTVBps               uint64                  `toml:"MaxLTVBps"`
+	LiquidationThresholdBps uint64                  `toml:"LiquidationThresholdBps"`
+	ReserveFactorBps        uint64                  `toml:"ReserveFactorBps"`
+	Breaker                 BreakerThresholds       `toml:"breaker"`
+	ProtocolFeeBps          uint64                  `toml:"ProtocolFeeBps"`
+	DeveloperFeeBps         uint64                  `toml:"DeveloperFeeBps"`
+	DeveloperFeeCollector   string                  `toml:"DeveloperFeeCollector"`
+	CollateralRouting       CollateralRoutingConfig `toml:"collateralRouting"`
+}
+
+// CollateralRoutingConfig describes the default collateral distribution applied
+// during liquidations when a pool has not specified overrides.
+type CollateralRoutingConfig struct {
+	LiquidatorBps    uint64 `toml:"LiquidatorBps"`
+	DeveloperBps     uint64 `toml:"DeveloperBps"`
+	DeveloperAddress string `toml:"DeveloperAddress"`
+	ProtocolBps      uint64 `toml:"ProtocolBps"`
+	ProtocolAddress  string `toml:"ProtocolAddress"`
 }
 
 // BreakerThresholds describes the limit switches for disabling module flows.

--- a/native/lending/engine_liquidation_test.go
+++ b/native/lending/engine_liquidation_test.go
@@ -1,0 +1,138 @@
+package lending
+
+import (
+	"math/big"
+	"testing"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+func TestLiquidateRoutesCollateral(t *testing.T) {
+	moduleAddr := makeAddress(crypto.NHBPrefix, 0x10)
+	collateralAddr := makeAddress(crypto.ZNHBPrefix, 0x11)
+	liquidator := makeAddress(crypto.NHBPrefix, 0x20)
+	borrower := makeAddress(crypto.NHBPrefix, 0x21)
+	developer := makeAddress(crypto.ZNHBPrefix, 0x22)
+	protocol := makeAddress(crypto.ZNHBPrefix, 0x23)
+
+	engine := NewEngine(moduleAddr, collateralAddr, RiskParameters{
+		LiquidationThreshold: 7500,
+		LiquidationBonus:     1000,
+	})
+	engine.SetCollateralRouting(CollateralRouting{
+		LiquidatorBps:   7000,
+		DeveloperBps:    2000,
+		DeveloperTarget: developer,
+		ProtocolBps:     1000,
+		ProtocolTarget:  protocol,
+	})
+	engine.SetPoolID("default")
+
+	state := newMockEngineState()
+	state.market = &Market{
+		PoolID:           "default",
+		TotalNHBSupplied: big.NewInt(10_000),
+		TotalNHBBorrowed: big.NewInt(800),
+		SupplyIndex:      new(big.Int).Set(ray),
+		BorrowIndex:      new(big.Int).Set(ray),
+	}
+	state.accounts[state.key(moduleAddr)] = &types.Account{BalanceNHB: big.NewInt(0)}
+	state.accounts[state.key(collateralAddr)] = &types.Account{BalanceZNHB: big.NewInt(10_000)}
+	state.accounts[state.key(liquidator)] = &types.Account{BalanceNHB: big.NewInt(5_000), BalanceZNHB: big.NewInt(0)}
+	state.accounts[state.key(borrower)] = &types.Account{BalanceNHB: big.NewInt(0)}
+	state.accounts[state.key(developer)] = &types.Account{BalanceZNHB: big.NewInt(0)}
+	state.accounts[state.key(protocol)] = &types.Account{BalanceZNHB: big.NewInt(0)}
+
+	borrowerAccount := &UserAccount{
+		Address:        borrower,
+		CollateralZNHB: big.NewInt(1_000),
+		DebtNHB:        big.NewInt(800),
+		ScaledDebt:     big.NewInt(800),
+	}
+	state.users[state.key(borrower)] = borrowerAccount
+
+	engine.SetState(state)
+
+	repaid, seized, err := engine.Liquidate(liquidator, borrower)
+	if err != nil {
+		t.Fatalf("liquidate: %v", err)
+	}
+	if repaid.Cmp(big.NewInt(800)) != 0 {
+		t.Fatalf("unexpected repay amount: %s", repaid)
+	}
+	if seized.Cmp(big.NewInt(880)) != 0 {
+		t.Fatalf("unexpected seized amount: %s", seized)
+	}
+
+	liquidatorAcc := state.accounts[state.key(liquidator)]
+	if liquidatorAcc.BalanceZNHB.Cmp(big.NewInt(616)) != 0 {
+		t.Fatalf("unexpected liquidator collateral: %s", liquidatorAcc.BalanceZNHB)
+	}
+	developerAcc := state.accounts[state.key(developer)]
+	if developerAcc.BalanceZNHB.Cmp(big.NewInt(176)) != 0 {
+		t.Fatalf("unexpected developer collateral: %s", developerAcc.BalanceZNHB)
+	}
+	protocolAcc := state.accounts[state.key(protocol)]
+	if protocolAcc.BalanceZNHB.Cmp(big.NewInt(88)) != 0 {
+		t.Fatalf("unexpected protocol collateral: %s", protocolAcc.BalanceZNHB)
+	}
+
+	borrowerUser := state.users[state.key(borrower)]
+	if borrowerUser.DebtNHB.Sign() != 0 || borrowerUser.CollateralZNHB.Cmp(big.NewInt(120)) != 0 {
+		t.Fatalf("unexpected borrower state: debt=%s collateral=%s", borrowerUser.DebtNHB, borrowerUser.CollateralZNHB)
+	}
+	if state.market.TotalNHBBorrowed.Sign() != 0 {
+		t.Fatalf("expected borrowed total to reset, got %s", state.market.TotalNHBBorrowed)
+	}
+}
+
+func TestLiquidateRoutingValidation(t *testing.T) {
+	moduleAddr := makeAddress(crypto.NHBPrefix, 0x30)
+	collateralAddr := makeAddress(crypto.ZNHBPrefix, 0x31)
+	liquidator := makeAddress(crypto.NHBPrefix, 0x32)
+	borrower := makeAddress(crypto.NHBPrefix, 0x33)
+	developer := makeAddress(crypto.ZNHBPrefix, 0x34)
+
+	setup := func() *Engine {
+		engine := NewEngine(moduleAddr, collateralAddr, RiskParameters{
+			LiquidationThreshold: 7000,
+			LiquidationBonus:     500,
+		})
+		engine.SetPoolID("default")
+
+		state := newMockEngineState()
+		state.market = &Market{
+			PoolID:           "default",
+			TotalNHBSupplied: big.NewInt(1_000),
+			TotalNHBBorrowed: big.NewInt(500),
+			SupplyIndex:      new(big.Int).Set(ray),
+			BorrowIndex:      new(big.Int).Set(ray),
+		}
+		state.accounts[state.key(moduleAddr)] = &types.Account{BalanceNHB: big.NewInt(0)}
+		state.accounts[state.key(collateralAddr)] = &types.Account{BalanceZNHB: big.NewInt(5_000)}
+		state.accounts[state.key(liquidator)] = &types.Account{BalanceNHB: big.NewInt(600)}
+		state.accounts[state.key(borrower)] = &types.Account{}
+		state.accounts[state.key(developer)] = &types.Account{BalanceZNHB: big.NewInt(0)}
+		state.users[state.key(borrower)] = &UserAccount{
+			Address:        borrower,
+			CollateralZNHB: big.NewInt(500),
+			DebtNHB:        big.NewInt(500),
+			ScaledDebt:     big.NewInt(500),
+		}
+		engine.SetState(state)
+		return engine
+	}
+
+	engine := setup()
+	engine.SetCollateralRouting(CollateralRouting{DeveloperBps: 3000, ProtocolBps: 8000, DeveloperTarget: developer})
+	if _, _, err := engine.Liquidate(liquidator, borrower); err != errCollateralRoutingBps {
+		t.Fatalf("expected collateral routing bps error, got %v", err)
+	}
+
+	engine = setup()
+	engine.SetCollateralRouting(CollateralRouting{DeveloperBps: 1000})
+	if _, _, err := engine.Liquidate(liquidator, borrower); err != errDeveloperCollateral {
+		t.Fatalf("expected developer collateral error, got %v", err)
+	}
+}

--- a/native/lending/types.go
+++ b/native/lending/types.go
@@ -46,6 +46,33 @@ type Market struct {
 	ReserveFactor uint64
 }
 
+// CollateralRouting captures the liquidation collateral distribution between
+// the liquidator, developer, and protocol reserve accounts.
+type CollateralRouting struct {
+	LiquidatorBps   uint64
+	DeveloperBps    uint64
+	DeveloperTarget crypto.Address
+	ProtocolBps     uint64
+	ProtocolTarget  crypto.Address
+}
+
+// Clone produces a deep copy of the collateral routing configuration to ensure
+// callers do not mutate shared address slices.
+func (r CollateralRouting) Clone() CollateralRouting {
+	clone := CollateralRouting{
+		LiquidatorBps: r.LiquidatorBps,
+		DeveloperBps:  r.DeveloperBps,
+		ProtocolBps:   r.ProtocolBps,
+	}
+	if bytes := r.DeveloperTarget.Bytes(); len(bytes) != 0 {
+		clone.DeveloperTarget = crypto.NewAddress(r.DeveloperTarget.Prefix(), append([]byte(nil), bytes...))
+	}
+	if bytes := r.ProtocolTarget.Bytes(); len(bytes) != 0 {
+		clone.ProtocolTarget = crypto.NewAddress(r.ProtocolTarget.Prefix(), append([]byte(nil), bytes...))
+	}
+	return clone
+}
+
 // UserAccount maintains the lending position for an individual participant.
 type UserAccount struct {
 	// Address is the unique account identifier within the NHB network.

--- a/rpc/modules/lending.go
+++ b/rpc/modules/lending.go
@@ -327,6 +327,7 @@ func (m *LendingModule) withEngine(poolID string, fn func(*lending.Engine, *lend
 		engine.SetReserveFactor(m.node.LendingReserveFactorBps())
 		engine.SetProtocolFeeBps(m.node.LendingProtocolFeeBps())
 		engine.SetBlockHeight(m.node.GetHeight())
+		engine.SetCollateralRouting(m.node.LendingCollateralRouting())
 		var market *lending.Market
 		stored, ok, err := manager.LendingGetMarket(id)
 		if err != nil {


### PR DESCRIPTION
## Summary
- add collateral routing configuration to the lending module and expose setters on the node
- split liquidation collateral among liquidator, developer, and protocol recipients based on configuration
- document the new routing options and cover them with unit tests

## Testing
- go test ./native/lending

------
https://chatgpt.com/codex/tasks/task_e_68d75bf3bc74832db6f6249588d415f7