### PR TITLE
Update lending dapp copy to NHBChain lending playbook

### DIFF
--- a/examples/lending-dapp/README.md
+++ b/examples/lending-dapp/README.md
@@ -4,8 +4,8 @@ This example showcases how to build a lending interface on top of the NHBChain d
 
 ## Features
 
-- **Earn**: Supply and withdraw NHB liquidity using the UI patterns from CODEx — LEND-UI-2.
-- **Borrow**: Deposit ZNHB as collateral, borrow NHB, repay loans, and experiment with developer fees using CODEx — LEND-UI-1.
+- **Earn**: Supply and withdraw NHB liquidity using the NHBChain Lending Playbook pattern LEND-02.
+- **Borrow**: Deposit ZNHB as collateral, borrow NHB, repay loans, and experiment with developer fees using the NHBChain Lending Playbook pattern LEND-01.
 - **Fee Recipient Demo**: Demonstrates how a developer can monetize their local deployment via the `lend_borrowNHBWithFee` RPC endpoint.
 - **Empowerment Narrative**: Includes messaging that connects the protocol to NHBChain's mission of expanding access to credit for unbanked communities.
 

--- a/examples/lending-dapp/pages/borrow.tsx
+++ b/examples/lending-dapp/pages/borrow.tsx
@@ -17,8 +17,8 @@ export default function BorrowPage() {
         <span>Access Credit</span>
         <h1>Borrow NHB against your ZNHB</h1>
         <p className="section-description">
-          CODEx — LEND-UI-1 maps directly to this page. Use the developer fee recipient field to wire your monetization strategy
-          into the `lend_borrowNHBWithFee` endpoint and ship a sustainable lending product.
+          The NHBChain Lending Playbook — pattern LEND-01 — maps directly to this page. Use the developer fee recipient field
+          to wire your monetization strategy into the `lend_borrowNHBWithFee` endpoint and ship a sustainable lending product.
         </p>
       </section>
 

--- a/examples/lending-dapp/pages/earn.tsx
+++ b/examples/lending-dapp/pages/earn.tsx
@@ -16,8 +16,8 @@ export default function EarnPage() {
         <span>Provide Liquidity</span>
         <h1>Earn sustainable NHB yield</h1>
         <p className="section-description">
-          CODEx — LEND-UI-2 demonstrates how lenders supply and withdraw liquidity. Swap the mock state in this component for
-          real RPC calls to connect with NHBChain pool contracts.
+          The NHBChain Lending Playbook — pattern LEND-02 — walks through this supply and withdrawal journey. Swap the mock
+          state in this component for real RPC calls to connect with NHBChain pool contracts.
         </p>
       </section>
 


### PR DESCRIPTION
## Summary
- replace CODEx references in the earn and borrow flows with NHBChain Lending Playbook guidance
- update the README to reference the NHBChain playbook patterns for earn and borrow experiences
- verify the lending dapp example no longer contains CODEx references

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d765df1280832d9d4f395fdf187129