### PR TITLE
Rename escrow gateway doc to NHBCHAIN branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ For the full identity management toolkit, refer to [`docs/identity-cli.md`](./do
 All protocol modules ship with reference documentation under [`docs/`](./docs):
 
 - **Identity & Username Directory** — Concepts, RPC specs, and gateway flows (`docs/identity.md`, `docs/identity-api.md`, `docs/identity-gateway.md`).
-- **Escrow Module** — Settlement lifecycle and developer guide (`docs/escrow.md`, `docs/codex-epic-escrow-gateway.md`).
+- **Escrow Module** — Settlement lifecycle and developer guide (`docs/escrow.md`, `docs/escrow/nhbchain-escrow-gateway.md`).
 - **Loyalty & Rewards** — Network-wide loyalty engine overview (`docs/loyalty.md`).
 - **Pay-by-Username** — UX flows and examples (`docs/pay-by-username.md`, `docs/examples/identity`).
 - **OpenAPI Specification** — Machine-readable schema for REST integrations (`docs/openapi/identity.yaml`).

--- a/docs/escrow/nhbchain-escrow-gateway.md
+++ b/docs/escrow/nhbchain-escrow-gateway.md
@@ -1,4 +1,4 @@
-# CODEx EPIC — Escrow Gateway (REST) + Disputes/Arbitration + P2P Market Hooks
+# NHBCHAIN EPIC — Escrow Gateway (REST) + Disputes/Arbitration + P2P Market Hooks
 
 ## Goals
 
@@ -200,7 +200,7 @@ await client.release({ escrowId }, { signer: buyerWallet });
 
 ---
 
-# CODEx Addendum — P2P Dual-Lock Escrow (Reverse Escrow for “Buy NHB”)
+# NHBCHAIN Addendum — P2P Dual-Lock Escrow (Reverse Escrow for “Buy NHB”)
 
 ## Intent
 
@@ -323,7 +323,7 @@ Body: { "offerId":"OFF_123", "buyer":"nhb1...", "reference":"P2P-123" }
 
 ---
 
-## Paste to CODEx (Delta)
+## Paste to NHBCHAIN (Delta)
 
 ```
 Title: Add P2P dual-lock escrow (reverse escrow) with atomic settlement

--- a/docs/overview/README.md
+++ b/docs/overview/README.md
@@ -3,7 +3,7 @@
 ## Core Modules
 
 * [Escrow & P2P Developer Guide](./escrow.md)
-* [Codex Escrow Gateway](./codex-epic-escrow-gateway.md)
+* [NHBCHAIN Escrow Gateway](../escrow/nhbchain-escrow-gateway.md)
 * [Loyalty Module](./loyalty.md)
 * [Staking & Delegation](./staking.md)
 


### PR DESCRIPTION
## Summary
- rename the escrow gateway documentation to use NHBCHAIN branding
- update internal references to use the new filename and terminology

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d761fa948c832d8085300eb15061ef