### PR TITLE
Protect mempool with mutex and configurable limit

### DIFF
--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -89,6 +89,8 @@ func main() {
 		panic(fmt.Sprintf("Failed to create node: %v", err))
 	}
 
+	node.SetMempoolLimit(cfg.Mempool.MaxTransactions)
+
 	govPolicy, err := cfg.Governance.Policy()
 	if err != nil {
 		panic(fmt.Sprintf("Failed to parse governance policy: %v", err))

--- a/config-local.toml
+++ b/config-local.toml
@@ -9,6 +9,9 @@ ValidatorKeystorePath = "./validator-local.keystore"
 ValidatorKMSURI = ""
 ValidatorKMSEnv = ""
 NetworkName = "nhb-local"
+
+[mempool]
+MaxTransactions = 5000
 [p2p]
 NetworkId = 187001
 MaxPeers = 64

--- a/config-peer.toml
+++ b/config-peer.toml
@@ -9,6 +9,9 @@ ValidatorKeystorePath = "./validator-peer.keystore"
 ValidatorKMSURI = ""
 ValidatorKMSEnv = ""
 NetworkName = "nhb-local"
+
+[mempool]
+MaxTransactions = 5000
 [p2p]
 NetworkId = 187001
 MaxPeers = 64

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,9 @@ ValidatorKeystorePath = ""
 ValidatorKMSURI = ""
 ValidatorKMSEnv = ""
 NetworkName = "nhb-local"
+
+[mempool]
+MaxTransactions = 5000
 [p2p]
 NetworkId = 187001
 MaxPeers = 64

--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	Governance            GovConfig      `toml:"governance"`
 	Swap                  swap.Config    `toml:"swap"`
 	Lending               lending.Config `toml:"lending"`
+	Mempool               MempoolConfig  `toml:"mempool"`
 }
 
 const defaultBlockTimestampToleranceSeconds = 5
@@ -116,6 +117,11 @@ type PotsoAbuseConfig struct {
 	MaxUserShareBps        uint64 `toml:"MaxUserShareBps"`
 }
 
+// MempoolConfig allows operators to tune the size of the transaction pool.
+type MempoolConfig struct {
+	MaxTransactions int `toml:"MaxTransactions"`
+}
+
 // GovConfig captures the governance policy knobs controlling proposal flow
 // without embedding business logic in the state machine.
 type GovConfig struct {
@@ -156,6 +162,7 @@ func Load(path string) (*Config, error) {
 
 	cfg.mergeP2PFromTopLevel()
 	cfg.Lending.EnsureDefaults()
+	cfg.ensureMempoolDefaults()
 
 	if strings.TrimSpace(cfg.NetworkName) == "" {
 		cfg.NetworkName = "nhb-local"
@@ -289,6 +296,12 @@ func Load(path string) (*Config, error) {
 	cfg.syncTopLevelToP2P()
 
 	return cfg, nil
+}
+
+func (cfg *Config) ensureMempoolDefaults() {
+	if cfg.Mempool.MaxTransactions < 0 {
+		cfg.Mempool.MaxTransactions = 0
+	}
 }
 
 // PotsoRewardConfig converts the loaded TOML representation into the runtime configuration structure.

--- a/core/mempool_test.go
+++ b/core/mempool_test.go
@@ -1,0 +1,85 @@
+package core
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"nhbchain/core/types"
+)
+
+func TestNodeMempoolConcurrentAdds(t *testing.T) {
+	node := newTestNode(t)
+	node.SetMempoolLimit(0)
+
+	const producers = 32
+	const perProducer = 64
+	var wg sync.WaitGroup
+	for p := 0; p < producers; p++ {
+		base := p * perProducer
+		wg.Add(1)
+		go func(base int) {
+			defer wg.Done()
+			for i := 0; i < perProducer; i++ {
+				tx := &types.Transaction{
+					ChainID: types.NHBChainID(),
+					Nonce:   uint64(base + i),
+				}
+				if err := node.AddTransaction(tx); err != nil {
+					t.Errorf("add transaction: %v", err)
+				}
+			}
+		}(base)
+	}
+	wg.Wait()
+
+	txs := node.GetMempool()
+	expected := producers * perProducer
+	if len(txs) != expected {
+		t.Fatalf("expected %d transactions, got %d", expected, len(txs))
+	}
+}
+
+func TestNodeMempoolLimitEnforcedConcurrently(t *testing.T) {
+	node := newTestNode(t)
+	const limit = 75
+	node.SetMempoolLimit(limit)
+
+	const workers = 10
+	const perWorker = 20
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var fullCount int
+	for w := 0; w < workers; w++ {
+		base := w * perWorker
+		wg.Add(1)
+		go func(base int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				tx := &types.Transaction{
+					ChainID: types.NHBChainID(),
+					Nonce:   uint64(base + i),
+				}
+				err := node.AddTransaction(tx)
+				if err != nil {
+					if !errors.Is(err, ErrMempoolFull) {
+						t.Errorf("unexpected error: %v", err)
+						return
+					}
+					mu.Lock()
+					fullCount++
+					mu.Unlock()
+				}
+			}
+		}(base)
+	}
+	wg.Wait()
+
+	txs := node.GetMempool()
+	if len(txs) != limit {
+		t.Fatalf("expected %d transactions in mempool, got %d", limit, len(txs))
+	}
+	if fullCount == 0 {
+		t.Fatalf("expected ErrMempoolFull under load")
+	}
+}

--- a/rpc/engagement_handlers.go
+++ b/rpc/engagement_handlers.go
@@ -2,7 +2,10 @@ package rpc
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+
+	"nhbchain/core"
 )
 
 type engagementRegisterDeviceParams struct {
@@ -68,6 +71,10 @@ func (s *Server) handleEngagementSubmitHeartbeat(w http.ResponseWriter, _ *http.
 	}
 	ts, err := s.node.EngagementSubmitHeartbeat(params.DeviceID, params.Token, params.Timestamp)
 	if err != nil {
+		if errors.Is(err, core.ErrMempoolFull) {
+			writeError(w, http.StatusServiceUnavailable, req.ID, codeMempoolFull, "mempool full", nil)
+			return
+		}
 		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, err.Error(), nil)
 		return
 	}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -40,6 +40,7 @@ const (
 	codeServerError    = -32000
 	codeDuplicateTx    = -32010
 	codeRateLimited    = -32020
+	codeMempoolFull    = -32030
 )
 
 type rateLimiter struct {
@@ -850,7 +851,14 @@ func (s *Server) handleSendTransaction(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 
-	s.node.AddTransaction(&tx)
+	if err := s.node.AddTransaction(&tx); err != nil {
+		if errors.Is(err, core.ErrMempoolFull) {
+			writeError(w, http.StatusServiceUnavailable, req.ID, codeMempoolFull, "mempool full", nil)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, req.ID, codeServerError, "failed to add transaction", err.Error())
+		return
+	}
 	writeResult(w, req.ID, "Transaction received by node.")
 }
 


### PR DESCRIPTION
## Summary
- guard the node mempool with a dedicated mutex, enforce a configurable capacity, and propagate overflow errors through RPC and heartbeat handling
- add mempool size configuration, wire it into node startup, and document it in the sample configs
- add concurrent unit tests that stress the mempool lock and ensure the limit is upheld under load

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d777b6bfec832db73d92eec1c0fcb8