### PR TITLE
Add gateway edge layer with JSON-RPC compatibility

### DIFF
--- a/docs/gateway/overview.md
+++ b/docs/gateway/overview.md
@@ -1,0 +1,47 @@
+# Gateway Overview
+
+The API gateway acts as the single public edge for NHBChain traffic. Requests
+arriving at `https://app.nhbcoin.com` are served by the gateway and are routed
+internally to dedicated services:
+
+| Public host | Purpose | Internal target |
+| ----------- | ------- | ---------------- |
+| `app.nhbcoin.com` | User-facing application and REST APIs | Gateway (this service) |
+| `rpc.nhbcoin.net` | Legacy JSON-RPC compatibility | Gateway `/rpc` endpoint |
+| `api.nhbcoin.net` | Historical JSON-RPC host (deprecated) | Gateway `/rpc` endpoint |
+| `nhbcoin.net` | On-chain service endpoints (`/v1/...`) | Gateway reverse proxy |
+
+The gateway replaces the previous monolithic JSON-RPC server. Traffic is routed
+according to the following prefixes:
+
+- `/v1/lending/*` → `lendingd`
+- `/v1/swap/*` → `swapd`
+- `/v1/gov/*` → `governd`
+- `/v1/consensus/*` → `consensusd`
+
+Each backend is responsible for a single domain. The gateway enforces
+cross-cutting concerns including authentication (JWT/OAuth bearer tokens),
+per-route rate limits, tracing and metrics, and a compatibility layer for legacy
+JSON-RPC methods.
+
+## Observability
+
+The gateway publishes Prometheus metrics at `/metrics` and emits OpenTelemetry
+traces for every request. Metrics and tracing are enabled by default and can be
+turned off in the gateway configuration.
+
+## Configuration
+
+The gateway is configured via YAML (or environment variables) to set backend
+endpoints, auth secrets, and rate limits. The default ports for the internal
+services are:
+
+| Service | Default URL |
+| ------- | ----------- |
+| `lendingd` | `http://127.0.0.1:7101` |
+| `swapd` | `http://127.0.0.1:7102` |
+| `governd` | `http://127.0.0.1:7103` |
+| `consensusd` | `http://127.0.0.1:7104` |
+
+Override these with environment variables (`NHB_GATEWAY_LENDING_URL`, etc.) or in
+`gateway.yaml`.

--- a/docs/migrate/monolith-to-gateway.md
+++ b/docs/migrate/monolith-to-gateway.md
@@ -1,0 +1,50 @@
+# Migrating from the Monolithic JSON-RPC Server
+
+The API gateway keeps the public JSON-RPC surface available under `/rpc` while
+backfilling requests to dedicated services. New integrations should migrate to
+the service-specific REST and gRPC surfaces exposed behind the gateway.
+
+## Method Mapping
+
+| Legacy JSON-RPC method | Gateway path | HTTP method | Backend service |
+| ---------------------- | ------------ | ----------- | --------------- |
+| `lending_getMarket` | `/v1/lending/markets/get` | `POST` | `lendingd` |
+| `lend_getPools` | `/v1/lending/pools` | `GET` | `lendingd` |
+| `lend_createPool` | `/v1/lending/pools` | `POST` | `lendingd` |
+| `lending_getUserAccount` | `/v1/lending/accounts/get` | `POST` | `lendingd` |
+| `lending_supplyNHB` | `/v1/lending/supply` | `POST` | `lendingd` |
+| `lending_withdrawNHB` | `/v1/lending/withdraw` | `POST` | `lendingd` |
+| `lending_depositZNHB` | `/v1/lending/collateral/deposit` | `POST` | `lendingd` |
+| `lending_withdrawZNHB` | `/v1/lending/collateral/withdraw` | `POST` | `lendingd` |
+| `lending_borrowNHB` | `/v1/lending/borrow` | `POST` | `lendingd` |
+| `lending_borrowNHBWithFee` | `/v1/lending/borrow/with-fee` | `POST` | `lendingd` |
+| `lending_repayNHB` | `/v1/lending/repay` | `POST` | `lendingd` |
+| `lending_liquidate` | `/v1/lending/liquidate` | `POST` | `lendingd` |
+| `swap_submitVoucher` | `/v1/swap/voucher/submit` | `POST` | `swapd` |
+| `swap_voucher_get` | `/v1/swap/voucher/get` | `POST` | `swapd` |
+| `swap_voucher_list` | `/v1/swap/voucher/list` | `POST` | `swapd` |
+| `swap_voucher_export` | `/v1/swap/voucher/export` | `POST` | `swapd` |
+| `swap_limits` | `/v1/swap/limits` | `GET` | `swapd` |
+| `swap_provider_status` | `/v1/swap/providers/status` | `GET` | `swapd` |
+| `swap_burn_list` | `/v1/swap/burn/list` | `GET` | `swapd` |
+| `swap_voucher_reverse` | `/v1/swap/voucher/reverse` | `POST` | `swapd` |
+| `gov_getProposal` | `/v1/gov/proposals/get` | `POST` | `governd` |
+| `gov_listProposals` | `/v1/gov/proposals` | `GET` | `governd` |
+| `gov_getTally` | `/v1/gov/proposals/tally` | `POST` | `governd` |
+| `gov_submitProposal` | `/v1/gov/proposals` | `POST` | `governd` |
+| `gov_vote` | `/v1/gov/votes` | `POST` | `governd` |
+| `gov_deposit` | `/v1/gov/deposits` | `POST` | `governd` |
+| `consensus_status` | `/v1/consensus/status` | `GET` | `consensusd` |
+| `consensus_validators` | `/v1/consensus/validators` | `GET` | `consensusd` |
+| `consensus_block` | `/v1/consensus/block` | `POST` | `consensusd` |
+
+Legacy JSON-RPC clients can continue posting to `/rpc`. The gateway converts
+the request into the corresponding REST call shown above, forwards it to the
+appropriate service, and wraps the response back into a JSON-RPC envelope.
+
+## Authentication and Rate Limits
+
+All mutating endpoints require a bearer token signed with the configured JWT/OAuth
+secret. Supply the token via the standard `Authorization: Bearer <token>` header.
+The gateway applies per-route rate limits which can be tuned in the configuration
+file under the `rateLimits` section.

--- a/examples/gateway/openapi.yaml
+++ b/examples/gateway/openapi.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.3
+info:
+  title: NHBChain Gateway
+  version: 1.0.0
+  description: |
+    Edge API that fronts the NHBChain microservices. Legacy JSON-RPC consumers
+    should continue POSTing to `/rpc`. New integrations should use the versioned
+    REST resources described here.
+servers:
+  - url: https://nhbcoin.net
+paths:
+  /v1/lending/markets/get:
+    post:
+      summary: Fetch a lending market definition
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                poolId:
+                  type: string
+      responses:
+        '200':
+          description: Market information
+  /v1/swap/voucher/submit:
+    post:
+      summary: Submit a signed swap voucher
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Voucher accepted
+  /v1/gov/proposals:
+    get:
+      summary: List governance proposals
+      responses:
+        '200':
+          description: Proposal list
+  /v1/consensus/status:
+    get:
+      summary: Retrieve consensus status
+      responses:
+        '200':
+          description: Status payload
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/gateway/compat/compat.go
+++ b/gateway/compat/compat.go
@@ -1,0 +1,181 @@
+package compat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Mapping struct {
+	Service string
+	Path    string
+	Method  string
+}
+
+type Service struct {
+	Name    string
+	BaseURL *url.URL
+	Client  *http.Client
+}
+
+type Dispatcher struct {
+	services map[string]*Service
+	mappings map[string]Mapping
+}
+
+func NewDispatcher(services []*Service, mappings map[string]Mapping) *Dispatcher {
+	svcMap := make(map[string]*Service, len(services))
+	for _, svc := range services {
+		if svc.Client == nil {
+			svc.Client = &http.Client{Timeout: 15 * time.Second}
+		}
+		svcMap[svc.Name] = svc
+	}
+	return &Dispatcher{services: svcMap, mappings: mappings}
+}
+
+func (d *Dispatcher) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload json.RawMessage
+		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			writeError(w, nil, -32700, fmt.Sprintf("read body: %v", err))
+			return
+		}
+		payload = body
+		if len(bytes.TrimSpace(payload)) == 0 {
+			writeError(w, nil, -32600, "empty request body")
+			return
+		}
+		if bytes.HasPrefix(bytes.TrimSpace(payload), []byte("[")) {
+			var requests []rpcRequest
+			if err := json.Unmarshal(payload, &requests); err != nil {
+				writeError(w, nil, -32700, fmt.Sprintf("decode batch: %v", err))
+				return
+			}
+			responses := make([]rpcResponse, 0, len(requests))
+			for _, req := range requests {
+				responses = append(responses, d.handleSingle(r.Context(), req))
+			}
+			writeJSON(w, responses)
+			return
+		}
+		var request rpcRequest
+		if err := json.Unmarshal(payload, &request); err != nil {
+			writeError(w, nil, -32700, fmt.Sprintf("decode request: %v", err))
+			return
+		}
+		resp := d.handleSingle(r.Context(), request)
+		writeJSON(w, resp)
+	})
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+	ID      any             `json:"id"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+	ID      any             `json:"id"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+func (d *Dispatcher) handleSingle(ctx context.Context, req rpcRequest) rpcResponse {
+	resp := rpcResponse{JSONRPC: "2.0", ID: req.ID}
+	mapping, ok := d.mappings[req.Method]
+	if !ok {
+		resp.Error = &rpcError{Code: -32601, Message: "method not found"}
+		return resp
+	}
+	service, ok := d.services[mapping.Service]
+	if !ok {
+		resp.Error = &rpcError{Code: -32001, Message: "service unavailable"}
+		return resp
+	}
+	method := mapping.Method
+	if method == "" {
+		method = http.MethodPost
+	}
+	endpoint := singleJoiningSlash(service.BaseURL.String(), mapping.Path)
+	payload := req.Params
+	if len(bytes.TrimSpace(payload)) == 0 {
+		payload = []byte("{}")
+	}
+	var bodyReader io.Reader
+	if method == http.MethodGet || method == http.MethodHead {
+		bodyReader = nil
+	} else {
+		bodyReader = bytes.NewReader(payload)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, method, endpoint, bodyReader)
+	if err != nil {
+		resp.Error = &rpcError{Code: -32602, Message: fmt.Sprintf("build request: %v", err)}
+		return resp
+	}
+	if bodyReader != nil {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+	httpResp, err := service.Client.Do(httpReq)
+	if err != nil {
+		resp.Error = &rpcError{Code: -32002, Message: fmt.Sprintf("upstream error: %v", err)}
+		return resp
+	}
+	defer httpResp.Body.Close()
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		resp.Error = &rpcError{Code: -32003, Message: fmt.Sprintf("read response: %v", err)}
+		return resp
+	}
+	if httpResp.StatusCode >= 400 {
+		resp.Error = &rpcError{Code: -32000, Message: "upstream error", Data: string(body)}
+		return resp
+	}
+	if len(body) == 0 {
+		resp.Result = json.RawMessage("null")
+	} else {
+		resp.Result = json.RawMessage(body)
+	}
+	return resp
+}
+
+func writeError(w http.ResponseWriter, id any, code int, msg string) {
+	writeJSON(w, rpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &rpcError{Code: code, Message: msg},
+	})
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	_ = enc.Encode(v)
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}

--- a/gateway/compat/mapping.go
+++ b/gateway/compat/mapping.go
@@ -1,0 +1,38 @@
+package compat
+
+import "net/http"
+
+var DefaultMappings = map[string]Mapping{
+	"lending_getMarket":        {Service: "lendingd", Path: "/v1/lending/markets/get", Method: http.MethodPost},
+	"lend_getPools":            {Service: "lendingd", Path: "/v1/lending/pools", Method: http.MethodGet},
+	"lend_createPool":          {Service: "lendingd", Path: "/v1/lending/pools", Method: http.MethodPost},
+	"lending_getUserAccount":   {Service: "lendingd", Path: "/v1/lending/accounts/get", Method: http.MethodPost},
+	"lending_supplyNHB":        {Service: "lendingd", Path: "/v1/lending/supply", Method: http.MethodPost},
+	"lending_withdrawNHB":      {Service: "lendingd", Path: "/v1/lending/withdraw", Method: http.MethodPost},
+	"lending_depositZNHB":      {Service: "lendingd", Path: "/v1/lending/collateral/deposit", Method: http.MethodPost},
+	"lending_withdrawZNHB":     {Service: "lendingd", Path: "/v1/lending/collateral/withdraw", Method: http.MethodPost},
+	"lending_borrowNHB":        {Service: "lendingd", Path: "/v1/lending/borrow", Method: http.MethodPost},
+	"lending_borrowNHBWithFee": {Service: "lendingd", Path: "/v1/lending/borrow/with-fee", Method: http.MethodPost},
+	"lending_repayNHB":         {Service: "lendingd", Path: "/v1/lending/repay", Method: http.MethodPost},
+	"lending_liquidate":        {Service: "lendingd", Path: "/v1/lending/liquidate", Method: http.MethodPost},
+
+	"swap_submitVoucher":   {Service: "swapd", Path: "/v1/swap/voucher/submit", Method: http.MethodPost},
+	"swap_voucher_get":     {Service: "swapd", Path: "/v1/swap/voucher/get", Method: http.MethodPost},
+	"swap_voucher_list":    {Service: "swapd", Path: "/v1/swap/voucher/list", Method: http.MethodPost},
+	"swap_voucher_export":  {Service: "swapd", Path: "/v1/swap/voucher/export", Method: http.MethodPost},
+	"swap_limits":          {Service: "swapd", Path: "/v1/swap/limits", Method: http.MethodGet},
+	"swap_provider_status": {Service: "swapd", Path: "/v1/swap/providers/status", Method: http.MethodGet},
+	"swap_burn_list":       {Service: "swapd", Path: "/v1/swap/burn/list", Method: http.MethodGet},
+	"swap_voucher_reverse": {Service: "swapd", Path: "/v1/swap/voucher/reverse", Method: http.MethodPost},
+
+	"gov_getProposal":    {Service: "governd", Path: "/v1/gov/proposals/get", Method: http.MethodPost},
+	"gov_listProposals":  {Service: "governd", Path: "/v1/gov/proposals", Method: http.MethodGet},
+	"gov_getTally":       {Service: "governd", Path: "/v1/gov/proposals/tally", Method: http.MethodPost},
+	"gov_submitProposal": {Service: "governd", Path: "/v1/gov/proposals", Method: http.MethodPost},
+	"gov_vote":           {Service: "governd", Path: "/v1/gov/votes", Method: http.MethodPost},
+	"gov_deposit":        {Service: "governd", Path: "/v1/gov/deposits", Method: http.MethodPost},
+
+	"consensus_status":     {Service: "consensusd", Path: "/v1/consensus/status", Method: http.MethodGet},
+	"consensus_validators": {Service: "consensusd", Path: "/v1/consensus/validators", Method: http.MethodGet},
+	"consensus_block":      {Service: "consensusd", Path: "/v1/consensus/block", Method: http.MethodPost},
+}

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ServiceConfig struct {
+	Name               string        `yaml:"name"`
+	Endpoint           string        `yaml:"endpoint"`
+	Timeout            time.Duration `yaml:"timeout"`
+	InsecureSkipVerify bool          `yaml:"insecureSkipVerify"`
+}
+
+type RateLimitConfig struct {
+	ID                string   `yaml:"id"`
+	RequestsPerMinute float64  `yaml:"requestsPerMinute"`
+	Burst             int      `yaml:"burst"`
+	Paths             []string `yaml:"paths"`
+}
+
+type ObservabilityConfig struct {
+	ServiceName   string `yaml:"serviceName"`
+	Metrics       bool   `yaml:"metrics"`
+	Tracing       bool   `yaml:"tracing"`
+	LogRequests   bool   `yaml:"logRequests"`
+	MetricsPrefix string `yaml:"metricsPrefix"`
+}
+
+type Config struct {
+	ListenAddress string              `yaml:"listen"`
+	ReadTimeout   time.Duration       `yaml:"readTimeout"`
+	WriteTimeout  time.Duration       `yaml:"writeTimeout"`
+	IdleTimeout   time.Duration       `yaml:"idleTimeout"`
+	Services      []ServiceConfig     `yaml:"services"`
+	RateLimits    []RateLimitConfig   `yaml:"rateLimits"`
+	Observability ObservabilityConfig `yaml:"observability"`
+	Auth          AuthConfig          `yaml:"auth"`
+}
+
+type AuthConfig struct {
+	Enabled        bool     `yaml:"enabled"`
+	HMACSecret     string   `yaml:"hmacSecret"`
+	Issuer         string   `yaml:"issuer"`
+	Audience       string   `yaml:"audience"`
+	ScopeClaim     string   `yaml:"scopeClaim"`
+	OptionalPaths  []string `yaml:"optionalPaths"`
+	AllowAnonymous bool     `yaml:"allowAnonymous"`
+}
+
+func Load(path string) (Config, error) {
+	cfg := Config{
+		ListenAddress: ":8080",
+		ReadTimeout:   30 * time.Second,
+		WriteTimeout:  30 * time.Second,
+		IdleTimeout:   120 * time.Second,
+		Observability: ObservabilityConfig{
+			ServiceName:   "nhb-gateway",
+			Metrics:       true,
+			Tracing:       true,
+			LogRequests:   true,
+			MetricsPrefix: "gateway",
+		},
+		Auth: AuthConfig{
+			Enabled:        false,
+			ScopeClaim:     "scope",
+			AllowAnonymous: true,
+		},
+	}
+	if path == "" {
+		return cfg, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("open config: %w", err)
+	}
+	defer file.Close()
+
+	decoder := yaml.NewDecoder(file)
+	if err := decoder.Decode(&cfg); err != nil {
+		return Config{}, fmt.Errorf("decode config: %w", err)
+	}
+	return cfg, nil
+}
+
+func (s ServiceConfig) URL() (*url.URL, error) {
+	if s.Endpoint == "" {
+		return nil, fmt.Errorf("endpoint missing for service %s", s.Name)
+	}
+	parsed, err := url.Parse(s.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("parse service %s endpoint: %w", s.Name, err)
+	}
+	return parsed, nil
+}
+
+func (cfg Config) ServiceByName(name string) (*ServiceConfig, error) {
+	for _, svc := range cfg.Services {
+		if svc.Name == name {
+			return &svc, nil
+		}
+	}
+	return nil, fmt.Errorf("service %s not configured", name)
+}

--- a/gateway/middleware/auth.go
+++ b/gateway/middleware/auth.go
@@ -1,0 +1,217 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+)
+
+type AuthConfig struct {
+	Enabled        bool
+	HMACSecret     string
+	Issuer         string
+	Audience       string
+	ScopeClaim     string
+	OptionalPaths  []string
+	AllowAnonymous bool
+}
+
+type contextKey string
+
+const (
+	ContextKeyToken  contextKey = "gateway.token"
+	ContextKeyScopes contextKey = "gateway.scopes"
+)
+
+type Authenticator struct {
+	cfg           AuthConfig
+	logger        *log.Logger
+	secret        []byte
+	optionalPaths []string
+	once          sync.Once
+}
+
+func NewAuthenticator(cfg AuthConfig, logger *log.Logger) *Authenticator {
+	if logger == nil {
+		logger = log.Default()
+	}
+	auth := &Authenticator{cfg: cfg, logger: logger}
+	auth.once.Do(func() {
+		auth.secret = []byte(strings.TrimSpace(cfg.HMACSecret))
+		if auth.cfg.ScopeClaim == "" {
+			auth.cfg.ScopeClaim = "scope"
+		}
+	})
+	return auth
+}
+
+func (a *Authenticator) Middleware(requiredScopes ...string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !a.cfg.Enabled {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if a.isOptional(r.URL.Path) && a.cfg.AllowAnonymous {
+				next.ServeHTTP(w, r)
+				return
+			}
+			tokenString := extractBearer(r.Header.Get("Authorization"))
+			if tokenString == "" {
+				http.Error(w, "missing bearer token", http.StatusUnauthorized)
+				return
+			}
+			claims, err := a.parseToken(tokenString)
+			if err != nil {
+				a.logger.Printf("auth: token validation failed: %v", err)
+				http.Error(w, "invalid token", http.StatusUnauthorized)
+				return
+			}
+			if err := validateClaims(claims, a.cfg.Issuer, a.cfg.Audience); err != nil {
+				a.logger.Printf("auth: claim validation failed: %v", err)
+				http.Error(w, "invalid token", http.StatusUnauthorized)
+				return
+			}
+			scopes := extractScopes(claims, a.cfg.ScopeClaim)
+			if len(requiredScopes) > 0 && !hasScopes(scopes, requiredScopes) {
+				http.Error(w, "insufficient scope", http.StatusForbidden)
+				return
+			}
+			ctx := context.WithValue(r.Context(), ContextKeyToken, tokenString)
+			ctx = context.WithValue(ctx, ContextKeyScopes, scopes)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func (a *Authenticator) isOptional(path string) bool {
+	for _, prefix := range a.cfg.OptionalPaths {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *Authenticator) parseToken(tokenString string) (jwt.MapClaims, error) {
+	if len(a.secret) == 0 {
+		return nil, errors.New("auth secret not configured")
+	}
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return a.secret, nil
+	}, jwt.WithLeeway(30*time.Second))
+	if err != nil {
+		return nil, err
+	}
+	if !token.Valid {
+		return nil, errors.New("token invalid")
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.New("claims not map")
+	}
+	return claims, nil
+}
+
+func validateClaims(claims jwt.MapClaims, issuer, audience string) error {
+	if issuer != "" {
+		if value, ok := claims["iss"].(string); !ok || value != issuer {
+			return errors.New("issuer mismatch")
+		}
+	}
+	if audience != "" {
+		switch val := claims["aud"].(type) {
+		case string:
+			if val != audience {
+				return errors.New("audience mismatch")
+			}
+		case []interface{}:
+			matched := false
+			for _, entry := range val {
+				if s, ok := entry.(string); ok && s == audience {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return errors.New("audience mismatch")
+			}
+		}
+	}
+	if exp, ok := claims["exp"].(float64); ok {
+		if int64(exp) < time.Now().Unix() {
+			return errors.New("token expired")
+		}
+	}
+	return nil
+}
+
+func extractScopes(claims jwt.MapClaims, scopeClaim string) []string {
+	if scopeClaim == "" {
+		scopeClaim = "scope"
+	}
+	raw, ok := claims[scopeClaim]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return nil
+		}
+		fields := strings.Fields(trimmed)
+		out := make([]string, 0, len(fields))
+		out = append(out, fields...)
+		return out
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for _, entry := range v {
+			if s, ok := entry.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func hasScopes(scopes []string, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	set := make(map[string]struct{}, len(scopes))
+	for _, scope := range scopes {
+		set[scope] = struct{}{}
+	}
+	for _, req := range required {
+		if _, ok := set[req]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func extractBearer(header string) string {
+	if header == "" {
+		return ""
+	}
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	if !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}

--- a/gateway/middleware/cors.go
+++ b/gateway/middleware/cors.go
@@ -1,0 +1,56 @@
+package middleware
+
+import "net/http"
+
+type CORSConfig struct {
+	AllowedOrigins   []string
+	AllowedMethods   []string
+	AllowedHeaders   []string
+	AllowCredentials bool
+}
+
+func CORS(cfg CORSConfig) func(http.Handler) http.Handler {
+	origins := cfg.AllowedOrigins
+	if len(origins) == 0 {
+		origins = []string{"*"}
+	}
+	methods := cfg.AllowedMethods
+	if len(methods) == 0 {
+		methods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
+	}
+	headers := cfg.AllowedHeaders
+	if len(headers) == 0 {
+		headers = []string{"Content-Type", "Authorization", "X-Requested-With"}
+	}
+	allowCredentials := "false"
+	if cfg.AllowCredentials {
+		allowCredentials = "true"
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for _, origin := range origins {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				break
+			}
+			w.Header().Set("Access-Control-Allow-Methods", join(methods))
+			w.Header().Set("Access-Control-Allow-Headers", join(headers))
+			w.Header().Set("Access-Control-Allow-Credentials", allowCredentials)
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func join(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	out := values[0]
+	for i := 1; i < len(values); i++ {
+		out += ", " + values[i]
+	}
+	return out
+}

--- a/gateway/middleware/observability.go
+++ b/gateway/middleware/observability.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type ObservabilityConfig struct {
+	ServiceName   string
+	MetricsPrefix string
+	LogRequests   bool
+	Enabled       bool
+}
+
+type Observability struct {
+	cfg       ObservabilityConfig
+	logger    *log.Logger
+	tracer    trace.Tracer
+	requests  *prometheus.CounterVec
+	durations *prometheus.HistogramVec
+	registry  *prometheus.Registry
+}
+
+func NewObservability(cfg ObservabilityConfig, logger *log.Logger) *Observability {
+	if logger == nil {
+		logger = log.Default()
+	}
+	if cfg.ServiceName == "" {
+		cfg.ServiceName = "nhb-gateway"
+	}
+	if cfg.MetricsPrefix == "" {
+		cfg.MetricsPrefix = "gateway"
+	}
+	registry := prometheus.NewRegistry()
+	requests := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: cfg.MetricsPrefix,
+		Name:      "requests_total",
+		Help:      "Total HTTP requests processed by the gateway.",
+	}, []string{"route", "method", "status"})
+	durations := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: cfg.MetricsPrefix,
+		Name:      "request_duration_seconds",
+		Help:      "Duration of HTTP requests in seconds.",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"route", "method"})
+	registry.MustRegister(requests, durations)
+	tracer := otel.Tracer(cfg.ServiceName)
+	return &Observability{
+		cfg:       cfg,
+		logger:    logger,
+		tracer:    tracer,
+		requests:  requests,
+		durations: durations,
+		registry:  registry,
+	}
+}
+
+func (o *Observability) Middleware(route string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !o.cfg.Enabled {
+				next.ServeHTTP(w, r)
+				return
+			}
+			start := time.Now()
+			ctx, span := o.tracer.Start(r.Context(), route, trace.WithAttributes(
+				attribute.String("http.method", r.Method),
+				attribute.String("http.route", route),
+			))
+			recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(recorder, r.WithContext(ctx))
+			span.SetAttributes(attribute.Int("http.status_code", recorder.status))
+			span.End()
+			duration := time.Since(start).Seconds()
+			o.requests.WithLabelValues(route, r.Method, http.StatusText(recorder.status)).Inc()
+			o.durations.WithLabelValues(route, r.Method).Observe(duration)
+			if o.cfg.LogRequests {
+				o.logger.Printf("%s %s -> %d (%.2fms)", r.Method, r.URL.Path, recorder.status, duration*1000)
+			}
+		})
+	}
+}
+
+func (o *Observability) MetricsHandler() http.Handler {
+	return promhttp.HandlerFor(o.registry, promhttp.HandlerOpts{})
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}

--- a/gateway/middleware/ratelimit.go
+++ b/gateway/middleware/ratelimit.go
@@ -1,0 +1,125 @@
+package middleware
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type RateLimit struct {
+	RequestsPerMinute float64
+	Burst             int
+}
+
+type rateEntry struct {
+	limiter *rate.Limiter
+}
+
+type RateLimiter struct {
+	logger   *log.Logger
+	limits   map[string]RateLimit
+	mu       sync.RWMutex
+	visitors map[string]*rateEntry
+	clockNow func() time.Time
+}
+
+func NewRateLimiter(limits map[string]RateLimit, logger *log.Logger) *RateLimiter {
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &RateLimiter{
+		logger:   logger,
+		limits:   limits,
+		visitors: make(map[string]*rateEntry),
+		clockNow: time.Now,
+	}
+}
+
+func (r *RateLimiter) Middleware(key string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			limit, ok := r.limits[key]
+			if !ok {
+				next.ServeHTTP(w, req)
+				return
+			}
+			identifier := clientID(req)
+			limiter := r.obtainLimiter(identifier, limit)
+			if !limiter.Allow() {
+				http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+				return
+			}
+			next.ServeHTTP(w, req)
+		})
+	}
+}
+
+func (r *RateLimiter) obtainLimiter(id string, cfg RateLimit) *rate.Limiter {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.visitors[id]
+	if ok {
+		return entry.limiter
+	}
+	perSecond := cfg.RequestsPerMinute / 60.0
+	if perSecond <= 0 {
+		perSecond = 1
+	}
+	burst := cfg.Burst
+	if burst <= 0 {
+		burst = 1
+	}
+	limiter := rate.NewLimiter(rate.Limit(perSecond), burst)
+	r.visitors[id] = &rateEntry{limiter: limiter}
+	go r.cleanup(id)
+	return limiter
+}
+
+func (r *RateLimiter) cleanup(id string) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		r.mu.Lock()
+		delete(r.visitors, id)
+		r.mu.Unlock()
+		return
+	}
+}
+
+func clientID(r *http.Request) string {
+	if ip := r.Header.Get("X-Real-IP"); ip != "" {
+		return ip
+	}
+	if ip := r.Header.Get("X-Forwarded-For"); ip != "" {
+		parts := net.ParseIP(ip)
+		if parts != nil {
+			return parts.String()
+		}
+		if comma := stringIndex(ip, ','); comma > 0 {
+			trimmed := strings.TrimSpace(ip[:comma])
+			if parsed := net.ParseIP(trimmed); parsed != nil {
+				return parsed.String()
+			}
+		}
+		return ip
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+func stringIndex(s string, ch byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ch {
+			return i
+		}
+	}
+	return -1
+}

--- a/gateway/routes/proxy.go
+++ b/gateway/routes/proxy.go
@@ -1,0 +1,46 @@
+package routes
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+func NewProxy(target *url.URL, stripPrefix string) http.Handler {
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	logger := log.Default()
+	basePath := strings.TrimSuffix(stripPrefix, "/")
+	proxy.Director = func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.Host = target.Host
+		path := req.URL.Path
+		if basePath != "" && strings.HasPrefix(path, basePath) {
+			path = strings.TrimPrefix(path, basePath)
+		}
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		req.URL.Path = singleJoiningSlash(target.Path, path)
+		req.URL.RawPath = req.URL.EscapedPath()
+	}
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		logger.Printf("proxy error: %v", err)
+		http.Error(w, "upstream error", http.StatusBadGateway)
+	}
+	return proxy
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}

--- a/gateway/routes/router.go
+++ b/gateway/routes/router.go
@@ -1,0 +1,75 @@
+package routes
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/go-chi/chi/v5"
+
+	"nhbchain/gateway/middleware"
+)
+
+type ServiceRoute struct {
+	Name           string
+	Prefix         string
+	Target         *url.URL
+	RequireAuth    bool
+	RequiredScopes []string
+	RateLimitKey   string
+}
+
+type Config struct {
+	Routes        []ServiceRoute
+	CompatHandler http.Handler
+	HealthHandler http.Handler
+	Authenticator *middleware.Authenticator
+	RateLimiter   *middleware.RateLimiter
+	Observability *middleware.Observability
+	CORS          middleware.CORSConfig
+}
+
+func New(cfg Config) http.Handler {
+	r := chi.NewRouter()
+	if cfg.CORS.AllowedOrigins != nil || cfg.CORS.AllowedMethods != nil {
+		r.Use(middleware.CORS(cfg.CORS))
+	} else {
+		r.Use(middleware.CORS(middleware.CORSConfig{}))
+	}
+
+	obs := cfg.Observability
+	if obs != nil {
+		r.Use(obs.Middleware("root"))
+	}
+
+	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	if cfg.CompatHandler != nil {
+		r.Handle("/rpc", cfg.CompatHandler)
+	}
+
+	for _, route := range cfg.Routes {
+		proxy := NewProxy(route.Target, route.Prefix)
+		r.Route(route.Prefix, func(sr chi.Router) {
+			if cfg.RateLimiter != nil && route.RateLimitKey != "" {
+				sr.Use(cfg.RateLimiter.Middleware(route.RateLimitKey))
+			}
+			if cfg.Authenticator != nil && route.RequireAuth {
+				sr.Use(cfg.Authenticator.Middleware(route.RequiredScopes...))
+			}
+			if obs != nil {
+				sr.Use(obs.Middleware(route.Name))
+			}
+			sr.Handle("/*", proxy)
+			sr.Handle("/", proxy)
+		})
+	}
+
+	if obs != nil {
+		r.Handle("/metrics", obs.MetricsHandler())
+	}
+
+	return r
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.16.3
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-chi/chi/v5 v5.2.3
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/holiman/uint256 v1.3.2
 	github.com/miekg/dns v1.1.59
@@ -19,6 +20,8 @@ require (
 	github.com/xitongsys/parquet-go-source v0.0.0-20241021075129-b732d2ac9c9b
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
+	go.opentelemetry.io/otel/trace v1.24.0
+	golang.org/x/time v0.9.0
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/yaml.v3 v3.0.1
@@ -27,6 +30,8 @@ require (
 	lukechampine.com/blake3 v1.4.1
 	modernc.org/sqlite v1.39.0
 )
+
+replace github.com/apache/thrift => github.com/apache/thrift v0.0.0-20181112125854-24918abba929
 
 require (
 	github.com/StackExchange/wmi v1.2.1 // indirect
@@ -78,7 +83,6 @@ require (
 	github.com/supranational/blst v0.3.14 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
-	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/mod v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188/go.mod h1:vXjM/+wXQnTPR4KqTKDgJukSZ6amVRtWMPEjE6sQoK8=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -963,6 +965,8 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220224211638-0e9765cccd65/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/go.work.sum
+++ b/go.work.sum
@@ -243,6 +243,7 @@ github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b/go.mod h1:W+zGtBO5Y1Ig
 github.com/envoyproxy/go-control-plane v0.12.0/go.mod h1:ZBTaoJ23lqITozF0M6G4/IragXCQKCnYbmlmtHvwRG0=
 github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -292,7 +293,6 @@ golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
-golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/rpc/net_handlers.go
+++ b/rpc/net_handlers.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 	"time"
 
@@ -140,8 +139,7 @@ func (s *Server) handleNetBan(w http.ResponseWriter, r *http.Request, req *RPCRe
 }
 
 func writeNetError(w http.ResponseWriter, id any, err error) {
-	var st *status.Status
-	if errors.As(err, &st) {
+	if st, ok := status.FromError(err); ok {
 		switch st.Code() {
 		case codes.InvalidArgument:
 			writeError(w, http.StatusBadRequest, id, codeNetInvalidParams, "invalid_params", st.Message())


### PR DESCRIPTION
## Summary
- add a dedicated gateway command that wires JWT authentication, per-route rate limits, observability, and reverse proxies for the lending, swap, governance, and consensus services
- introduce a compatibility dispatcher that translates legacy JSON-RPC methods into the new service endpoints while keeping method names stable
- document the gateway architecture and migration mapping, publish an OpenAPI example, and update network error handling to use gRPC status conversion

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d830f25398832d9ab72700af76d157