### PR TITLE
Add configurable RPC HTTP server timeouts and TLS support

### DIFF
--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -293,6 +293,12 @@ func main() {
 	rpcServer := rpc.NewServer(node, rpc.ServerConfig{
 		TrustProxyHeaders: cfg.RPCTrustProxyHeaders,
 		TrustedProxies:    append([]string{}, cfg.RPCTrustedProxies...),
+		ReadHeaderTimeout: time.Duration(cfg.RPCReadHeaderTimeout) * time.Second,
+		ReadTimeout:       time.Duration(cfg.RPCReadTimeout) * time.Second,
+		WriteTimeout:      time.Duration(cfg.RPCWriteTimeout) * time.Second,
+		IdleTimeout:       time.Duration(cfg.RPCIdleTimeout) * time.Second,
+		TLSCertFile:       cfg.RPCTLSCertFile,
+		TLSKeyFile:        cfg.RPCTLSKeyFile,
 	})
 	go rpcServer.Start(cfg.RPCAddress)
 	go p2pServer.Start()

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,12 @@ type Config struct {
 	RPCAddress            string         `toml:"RPCAddress"`
 	RPCTrustedProxies     []string       `toml:"RPCTrustedProxies"`
 	RPCTrustProxyHeaders  bool           `toml:"RPCTrustProxyHeaders"`
+	RPCReadHeaderTimeout  int            `toml:"RPCReadHeaderTimeout"`
+	RPCReadTimeout        int            `toml:"RPCReadTimeout"`
+	RPCWriteTimeout       int            `toml:"RPCWriteTimeout"`
+	RPCIdleTimeout        int            `toml:"RPCIdleTimeout"`
+	RPCTLSCertFile        string         `toml:"RPCTLSCertFile"`
+	RPCTLSKeyFile         string         `toml:"RPCTLSKeyFile"`
 	DataDir               string         `toml:"DataDir"`
 	GenesisFile           string         `toml:"GenesisFile"`
 	AllowAutogenesis      bool           `toml:"AllowAutogenesis"`
@@ -673,25 +679,29 @@ func createDefault(path string) (*Config, error) {
 	}
 
 	cfg := &Config{
-		ListenAddress:    ":6001",
-		RPCAddress:       ":8080",
-		DataDir:          "./nhb-data",
-		GenesisFile:      "",
-		AllowAutogenesis: false,
-		NetworkName:      "nhb-local",
-		Bootnodes:        []string{},
-		PersistentPeers:  []string{},
-		MaxPeers:         64,
-		MaxInbound:       64,
-		MaxOutbound:      64,
-		MinPeers:         32,
-		OutboundPeers:    16,
-		PeerBanSeconds:   int((60 * time.Minute).Seconds()),
-		ReadTimeout:      int((90 * time.Second).Seconds()),
-		WriteTimeout:     int((5 * time.Second).Seconds()),
-		MaxMsgBytes:      1 << 20,
-		MaxMsgsPerSecond: 32,
-		ClientVersion:    "nhbchain/node",
+		ListenAddress:        ":6001",
+		RPCAddress:           ":8080",
+		DataDir:              "./nhb-data",
+		GenesisFile:          "",
+		AllowAutogenesis:     false,
+		NetworkName:          "nhb-local",
+		Bootnodes:            []string{},
+		PersistentPeers:      []string{},
+		MaxPeers:             64,
+		MaxInbound:           64,
+		MaxOutbound:          64,
+		MinPeers:             32,
+		OutboundPeers:        16,
+		PeerBanSeconds:       int((60 * time.Minute).Seconds()),
+		ReadTimeout:          int((90 * time.Second).Seconds()),
+		WriteTimeout:         int((5 * time.Second).Seconds()),
+		RPCReadHeaderTimeout: int((10 * time.Second).Seconds()),
+		RPCReadTimeout:       int((15 * time.Second).Seconds()),
+		RPCWriteTimeout:      int((15 * time.Second).Seconds()),
+		RPCIdleTimeout:       int((120 * time.Second).Seconds()),
+		MaxMsgBytes:          1 << 20,
+		MaxMsgsPerSecond:     32,
+		ClientVersion:        "nhbchain/node",
 	}
 	cfg.P2P = P2PSection{
 		NetworkID:          187001,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,6 +38,12 @@ MaxMsgsPerSecond = 12.5
 ClientVersion = "nhbchain/test"
 RPCTrustedProxies = ["10.0.0.1"]
 RPCTrustProxyHeaders = true
+RPCReadHeaderTimeout = 6
+RPCReadTimeout = 20
+RPCWriteTimeout = 18
+RPCIdleTimeout = 45
+RPCTLSCertFile = "/path/to/cert.pem"
+RPCTLSKeyFile = "/path/to/key.pem"
 
 [p2p]
 NetworkId = 187001
@@ -93,6 +99,18 @@ PEX = false
 	}
 	if !cfg.RPCTrustProxyHeaders {
 		t.Fatalf("expected RPCTrustProxyHeaders to be true")
+	}
+	if cfg.RPCReadHeaderTimeout != 6 {
+		t.Fatalf("unexpected RPC read header timeout: %d", cfg.RPCReadHeaderTimeout)
+	}
+	if cfg.RPCReadTimeout != 20 || cfg.RPCWriteTimeout != 18 {
+		t.Fatalf("unexpected RPC read/write timeouts: %d/%d", cfg.RPCReadTimeout, cfg.RPCWriteTimeout)
+	}
+	if cfg.RPCIdleTimeout != 45 {
+		t.Fatalf("unexpected RPC idle timeout: %d", cfg.RPCIdleTimeout)
+	}
+	if cfg.RPCTLSCertFile != "/path/to/cert.pem" || cfg.RPCTLSKeyFile != "/path/to/key.pem" {
+		t.Fatalf("unexpected RPC TLS paths: %s %s", cfg.RPCTLSCertFile, cfg.RPCTLSKeyFile)
 	}
 	if len(cfg.Bootnodes) != 1 || cfg.Bootnodes[0] != "1.1.1.1:6001" {
 		t.Fatalf("bootnodes not parsed: %v", cfg.Bootnodes)


### PR DESCRIPTION
## Summary
- Replace the global HTTP mux with a private server that applies configurable timeouts and optional TLS, and add graceful shutdown helpers.
- Expose RPC HTTP timeout and TLS certificate path settings in node configuration with sensible defaults and wire them into node startup.
- Update the lending E2E harness to start/stop the RPC server through the new wrapper to guard against regressions.

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d77a4fed74832db1fd3bf647ee8132