### PR TITLE
feat: scaffold lendingd service

### DIFF
--- a/docs/finance/lending/rpc-api.md
+++ b/docs/finance/lending/rpc-api.md
@@ -1,5 +1,10 @@
 # Lending RPC API Reference
 
+> **Note:** A dedicated `lendingd` service is now available and documents its
+> gRPC API separately in [/docs/lending/service.md](../../lending/service.md).
+> The legacy JSON-RPC interface described below remains supported for existing
+> deployments but will be phased out in favour of the standalone service.
+
 The NHBChain node exposes a JSON-RPC interface for interacting with the native
 lending engine. This document describes each method, the expected request
 payloads, and the shape of the responses returned by the node.

--- a/docs/lending/cookbook.md
+++ b/docs/lending/cookbook.md
@@ -1,0 +1,17 @@
+# Lending Service Cookbook
+
+The cookbook will evolve alongside the dedicated lending service. For now it
+tracks the placeholder behaviour so integrators are aware of the current
+limitations.
+
+## Querying markets
+
+The `GetMarket` and `ListMarkets` RPCs are exposed but return `UNIMPLEMENTED`
+until the service is wired to the consensus query API.
+
+## Managing positions
+
+All write operations (`SupplyAsset`, `WithdrawAsset`, `BorrowAsset`,
+`RepayAsset`) are intentionally disabled while the new lending engine is being
+ported. Client applications should continue to rely on the legacy JSON-RPC flows
+until an upcoming milestone replaces them with fully managed transactions.

--- a/docs/lending/service.md
+++ b/docs/lending/service.md
@@ -1,0 +1,24 @@
+# Lending Service (`lendingd`)
+
+The `lendingd` daemon exposes the `lending.v1` gRPC API described in
+`proto/lending/v1/lending.proto`. The service currently starts an empty gRPC
+server that reserves the canonical port (`50053`) and will be extended in future
+iterations to proxy requests into the on-chain lending module.
+
+## Configuration
+
+The service loads YAML configuration via the `-config` flag. A minimal example
+is provided in `services/lending/config.yaml`:
+
+```yaml
+listen: ":50053"
+```
+
+## Running locally
+
+```bash
+go run ./services/lendingd -config services/lending/config.yaml
+```
+
+The server responds on the configured address but, at this stage, returns
+`UNIMPLEMENTED` for all RPCs.

--- a/examples/compose/lendingd.yml
+++ b/examples/compose/lendingd.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  lendingd:
+    image: ghcr.io/nhbchain/lendingd:latest
+    command: ["/app/lendingd", "-config", "/config/config.yaml"]
+    ports:
+      - "50053:50053"
+    volumes:
+      - ./config.yaml:/config/config.yaml:ro

--- a/examples/lending/quickstart.ts
+++ b/examples/lending/quickstart.ts
@@ -1,0 +1,4 @@
+// Placeholder quickstart for the lending service.
+// The full flow will be documented once the gRPC API is wired to consensus state.
+
+console.log("Refer to docs/lending/service.md for the current status of lendingd.");

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.24.0
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.34.2
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.0
 	lukechampine.com/blake3 v1.4.1

--- a/services/lending/client/client.go
+++ b/services/lending/client/client.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	lendingv1 "nhbchain/proto/lending/v1"
+)
+
+// Client provides a thin wrapper around the lending service gRPC API.
+type Client struct {
+	conn *grpc.ClientConn
+	api  lendingv1.LendingServiceClient
+}
+
+// Dial initialises a client connection to the lending service endpoint.
+func Dial(ctx context.Context, target string, opts ...grpc.DialOption) (*Client, error) {
+	if len(opts) == 0 {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	conn, err := grpc.DialContext(ctx, target, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{conn: conn, api: lendingv1.NewLendingServiceClient(conn)}, nil
+}
+
+// Close tears down the underlying connection.
+func (c *Client) Close() error {
+	if c == nil || c.conn == nil {
+		return nil
+	}
+	return c.conn.Close()
+}
+
+// Raw exposes the generated client for advanced usage.
+func (c *Client) Raw() lendingv1.LendingServiceClient {
+	if c == nil {
+		return nil
+	}
+	return c.api
+}

--- a/services/lending/config.yaml
+++ b/services/lending/config.yaml
@@ -1,0 +1,3 @@
+# Example configuration for the lending daemon.
+# listen specifies the address the gRPC server should bind to.
+listen: ":50053"

--- a/services/lending/server/server.go
+++ b/services/lending/server/server.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	lendingv1 "nhbchain/proto/lending/v1"
+)
+
+// Service implements the lending.v1 gRPC interface. The current implementation
+// acts as a placeholder until the full lending engine integration is
+// completed.
+type Service struct {
+	lendingv1.UnimplementedLendingServiceServer
+}
+
+// New constructs a new lending service instance.
+func New() *Service {
+	return &Service{}
+}
+
+// GetMarket is currently unimplemented.
+func (s *Service) GetMarket(ctx context.Context, req *lendingv1.GetMarketRequest) (*lendingv1.GetMarketResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "GetMarket is not implemented yet")
+}
+
+// ListMarkets is currently unimplemented.
+func (s *Service) ListMarkets(ctx context.Context, req *lendingv1.ListMarketsRequest) (*lendingv1.ListMarketsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "ListMarkets is not implemented yet")
+}
+
+// GetPosition is currently unimplemented.
+func (s *Service) GetPosition(ctx context.Context, req *lendingv1.GetPositionRequest) (*lendingv1.GetPositionResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "GetPosition is not implemented yet")
+}
+
+// SupplyAsset is currently unimplemented.
+func (s *Service) SupplyAsset(ctx context.Context, req *lendingv1.SupplyAssetRequest) (*lendingv1.SupplyAssetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "SupplyAsset is not implemented yet")
+}
+
+// WithdrawAsset is currently unimplemented.
+func (s *Service) WithdrawAsset(ctx context.Context, req *lendingv1.WithdrawAssetRequest) (*lendingv1.WithdrawAssetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "WithdrawAsset is not implemented yet")
+}
+
+// BorrowAsset is currently unimplemented.
+func (s *Service) BorrowAsset(ctx context.Context, req *lendingv1.BorrowAssetRequest) (*lendingv1.BorrowAssetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "BorrowAsset is not implemented yet")
+}
+
+// RepayAsset is currently unimplemented.
+func (s *Service) RepayAsset(ctx context.Context, req *lendingv1.RepayAssetRequest) (*lendingv1.RepayAssetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "RepayAsset is not implemented yet")
+}

--- a/services/lendingd/main.go
+++ b/services/lendingd/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"google.golang.org/grpc"
+	"gopkg.in/yaml.v3"
+
+	lendingv1 "nhbchain/proto/lending/v1"
+	lendingserver "nhbchain/services/lending/server"
+)
+
+type Config struct {
+	ListenAddress string `yaml:"listen"`
+}
+
+func loadConfig(path string) (Config, error) {
+	cfg := Config{ListenAddress: ":50053"}
+	if path == "" {
+		return cfg, fmt.Errorf("config path required")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("open config: %w", err)
+	}
+	defer file.Close()
+	decoder := yaml.NewDecoder(file)
+	if err := decoder.Decode(&cfg); err != nil {
+		return Config{}, fmt.Errorf("decode config: %w", err)
+	}
+	if cfg.ListenAddress == "" {
+		cfg.ListenAddress = ":50053"
+	}
+	return cfg, nil
+}
+
+func main() {
+	var cfgPath string
+	flag.StringVar(&cfgPath, "config", "services/lending/config.yaml", "path to lendingd config")
+	flag.Parse()
+
+	cfg, err := loadConfig(cfgPath)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", cfg.ListenAddress)
+	if err != nil {
+		log.Fatalf("listen on %s: %v", cfg.ListenAddress, err)
+	}
+	grpcServer := grpc.NewServer()
+	service := lendingserver.New()
+	lendingv1.RegisterLendingServiceServer(grpcServer, service)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		log.Printf("lendingd listening on %s", cfg.ListenAddress)
+		serverErr <- grpcServer.Serve(listener)
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Println("shutdown signal received")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		done := make(chan struct{})
+		go func() {
+			grpcServer.GracefulStop()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-shutdownCtx.Done():
+			log.Println("forcing server stop")
+			grpcServer.Stop()
+		}
+	case err := <-serverErr:
+		if err != nil {
+			log.Fatalf("serve gRPC: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a basic `lendingd` daemon that boots a gRPC server and loads YAML config
- scaffold placeholder lending server/client packages plus docs and examples ahead of the full implementation
- document that legacy JSON-RPC flows will be superseded by the new service

## Testing
- go test ./... *(fails: build issues in existing rpc and otc-gateway packages when building with go1.24 toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68d81735209c832d9a0336d78fdf6cef