### PR TITLE
Gate RPC X-Forwarded-For usage behind trusted proxy configuration

### DIFF
--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -290,7 +290,10 @@ func main() {
 	node.SetBftEngine(bftEngine)
 
 	// --- Server Startup ---
-	rpcServer := rpc.NewServer(node)
+	rpcServer := rpc.NewServer(node, rpc.ServerConfig{
+		TrustProxyHeaders: cfg.RPCTrustProxyHeaders,
+		TrustedProxies:    append([]string{}, cfg.RPCTrustedProxies...),
+	})
 	go rpcServer.Start(cfg.RPCAddress)
 	go p2pServer.Start()
 

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,8 @@ import (
 type Config struct {
 	ListenAddress         string         `toml:"ListenAddress"`
 	RPCAddress            string         `toml:"RPCAddress"`
+	RPCTrustedProxies     []string       `toml:"RPCTrustedProxies"`
+	RPCTrustProxyHeaders  bool           `toml:"RPCTrustProxyHeaders"`
 	DataDir               string         `toml:"DataDir"`
 	GenesisFile           string         `toml:"GenesisFile"`
 	AllowAutogenesis      bool           `toml:"AllowAutogenesis"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,6 +36,8 @@ WriteTimeout = 4
 MaxMsgBytes = 2048
 MaxMsgsPerSecond = 12.5
 ClientVersion = "nhbchain/test"
+RPCTrustedProxies = ["10.0.0.1"]
+RPCTrustProxyHeaders = true
 
 [p2p]
 NetworkId = 187001
@@ -85,6 +87,12 @@ PEX = false
 	}
 	if cfg.ClientVersion != "nhbchain/test" {
 		t.Fatalf("unexpected client version: %s", cfg.ClientVersion)
+	}
+	if len(cfg.RPCTrustedProxies) != 1 || cfg.RPCTrustedProxies[0] != "10.0.0.1" {
+		t.Fatalf("unexpected RPC trusted proxies: %v", cfg.RPCTrustedProxies)
+	}
+	if !cfg.RPCTrustProxyHeaders {
+		t.Fatalf("expected RPCTrustProxyHeaders to be true")
 	}
 	if len(cfg.Bootnodes) != 1 || cfg.Bootnodes[0] != "1.1.1.1:6001" {
 		t.Fatalf("bootnodes not parsed: %v", cfg.Bootnodes)

--- a/rpc/http_test.go
+++ b/rpc/http_test.go
@@ -1,0 +1,94 @@
+package rpc
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClientSourceIgnoresForwardedForWhenNotTrusted(t *testing.T) {
+	server := NewServer(nil, ServerConfig{})
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.RemoteAddr = "10.0.0.5:1234"
+	req.Header.Set("X-Forwarded-For", "203.0.113.9")
+
+	if source := server.clientSource(req); source != "10.0.0.5" {
+		t.Fatalf("expected remote address, got %q", source)
+	}
+}
+
+func TestClientSourceHonorsForwardedForFromTrustedProxy(t *testing.T) {
+	server := NewServer(nil, ServerConfig{TrustedProxies: []string{"10.0.0.1"}})
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.RemoteAddr = "10.0.0.1:8080"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7")
+
+	if source := server.clientSource(req); source != "198.51.100.7" {
+		t.Fatalf("expected forwarded client, got %q", source)
+	}
+}
+
+func TestClientSourceHonorsForwardedForWhenTrustFlagEnabled(t *testing.T) {
+	server := NewServer(nil, ServerConfig{TrustProxyHeaders: true})
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.RemoteAddr = "192.0.2.10:7000"
+	req.Header.Set("X-Forwarded-For", "198.51.100.8")
+
+	if source := server.clientSource(req); source != "198.51.100.8" {
+		t.Fatalf("expected forwarded client, got %q", source)
+	}
+}
+
+func TestRateLimitSpoofedForwardedFor(t *testing.T) {
+	server := NewServer(nil, ServerConfig{})
+	now := time.Now()
+	remoteAddr := "10.1.1.1:9000"
+
+	for i := 0; i < maxTxPerWindow; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.RemoteAddr = remoteAddr
+		req.Header.Set("X-Forwarded-For", fmt.Sprintf("198.51.100.%d", i))
+		if !server.allowSource(server.clientSource(req), now) {
+			t.Fatalf("request %d should not be rate limited", i)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.RemoteAddr = remoteAddr
+	req.Header.Set("X-Forwarded-For", "198.51.100.250")
+	if server.allowSource(server.clientSource(req), now) {
+		t.Fatalf("spoofed forwarded-for should not bypass rate limiting")
+	}
+}
+
+func TestRateLimitTrustedProxyHonorsForwardedFor(t *testing.T) {
+	server := NewServer(nil, ServerConfig{TrustedProxies: []string{"10.0.0.1"}})
+	now := time.Now()
+	remoteAddr := "10.0.0.1:5000"
+
+	forwarded := "198.51.100.1"
+	for i := 0; i < maxTxPerWindow; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.RemoteAddr = remoteAddr
+		req.Header.Set("X-Forwarded-For", forwarded)
+		if !server.allowSource(server.clientSource(req), now) {
+			t.Fatalf("trusted proxy request %d should be allowed", i)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.RemoteAddr = remoteAddr
+	req.Header.Set("X-Forwarded-For", forwarded)
+	if server.allowSource(server.clientSource(req), now) {
+		t.Fatalf("expected rate limit when exceeding window for same client")
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/", nil)
+	req.RemoteAddr = remoteAddr
+	req.Header.Set("X-Forwarded-For", "198.51.100.2")
+	if !server.allowSource(server.clientSource(req), now) {
+		t.Fatalf("distinct client behind trusted proxy should be allowed")
+	}
+}

--- a/rpc/loyalty_handlers_test.go
+++ b/rpc/loyalty_handlers_test.go
@@ -46,7 +46,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	agg.Register("manual", manual)
 	node.SetSwapOracle(agg)
 	node.SetSwapManualOracle(manual)
-	server := NewServer(node)
+	server := NewServer(node, ServerConfig{})
 	return &testEnv{server: server, node: node, token: token}
 }
 

--- a/tests/e2e/lending_rpc_test.go
+++ b/tests/e2e/lending_rpc_test.go
@@ -79,7 +79,7 @@ func TestLendingRPCEndpoints(t *testing.T) {
 		t.Fatalf("seed lending state: %v", err)
 	}
 
-	server := rpc.NewServer(node)
+	server := rpc.NewServer(node, rpc.ServerConfig{})
 	ts := httptest.NewServer(server)
 	defer ts.Close()
 


### PR DESCRIPTION
## Summary
- add RPC server options for trusted proxy headers and thread them through node configuration
- ensure client source attribution only trusts X-Forwarded-For from authorised proxies and cover it with targeted unit tests
- update configuration parsing and existing tests to accommodate the new RPC server constructor

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d7759ac2e0832d8f0e591556e3d739