### PR TITLE
Handle unlimited swap ledger exports

### DIFF
--- a/native/swap/ledger.go
+++ b/native/swap/ledger.go
@@ -220,9 +220,6 @@ func (l *Ledger) List(startTs, endTs int64, cursor string, limit int) ([]*Vouche
 	if l == nil {
 		return nil, "", fmt.Errorf("ledger not initialised")
 	}
-	if limit <= 0 {
-		limit = 50
-	}
 	entries, err := l.loadIndex()
 	if err != nil {
 		return nil, "", err
@@ -258,8 +255,12 @@ func (l *Ledger) List(startTs, endTs int64, cursor string, limit int) ([]*Vouche
 		}
 	}
 	nextCursor := ""
-	records := make([]*VoucherRecord, 0, min(limit, len(filtered)-startIdx))
-	for i := startIdx; i < len(filtered) && len(records) < limit; i++ {
+	pageSize := limit
+	if pageSize <= 0 {
+		pageSize = len(filtered) - startIdx
+	}
+	records := make([]*VoucherRecord, 0, min(pageSize, len(filtered)-startIdx))
+	for i := startIdx; i < len(filtered) && len(records) < pageSize; i++ {
 		entry := filtered[i]
 		record, ok, err := l.Get(entry.ProviderTxID)
 		if err != nil {


### PR DESCRIPTION
## Summary
- treat non-positive list limits as no pagination so CSV exports capture every voucher
- add a regression test that creates more than 50 vouchers and asserts the export returns them all

## Testing
- go test ./native/swap -run TestLedgerExportCSVNoPagination -count=1

------
https://chatgpt.com/codex/tasks/task_e_68d76dbe7cc8832d912e17c758537bf3