### PR TITLE
Align escrow comments with NHBCHAIN release naming

### DIFF
--- a/native/escrow/engine.go
+++ b/native/escrow/engine.go
@@ -53,8 +53,9 @@ func (e escrowEvent) EventType() string {
 func (e escrowEvent) Event() *types.Event { return e.evt }
 
 // Engine wires the escrow business logic with external state and event
-// emitters. The full transition logic will arrive in CODEx 1.2; for now the
-// engine provides deterministic event emission helpers.
+// emitters. The full transition logic will arrive in the NHBCHAIN NET-2
+// milestone; for now the engine provides deterministic event emission
+// helpers.
 type Engine struct {
 	state       engineState
 	emitter     events.Emitter

--- a/native/escrow/escrow.go
+++ b/native/escrow/escrow.go
@@ -17,8 +17,9 @@ const (
 )
 
 // LegacyEscrow holds the state of a single P2P escrow transaction from the
-// initial chain prototype. The hardened escrow engine introduced in CODEx 1.1
-// uses the Escrow struct defined in types.go. This legacy type remains to keep
+// initial chain prototype. The hardened escrow engine introduced in the
+// NHBCHAIN NET-1 milestone uses the Escrow struct defined in types.go. This
+// legacy type remains to keep
 // the historical state transition logic compiling until that implementation is
 // replaced by the new engine.
 type LegacyEscrow struct {


### PR DESCRIPTION
## Summary
- update escrow engine comments to refer to the NHBCHAIN NET-2 milestone for the remaining transition work
- align legacy escrow documentation with the NHBCHAIN NET-1 milestone terminology

## Testing
- not run (comments only)


------
https://chatgpt.com/codex/tasks/task_e_68d7655e188c832d9467e1bf17af7622