### PR TITLE
Rename Codex NET-1 docs to NHBCHAIN

### DIFF
--- a/docs/overview/nhbchain-net1.md
+++ b/docs/overview/nhbchain-net1.md
@@ -1,6 +1,6 @@
-# CODEX NET-1 Delivery Notes
+# NHBCHAIN NET-1 Delivery Notes
 
-These notes document the CODEX NET-1 hardening work so protocol engineers,
+These notes document the NHBCHAIN NET-1 hardening work so protocol engineers,
 operations, and partner teams have a canonical reference for the shipped
 changes.
 

--- a/docs/overview/p2p.md
+++ b/docs/overview/p2p.md
@@ -1,7 +1,7 @@
-# P2P Networking Hardening (CODEX NET-1)
+# P2P Networking Hardening (NHBCHAIN NET-1)
 
 The NHB node ships with an authenticated TCP transport and JSON framing. The
-CODEX NET-1 workstream tightened the peer admission flow, message safety, and
+NHBCHAIN NET-1 workstream tightened the peer admission flow, message safety, and
 operator controls. This guide documents the current behavior so operators,
 integrators, and auditors understand the guarantees exposed by the new stack.
 


### PR DESCRIPTION
## Summary
- rename the Codex NET-1 delivery notes to nhbchain-net1.md and update terminology to NHBCHAIN
- refresh the P2P hardening overview to use the NHBCHAIN NET-1 naming

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d762cb99a0832dab7c22d736a49093