### PR TITLE
Add persistence and tests for reputation skill verification

### DIFF
--- a/core/node_reputation_test.go
+++ b/core/node_reputation_test.go
@@ -1,0 +1,165 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	nhbstate "nhbchain/core/state"
+	"nhbchain/crypto"
+	"nhbchain/native/reputation"
+)
+
+func TestNodeReputationVerifySkillAuthorized(t *testing.T) {
+	node := newTestNode(t)
+	fixed := time.Unix(1_700_000_000, 0).UTC()
+	node.SetTimeSource(func() time.Time { return fixed })
+
+	verifierKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("verifier key: %v", err)
+	}
+	subjectKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("subject key: %v", err)
+	}
+	verifierAddr := toAddress(verifierKey)
+	subjectAddr := toAddress(subjectKey)
+	assignRole(t, node, roleReputationVerifier, verifierAddr)
+
+	expires := fixed.Add(6 * time.Hour).Unix()
+	verification, err := node.ReputationVerifySkill(verifierAddr, subjectAddr, "Solidity", expires)
+	if err != nil {
+		t.Fatalf("verify skill: %v", err)
+	}
+	if verification == nil {
+		t.Fatalf("expected verification result")
+	}
+	if verification.IssuedAt != fixed.Unix() {
+		t.Fatalf("expected issuedAt %d, got %d", fixed.Unix(), verification.IssuedAt)
+	}
+	if verification.ExpiresAt != expires {
+		t.Fatalf("expected expiresAt %d, got %d", expires, verification.ExpiresAt)
+	}
+	if verification.Skill != "Solidity" {
+		t.Fatalf("expected skill 'Solidity', got %q", verification.Skill)
+	}
+
+	if err := node.WithState(func(m *nhbstate.Manager) error {
+		ledger := reputation.NewLedger(m)
+		stored, ok, err := ledger.Get(subjectAddr, "Solidity", verifierAddr)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("expected verification persisted")
+		}
+		if stored.IssuedAt != verification.IssuedAt {
+			return fmt.Errorf("expected issuedAt %d, got %d", verification.IssuedAt, stored.IssuedAt)
+		}
+		if stored.ExpiresAt != verification.ExpiresAt {
+			return fmt.Errorf("expected expiresAt %d, got %d", verification.ExpiresAt, stored.ExpiresAt)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("ledger verification: %v", err)
+	}
+
+	events := node.Events()
+	if len(events) == 0 {
+		t.Fatalf("expected event to be emitted")
+	}
+	evt := events[len(events)-1]
+	if evt.Type != reputation.EventTypeSkillVerified {
+		t.Fatalf("expected event type %q, got %q", reputation.EventTypeSkillVerified, evt.Type)
+	}
+	if evt.Attributes["skill"] != "Solidity" {
+		t.Fatalf("expected skill attribute 'Solidity', got %q", evt.Attributes["skill"])
+	}
+	if evt.Attributes["subject"] == "" || evt.Attributes["verifier"] == "" {
+		t.Fatalf("expected subject and verifier attributes")
+	}
+	if evt.Attributes["issuedAt"] != strconv.FormatInt(fixed.Unix(), 10) {
+		t.Fatalf("expected issuedAt attribute %d, got %q", fixed.Unix(), evt.Attributes["issuedAt"])
+	}
+	if evt.Attributes["expiresAt"] != strconv.FormatInt(expires, 10) {
+		t.Fatalf("expected expiresAt attribute %d, got %q", expires, evt.Attributes["expiresAt"])
+	}
+}
+
+func TestNodeReputationVerifySkillUnauthorized(t *testing.T) {
+	node := newTestNode(t)
+	node.SetTimeSource(func() time.Time { return time.Unix(1_700_000_100, 0).UTC() })
+
+	verifierKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("verifier key: %v", err)
+	}
+	subjectKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("subject key: %v", err)
+	}
+	verifierAddr := toAddress(verifierKey)
+	subjectAddr := toAddress(subjectKey)
+
+	initialEvents := len(node.Events())
+	_, err = node.ReputationVerifySkill(verifierAddr, subjectAddr, "Design", 0)
+	if !errors.Is(err, ErrReputationVerifierUnauthorized) {
+		t.Fatalf("expected ErrReputationVerifierUnauthorized, got %v", err)
+	}
+	if len(node.Events()) != initialEvents {
+		t.Fatalf("expected no events to be emitted on failure")
+	}
+	if err := node.WithState(func(m *nhbstate.Manager) error {
+		ledger := reputation.NewLedger(m)
+		_, ok, err := ledger.Get(subjectAddr, "Design", verifierAddr)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return fmt.Errorf("unexpected verification persisted")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("ledger check: %v", err)
+	}
+}
+
+func TestNodeReputationVerifySkillInvalidSkill(t *testing.T) {
+	node := newTestNode(t)
+	node.SetTimeSource(func() time.Time { return time.Unix(1_700_000_200, 0).UTC() })
+
+	verifierKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("verifier key: %v", err)
+	}
+	subjectKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("subject key: %v", err)
+	}
+	verifierAddr := toAddress(verifierKey)
+	subjectAddr := toAddress(subjectKey)
+	assignRole(t, node, roleReputationVerifier, verifierAddr)
+
+	initialEvents := len(node.Events())
+	_, err = node.ReputationVerifySkill(verifierAddr, subjectAddr, "   ", 0)
+	if err == nil || !strings.Contains(err.Error(), "skill required") {
+		t.Fatalf("expected skill required error, got %v", err)
+	}
+	if len(node.Events()) != initialEvents {
+		t.Fatalf("expected no events to be emitted on validation failure")
+	}
+	if err := node.WithState(func(m *nhbstate.Manager) error {
+		ledger := reputation.NewLedger(m)
+		_, ok, err := ledger.Get(subjectAddr, "", verifierAddr)
+		if err == nil && ok {
+			return fmt.Errorf("unexpected verification persisted")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("ledger check: %v", err)
+	}
+}

--- a/native/reputation/storage.go
+++ b/native/reputation/storage.go
@@ -1,0 +1,114 @@
+package reputation
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// storage abstracts the subset of state manager functionality required by the
+// reputation ledger.
+type storage interface {
+	KVGet(key []byte, out interface{}) (bool, error)
+	KVPut(key []byte, value interface{}) error
+}
+
+var skillVerificationPrefix = []byte("reputation/skill/")
+
+func skillVerificationKey(subject [20]byte, skill string, verifier [20]byte) []byte {
+	normalized := strings.ToLower(strings.TrimSpace(skill))
+	if normalized == "" {
+		return nil
+	}
+	digest := ethcrypto.Keccak256([]byte(normalized))
+	return []byte(fmt.Sprintf("%s%x/%x/%x", skillVerificationPrefix, subject, digest, verifier))
+}
+
+// Ledger persists skill verifications issued by authorised verifiers.
+type Ledger struct {
+	store storage
+}
+
+// NewLedger constructs a ledger bound to the provided storage backend.
+func NewLedger(store storage) *Ledger {
+	return &Ledger{store: store}
+}
+
+// Put stores the verification record, overwriting any previous attestation from
+// the same verifier for the subject and skill combination.
+func (l *Ledger) Put(verification *SkillVerification) error {
+	if l == nil {
+		return errors.New("reputation: ledger not initialised")
+	}
+	if l.store == nil {
+		return errors.New("reputation: storage unavailable")
+	}
+	if verification == nil {
+		return errors.New("reputation: verification required")
+	}
+	sanitized := *verification
+	sanitized.Skill = strings.TrimSpace(sanitized.Skill)
+	if err := sanitized.Validate(); err != nil {
+		return err
+	}
+	if sanitized.IssuedAt < 0 {
+		return fmt.Errorf("reputation: issuedAt must be positive")
+	}
+	key := skillVerificationKey(sanitized.Subject, sanitized.Skill, sanitized.Verifier)
+	if key == nil {
+		return errors.New("reputation: skill required")
+	}
+	stored := storedSkillVerification{
+		Subject:  sanitized.Subject,
+		Skill:    sanitized.Skill,
+		Verifier: sanitized.Verifier,
+		IssuedAt: uint64(sanitized.IssuedAt),
+	}
+	if sanitized.ExpiresAt > 0 {
+		stored.ExpiresAt = uint64(sanitized.ExpiresAt)
+	}
+	return l.store.KVPut(key, &stored)
+}
+
+// Get retrieves the verification record issued by the specified verifier for the
+// subject and skill combination.
+func (l *Ledger) Get(subject [20]byte, skill string, verifier [20]byte) (*SkillVerification, bool, error) {
+	if l == nil {
+		return nil, false, errors.New("reputation: ledger not initialised")
+	}
+	if l.store == nil {
+		return nil, false, errors.New("reputation: storage unavailable")
+	}
+	key := skillVerificationKey(subject, skill, verifier)
+	if key == nil {
+		return nil, false, errors.New("reputation: skill required")
+	}
+	var stored storedSkillVerification
+	ok, err := l.store.KVGet(key, &stored)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	verification := &SkillVerification{
+		Subject:  stored.Subject,
+		Skill:    stored.Skill,
+		Verifier: stored.Verifier,
+		IssuedAt: int64(stored.IssuedAt),
+	}
+	if stored.ExpiresAt > 0 {
+		verification.ExpiresAt = int64(stored.ExpiresAt)
+	}
+	return verification, true, nil
+}
+
+type storedSkillVerification struct {
+	Subject   [20]byte
+	Skill     string
+	Verifier  [20]byte
+	IssuedAt  uint64
+	ExpiresAt uint64
+}

--- a/native/reputation/storage_test.go
+++ b/native/reputation/storage_test.go
@@ -1,0 +1,89 @@
+package reputation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type memoryStore struct {
+	data map[string][]byte
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{data: make(map[string][]byte)}
+}
+
+func (m *memoryStore) KVPut(key []byte, value interface{}) error {
+	encoded, err := rlp.EncodeToBytes(value)
+	if err != nil {
+		return err
+	}
+	m.data[string(key)] = encoded
+	return nil
+}
+
+func (m *memoryStore) KVGet(key []byte, out interface{}) (bool, error) {
+	encoded, ok := m.data[string(key)]
+	if !ok {
+		return false, nil
+	}
+	if out == nil {
+		return true, nil
+	}
+	if err := rlp.DecodeBytes(encoded, out); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func TestLedgerPutAndGet(t *testing.T) {
+	store := newMemoryStore()
+	ledger := NewLedger(store)
+
+	var subject [20]byte
+	copy(subject[:], []byte("subject-address-123"))
+	var verifier [20]byte
+	copy(verifier[:], []byte("verifier-address-456"))
+
+	issued := time.Now().Unix()
+	expires := issued + 3600
+	verification := &SkillVerification{
+		Subject:   subject,
+		Skill:     "  Solidity  ",
+		Verifier:  verifier,
+		IssuedAt:  issued,
+		ExpiresAt: expires,
+	}
+	if err := ledger.Put(verification); err != nil {
+		t.Fatalf("put verification: %v", err)
+	}
+
+	stored, ok, err := ledger.Get(subject, "solidity", verifier)
+	if err != nil {
+		t.Fatalf("get verification: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected verification to exist")
+	}
+	if stored.Skill != "Solidity" {
+		t.Fatalf("expected skill 'Solidity', got %q", stored.Skill)
+	}
+	if stored.IssuedAt != issued {
+		t.Fatalf("expected issuedAt %d, got %d", issued, stored.IssuedAt)
+	}
+	if stored.ExpiresAt != expires {
+		t.Fatalf("expected expiresAt %d, got %d", expires, stored.ExpiresAt)
+	}
+}
+
+func TestLedgerPutInvalidSkill(t *testing.T) {
+	store := newMemoryStore()
+	ledger := NewLedger(store)
+
+	err := ledger.Put(&SkillVerification{})
+	if err == nil {
+		t.Fatalf("expected error for invalid verification")
+	}
+}


### PR DESCRIPTION
## Summary
- add a native reputation ledger to persist verifier-issued skill attestations
- wire Node.ReputationVerifySkill to enforce verifier roles, record verifications, and emit the skillVerified event
- cover the new storage and RPC surface with unit and integration tests

## Testing
- go test -v ./native/reputation -run Ledger -count=1
- go test -v ./core -run ReputationVerifySkill -count=1


------
https://chatgpt.com/codex/tasks/task_e_68d7700161dc832dbf39a7e6f6276fa8