### PR TITLE
Add synthetic multi-service E2E and chaos tests

### DIFF
--- a/docs/testing/e2e.md
+++ b/docs/testing/e2e.md
@@ -1,0 +1,36 @@
+# End-to-End & Chaos Testing
+
+The end-to-end suite exercises the supply → borrow → repay, mint → redeem, and governance proposal flows across a synthetic service mesh. Chaos tests simulate process crashes and validate that retries are idempotent and recovery occurs in under 30 seconds.
+
+## Running locally
+
+```bash
+go test ./tests/e2e ./tests/chaos
+```
+
+Both packages build an in-process cluster consisting of stubbed versions of `consensusd`, `p2pd`, `lendingd`, `swapd`, `governd`, and the HTTP gateway. Each service exposes a minimal API that mimics the real production interfaces so downstream clients can exercise the expected flows.
+
+## What the tests cover
+
+- **Lending flow:** supply collateral, borrow against it, repay, and verify health metrics through the gateway.
+- **Swap flow:** mint and redeem tokens while respecting balance limits and idempotent request IDs.
+- **Governance flow:** submit a proposal, cast votes, apply the change, and confirm the result via consensus state.
+- **Chaos:** terminate `lendingd` or `swapd` mid-transaction, restart, and ensure the original request ID can be safely retried with consistent results.
+
+## CI integration
+
+Add the following job to your GitHub Actions workflow to run the suite on each pull request:
+
+```yaml
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - run: go test ./tests/e2e ./tests/chaos
+```
+
+This command returns non-zero on any regression, allowing CI to block merges until the full flows and chaos recovery scenarios succeed.

--- a/tests/chaos/recovery_test.go
+++ b/tests/chaos/recovery_test.go
@@ -1,0 +1,185 @@
+package chaos
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"nhbchain/tests/support/cluster"
+)
+
+type lendingResponse struct {
+	Position struct {
+		Borrowed int64 `json:"borrowed"`
+		Supplied int64 `json:"supplied"`
+	} `json:"position"`
+}
+
+type swapResponse struct {
+	Balance int64 `json:"balance"`
+}
+
+func TestLendingFlowRecoversAfterServiceRestart(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	cl, err := cluster.New(ctx)
+	if err != nil {
+		t.Fatalf("start cluster: %v", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := cl.Stop(shutdownCtx); err != nil {
+			t.Fatalf("stop cluster: %v", err)
+		}
+	}()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	base := cl.GatewayURL()
+	account := "borrower-one"
+
+	// seed collateral
+	payload := map[string]any{"account": account, "amount": 900, "request_id": "seed-1"}
+	requirePost(t, client, fmt.Sprintf("%s/v1/lending/supply", base), payload, &lendingResponse{})
+
+	start := time.Now()
+
+	borrow := map[string]any{"account": account, "amount": 400, "request_id": "borrow-2"}
+	// stop lending service to simulate crash
+	if err := cl.Kill(ctx, cluster.ServiceLending); err != nil {
+		t.Fatalf("kill lending: %v", err)
+	}
+	err = postExpectError(client, fmt.Sprintf("%s/v1/lending/borrow", base), borrow)
+	if err == nil {
+		t.Fatalf("expected borrow to fail during outage")
+	}
+
+	if _, err := cl.Restart(ctx, cluster.ServiceLending); err != nil {
+		t.Fatalf("restart lending: %v", err)
+	}
+
+	// retry should succeed and be idempotent
+	var borrowResp lendingResponse
+	requirePost(t, client, fmt.Sprintf("%s/v1/lending/borrow", base), borrow, &borrowResp)
+	if borrowResp.Position.Borrowed != 400 {
+		t.Fatalf("unexpected borrow result: %+v", borrowResp.Position)
+	}
+
+	// repeated retry with same request id should not change balance
+	requirePost(t, client, fmt.Sprintf("%s/v1/lending/borrow", base), borrow, &borrowResp)
+	if borrowResp.Position.Borrowed != 400 {
+		t.Fatalf("idempotent retry changed state: %+v", borrowResp.Position)
+	}
+
+	repay := map[string]any{"account": account, "amount": 200, "request_id": "repay-2"}
+	requirePost(t, client, fmt.Sprintf("%s/v1/lending/repay", base), repay, &borrowResp)
+	if borrowResp.Position.Borrowed != 200 {
+		t.Fatalf("unexpected repay result: %+v", borrowResp.Position)
+	}
+
+	if time.Since(start) > 30*time.Second {
+		t.Fatalf("recovery exceeded MTTR target: %v", time.Since(start))
+	}
+}
+
+func TestSwapMintRedeemWithChaos(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	cl, err := cluster.New(ctx)
+	if err != nil {
+		t.Fatalf("start cluster: %v", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := cl.Stop(shutdownCtx); err != nil {
+			t.Fatalf("stop cluster: %v", err)
+		}
+	}()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	base := cl.GatewayURL()
+	account := "swapper-two"
+
+	mint := map[string]any{"account": account, "amount": 600, "request_id": "mint-chaos"}
+	requirePost(t, client, fmt.Sprintf("%s/v1/swap/mint", base), mint, &swapResponse{})
+
+	redeem := map[string]any{"account": account, "amount": 250, "request_id": "redeem-chaos"}
+	if err := cl.Kill(ctx, cluster.ServiceSwap); err != nil {
+		t.Fatalf("kill swapd: %v", err)
+	}
+	if err := postExpectError(client, fmt.Sprintf("%s/v1/swap/redeem", base), redeem); err == nil {
+		t.Fatalf("expected redeem failure while service stopped")
+	}
+
+	if _, err := cl.Restart(ctx, cluster.ServiceSwap); err != nil {
+		t.Fatalf("restart swapd: %v", err)
+	}
+
+	var redeemResp swapResponse
+	requirePost(t, client, fmt.Sprintf("%s/v1/swap/redeem", base), redeem, &redeemResp)
+	if redeemResp.Balance != 350 {
+		t.Fatalf("unexpected redeem balance: %+v", redeemResp)
+	}
+
+	// duplicate redeem request should not reduce balance again
+	requirePost(t, client, fmt.Sprintf("%s/v1/swap/redeem", base), redeem, &redeemResp)
+	if redeemResp.Balance != 350 {
+		t.Fatalf("idempotent redeem altered balance: %+v", redeemResp)
+	}
+}
+
+func requirePost(t *testing.T, client *http.Client, url string, payload map[string]any, out any) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("post %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("post %s status %d: %s", url, resp.StatusCode, string(data))
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			t.Fatalf("decode %s: %v", url, err)
+		}
+	}
+}
+
+func postExpectError(client *http.Client, url string, payload map[string]any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		return fmt.Errorf("expected non-200 status")
+	}
+	return fmt.Errorf("status %d", resp.StatusCode)
+}

--- a/tests/e2e/flows_e2e_test.go
+++ b/tests/e2e/flows_e2e_test.go
@@ -1,0 +1,225 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"nhbchain/tests/support/cluster"
+)
+
+type lendingPosition struct {
+	Account      string `json:"account"`
+	Supplied     int64  `json:"supplied"`
+	Borrowed     int64  `json:"borrowed"`
+	HealthFactor string `json:"health_factor"`
+}
+
+type lendingResponse struct {
+	Position lendingPosition `json:"position"`
+}
+
+type swapResponse struct {
+	Account string `json:"account"`
+	Balance int64  `json:"balance"`
+}
+
+type proposalResponse struct {
+	Proposal struct {
+		ID          int    `json:"id"`
+		Status      string `json:"status"`
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		YesVotes    int    `json:"yes_votes"`
+	} `json:"proposal"`
+}
+
+type applyResponse struct {
+	ProposalID int   `json:"proposal_id"`
+	Height     int64 `json:"height"`
+}
+
+type consensusSnapshot struct {
+	Height    int   `json:"height"`
+	Proposals []int `json:"proposals"`
+}
+
+func TestEndToEndFinancialFlows(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cl, err := cluster.New(ctx)
+	if err != nil {
+		t.Fatalf("start cluster: %v", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := cl.Stop(shutdownCtx); err != nil {
+			t.Fatalf("shutdown cluster: %v", err)
+		}
+	}()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	base := cl.GatewayURL()
+	account := "alice-account"
+
+	supply := map[string]any{"account": account, "amount": 1000, "request_id": "supply-1"}
+	var supplyResp lendingResponse
+	doPost(t, client, fmt.Sprintf("%s/v1/lending/supply", base), supply, &supplyResp)
+	if supplyResp.Position.Supplied != 1000 {
+		t.Fatalf("unexpected supply: %+v", supplyResp.Position)
+	}
+
+	// ensure idempotent replays do not change state
+	var replay lendingResponse
+	doPost(t, client, fmt.Sprintf("%s/v1/lending/supply", base), supply, &replay)
+	if replay.Position.Supplied != 1000 {
+		t.Fatalf("idempotent supply mismatch: %+v", replay.Position)
+	}
+
+	borrow := map[string]any{"account": account, "amount": 400, "request_id": "borrow-1"}
+	var borrowResp lendingResponse
+	doPost(t, client, fmt.Sprintf("%s/v1/lending/borrow", base), borrow, &borrowResp)
+	if borrowResp.Position.Borrowed != 400 {
+		t.Fatalf("unexpected borrow: %+v", borrowResp.Position)
+	}
+
+	position := queryPosition(t, client, base, account)
+	if position.Position.Borrowed != 400 || position.Position.Supplied != 1000 {
+		t.Fatalf("unexpected position after borrow: %+v", position.Position)
+	}
+
+	repay := map[string]any{"account": account, "amount": 250, "request_id": "repay-1"}
+	var repayResp lendingResponse
+	doPost(t, client, fmt.Sprintf("%s/v1/lending/repay", base), repay, &repayResp)
+	if repayResp.Position.Borrowed != 150 {
+		t.Fatalf("unexpected borrow after repay: %+v", repayResp.Position)
+	}
+
+	mint := map[string]any{"account": account, "amount": 500, "request_id": "mint-1"}
+	var mintResp swapResponse
+	doPost(t, client, fmt.Sprintf("%s/v1/swap/mint", base), mint, &mintResp)
+	if mintResp.Balance != 500 {
+		t.Fatalf("unexpected mint balance: %+v", mintResp)
+	}
+
+	redeem := map[string]any{"account": account, "amount": 200, "request_id": "redeem-1"}
+	var redeemResp swapResponse
+	doPost(t, client, fmt.Sprintf("%s/v1/swap/redeem", base), redeem, &redeemResp)
+	if redeemResp.Balance != 300 {
+		t.Fatalf("unexpected balance after redeem: %+v", redeemResp)
+	}
+
+	proposalPayload := map[string]any{"title": "raise-cap", "description": "increase limits", "request_id": "proposal-1"}
+	var proposalResp proposalResponse
+	doPost(t, client, fmt.Sprintf("%s/v1/gov/proposals", base), proposalPayload, &proposalResp)
+	proposalID := proposalResp.Proposal.ID
+	if proposalID == 0 {
+		t.Fatalf("proposal id missing: %+v", proposalResp)
+	}
+
+	votePayload := map[string]any{"voter": "validator-1", "option": "yes", "request_id": "vote-1"}
+	doPost(t, client, fmt.Sprintf("%s/v1/gov/proposals/%d/vote", base, proposalID), votePayload, &proposalResp)
+	if proposalResp.Proposal.YesVotes != 1 {
+		t.Fatalf("vote not recorded: %+v", proposalResp.Proposal)
+	}
+
+	applyPayload := map[string]any{"request_id": "apply-1"}
+	var applied applyResponse
+	doPost(t, client, fmt.Sprintf("%s/v1/gov/proposals/%d/apply", base, proposalID), applyPayload, &applied)
+	if applied.ProposalID != proposalID || applied.Height == 0 {
+		t.Fatalf("unexpected apply response: %+v", applied)
+	}
+
+	snapshot := queryConsensus(t, client, base)
+	if snapshot.Height != int(applied.Height) || len(snapshot.Proposals) == 0 {
+		t.Fatalf("unexpected consensus snapshot: %+v", snapshot)
+	}
+	found := false
+	for _, id := range snapshot.Proposals {
+		if id == proposalID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("proposal %d not applied in consensus: %+v", proposalID, snapshot)
+	}
+}
+
+func doPost(t *testing.T, client *http.Client, url string, payload map[string]any, out any) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("post %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("post %s status %d: %s", url, resp.StatusCode, string(data))
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			t.Fatalf("decode response from %s: %v", url, err)
+		}
+	}
+}
+
+func queryPosition(t *testing.T, client *http.Client, base, account string) lendingResponse {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/lending/position?account=%s", base, account), nil)
+	if err != nil {
+		t.Fatalf("position request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("get position: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("position status %d: %s", resp.StatusCode, string(data))
+	}
+	var result lendingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode position: %v", err)
+	}
+	return result
+}
+
+func queryConsensus(t *testing.T, client *http.Client, base string) consensusSnapshot {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/consensus/applied", base), nil)
+	if err != nil {
+		t.Fatalf("consensus request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("get consensus snapshot: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(resp.Body)
+		t.Fatalf("consensus status %d: %s", resp.StatusCode, string(data))
+	}
+	var snapshot consensusSnapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snapshot); err != nil {
+		t.Fatalf("decode consensus snapshot: %v", err)
+	}
+	return snapshot
+}

--- a/tests/support/cluster/services.go
+++ b/tests/support/cluster/services.go
@@ -1,0 +1,679 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type ServiceName string
+
+const (
+	ServiceConsensus ServiceName = "consensusd"
+	ServiceP2P       ServiceName = "p2pd"
+	ServiceLending   ServiceName = "lendingd"
+	ServiceSwap      ServiceName = "swapd"
+	ServiceGov       ServiceName = "governd"
+	ServiceGateway   ServiceName = "gateway"
+)
+
+type Cluster struct {
+	state    *State
+	services map[ServiceName]*serviceProcess
+	gateway  *gatewayServer
+	client   *http.Client
+	mu       sync.Mutex
+}
+
+type serviceProcess struct {
+	name        ServiceName
+	addr        string
+	handlerFunc func(*State) http.Handler
+	server      *http.Server
+	listener    net.Listener
+	running     bool
+	mu          sync.Mutex
+}
+
+func New(ctx context.Context) (*Cluster, error) {
+	state := newState()
+	cluster := &Cluster{
+		state:    state,
+		services: make(map[ServiceName]*serviceProcess),
+		client:   &http.Client{Timeout: 3 * time.Second},
+	}
+
+	cluster.services[ServiceConsensus] = newService(ServiceConsensus, consensusHandler)
+	cluster.services[ServiceP2P] = newService(ServiceP2P, p2pHandler)
+	cluster.services[ServiceLending] = newService(ServiceLending, lendingHandler)
+	cluster.services[ServiceSwap] = newService(ServiceSwap, swapHandler)
+	cluster.services[ServiceGov] = newService(ServiceGov, func(state *State) http.Handler {
+		return govHandler(state, cluster)
+	})
+
+	for name, svc := range cluster.services {
+		if err := svc.start(ctx, state); err != nil {
+			return nil, fmt.Errorf("start %s: %w", name, err)
+		}
+	}
+
+	endpoints := make(map[ServiceName]*url.URL)
+	for name, svc := range cluster.services {
+		parsed, err := url.Parse("http://" + svc.addr)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s addr: %w", name, err)
+		}
+		endpoints[name] = parsed
+	}
+
+	gw, err := newGatewayServer(endpoints)
+	if err != nil {
+		return nil, fmt.Errorf("start gateway: %w", err)
+	}
+	cluster.gateway = gw
+	cluster.services[ServiceGateway] = gw.process
+
+	return cluster, nil
+}
+
+func newService(name ServiceName, build func(*State) http.Handler) *serviceProcess {
+	return &serviceProcess{name: name, handlerFunc: build}
+}
+
+func (c *Cluster) Stop(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var errs []string
+	for name, svc := range c.services {
+		if err := svc.stop(ctx); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf(strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func (s *serviceProcess) start(ctx context.Context, state *State) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.running {
+		return nil
+	}
+	handler := s.handlerFunc(state)
+	if handler == nil {
+		return fmt.Errorf("handler not provided")
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+	s.addr = listener.Addr().String()
+	srv := &http.Server{Handler: handler}
+	s.server = srv
+	s.listener = listener
+	go func() {
+		_ = srv.Serve(listener)
+	}()
+	if err := waitForHealthy(ctx, "http://"+s.addr); err != nil {
+		_ = srv.Close()
+		return err
+	}
+	s.running = true
+	return nil
+}
+
+func (s *serviceProcess) stop(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.running {
+		return nil
+	}
+	shutdownCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if err := s.server.Shutdown(shutdownCtx); err != nil {
+		return err
+	}
+	s.running = false
+	return nil
+}
+
+func (s *serviceProcess) restart(ctx context.Context, state *State) error {
+	if err := s.stop(ctx); err != nil {
+		return err
+	}
+	// ensure listener is closed before reusing address
+	if s.listener != nil {
+		_ = s.listener.Close()
+	}
+	// bind to the previous address if possible
+	addr := s.addr
+	handler := s.handlerFunc(state)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		// fall back to random port
+		listener, err = net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return fmt.Errorf("listen: %w", err)
+		}
+	}
+	s.addr = listener.Addr().String()
+	srv := &http.Server{Handler: handler}
+	s.server = srv
+	s.listener = listener
+	go func() {
+		_ = srv.Serve(listener)
+	}()
+	if err := waitForHealthy(ctx, "http://"+s.addr); err != nil {
+		_ = srv.Close()
+		return err
+	}
+	s.running = true
+	return nil
+}
+
+func waitForHealthy(ctx context.Context, base string) error {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		reqCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		req, _ := http.NewRequestWithContext(reqCtx, http.MethodGet, base+"/healthz", nil)
+		resp, err := client.Do(req)
+		cancel()
+		if err == nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("health check failed: %w", err)
+			}
+			return fmt.Errorf("health check failed with status %d", resp.StatusCode)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func consensusHandler(state *State) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("/applied", func(w http.ResponseWriter, r *http.Request) {
+		snapshot := state.consensusState()
+		writeJSON(w, http.StatusOK, snapshot)
+	})
+	mux.HandleFunc("/apply", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			ProposalID int    `json:"proposal_id"`
+			RequestID  string `json:"request_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		resp, err := state.apply(req.RequestID, req.ProposalID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+	return mux
+}
+
+func p2pHandler(state *State) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("/peers", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"peers": []string{"node-a", "node-b"}})
+	})
+	return mux
+}
+
+func lendingHandler(state *State) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("/supply", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Account   string `json:"account"`
+			Amount    int64  `json:"amount"`
+			RequestID string `json:"request_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		resp, err := state.supply(req.Account, req.RequestID, req.Amount)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+	mux.HandleFunc("/borrow", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Account   string `json:"account"`
+			Amount    int64  `json:"amount"`
+			RequestID string `json:"request_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		resp, err := state.borrow(req.Account, req.RequestID, req.Amount)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+	mux.HandleFunc("/repay", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Account   string `json:"account"`
+			Amount    int64  `json:"amount"`
+			RequestID string `json:"request_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		resp, err := state.repay(req.Account, req.RequestID, req.Amount)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+	mux.HandleFunc("/position", func(w http.ResponseWriter, r *http.Request) {
+		account := r.URL.Query().Get("account")
+		resp := state.position(account)
+		writeJSON(w, http.StatusOK, resp)
+	})
+	return mux
+}
+
+func swapHandler(state *State) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("/mint", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Account   string `json:"account"`
+			Amount    int64  `json:"amount"`
+			RequestID string `json:"request_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		resp, err := state.mint(req.Account, req.RequestID, req.Amount)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+	mux.HandleFunc("/redeem", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Account   string `json:"account"`
+			Amount    int64  `json:"amount"`
+			RequestID string `json:"request_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		resp, err := state.redeem(req.Account, req.RequestID, req.Amount)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	})
+	mux.HandleFunc("/balance", func(w http.ResponseWriter, r *http.Request) {
+		account := r.URL.Query().Get("account")
+		resp := state.balance(account)
+		writeJSON(w, http.StatusOK, resp)
+	})
+	return mux
+}
+
+func govHandler(state *State, cluster *Cluster) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("/proposals", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			var req struct {
+				Title       string `json:"title"`
+				Description string `json:"description"`
+				RequestID   string `json:"request_id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "invalid payload", http.StatusBadRequest)
+				return
+			}
+			resp, err := state.propose(req.RequestID, req.Title, req.Description)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			}
+			writeJSON(w, http.StatusOK, resp)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/proposals/", func(w http.ResponseWriter, r *http.Request) {
+		trimmed := strings.TrimPrefix(r.URL.Path, "/proposals/")
+		parts := strings.Split(trimmed, "/")
+		if len(parts) == 0 {
+			http.Error(w, "proposal id required", http.StatusBadRequest)
+			return
+		}
+		id, err := strconv.Atoi(parts[0])
+		if err != nil {
+			http.Error(w, "invalid proposal id", http.StatusBadRequest)
+			return
+		}
+		if len(parts) == 1 {
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			resp, err := state.proposalByID(id)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			writeJSON(w, http.StatusOK, resp)
+			return
+		}
+		switch parts[1] {
+		case "vote":
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			var req struct {
+				Voter     string `json:"voter"`
+				Option    string `json:"option"`
+				RequestID string `json:"request_id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "invalid payload", http.StatusBadRequest)
+				return
+			}
+			resp, err := state.vote(req.RequestID, id, req.Voter, req.Option)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			}
+			writeJSON(w, http.StatusOK, resp)
+		case "apply":
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			var req struct {
+				RequestID string `json:"request_id"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "invalid payload", http.StatusBadRequest)
+				return
+			}
+			applyResp, err := state.apply(req.RequestID, id)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			}
+			// forward to consensus apply endpoint to simulate broadcast
+			if err := cluster.notifyConsensus(applyResp, req.RequestID); err != nil {
+				http.Error(w, fmt.Sprintf("consensus apply failed: %v", err), http.StatusBadGateway)
+				return
+			}
+			writeJSON(w, http.StatusOK, applyResp)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	return mux
+}
+
+func (c *Cluster) notifyConsensus(resp applyResponse, requestID string) error {
+	consensus := c.services[ServiceConsensus]
+	if consensus == nil {
+		return fmt.Errorf("consensus service missing")
+	}
+	payload := map[string]any{"proposal_id": resp.ProposalID, "request_id": requestID}
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequest(http.MethodPost, "http://"+consensus.addr+"/apply", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	httpClient := &http.Client{Timeout: 2 * time.Second}
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		data, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("consensus apply status %d: %s", res.StatusCode, strings.TrimSpace(string(data)))
+	}
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if v != nil {
+		_ = json.NewEncoder(w).Encode(v)
+	}
+}
+
+type gatewayServer struct {
+	process *serviceProcess
+	client  *http.Client
+	routes  map[string]ServiceName
+	targets map[ServiceName]*url.URL
+}
+
+func newGatewayServer(endpoints map[ServiceName]*url.URL) (*gatewayServer, error) {
+	routes := map[string]ServiceName{
+		"/v1/lending":   ServiceLending,
+		"/v1/swap":      ServiceSwap,
+		"/v1/gov":       ServiceGov,
+		"/v1/consensus": ServiceConsensus,
+	}
+	gw := &gatewayServer{
+		client:  &http.Client{Timeout: 3 * time.Second},
+		routes:  routes,
+		targets: endpoints,
+	}
+	process := newService(ServiceGateway, func(state *State) http.Handler {
+		return gw.handler()
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := process.start(ctx, newState()); err != nil {
+		return nil, err
+	}
+	gw.process = process
+	return gw, nil
+}
+
+func (g *gatewayServer) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		targetName, prefix := g.matchRoute(r.URL.Path)
+		if targetName == "" {
+			http.NotFound(w, r)
+			return
+		}
+		targetURL := g.targets[ServiceName(targetName)]
+		if targetURL == nil {
+			http.Error(w, "service unavailable", http.StatusBadGateway)
+			return
+		}
+		forwardPath := strings.TrimPrefix(r.URL.Path, prefix)
+		if !strings.HasPrefix(forwardPath, "/") {
+			forwardPath = "/" + forwardPath
+		}
+		outURL := *targetURL
+		outURL.Path = path.Join(targetURL.Path, forwardPath)
+		outURL.RawQuery = r.URL.RawQuery
+
+		var body io.Reader
+		if r.Body != nil {
+			data, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "read body", http.StatusBadRequest)
+				return
+			}
+			body = bytes.NewReader(data)
+			r.Body = io.NopCloser(bytes.NewReader(data))
+		}
+
+		req, err := http.NewRequestWithContext(r.Context(), r.Method, outURL.String(), body)
+		if err != nil {
+			http.Error(w, "forward request", http.StatusBadRequest)
+			return
+		}
+		req.Header = r.Header.Clone()
+		resp, err := g.client.Do(req)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("upstream error: %v", err), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		for k, v := range resp.Header {
+			for _, value := range v {
+				w.Header().Add(k, value)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+	})
+	return mux
+}
+
+func (g *gatewayServer) matchRoute(path string) (string, string) {
+	longestPrefix := ""
+	var serviceName ServiceName
+	for prefix, svc := range g.routes {
+		if strings.HasPrefix(path, prefix) && len(prefix) > len(longestPrefix) {
+			longestPrefix = prefix
+			serviceName = svc
+		}
+	}
+	if longestPrefix == "" {
+		return "", ""
+	}
+	return string(serviceName), longestPrefix
+}
+
+func (g *gatewayServer) updateTarget(name ServiceName, addr string) {
+	if g == nil {
+		return
+	}
+	parsed, err := url.Parse(addr)
+	if err != nil {
+		return
+	}
+	if g.targets == nil {
+		g.targets = make(map[ServiceName]*url.URL)
+	}
+	g.targets[name] = parsed
+}
+
+func (c *Cluster) Kill(ctx context.Context, name ServiceName) error {
+	svc, ok := c.services[name]
+	if !ok {
+		return fmt.Errorf("service %s not found", name)
+	}
+	return svc.stop(ctx)
+}
+
+func (c *Cluster) Restart(ctx context.Context, name ServiceName) (string, error) {
+	svc, ok := c.services[name]
+	if !ok {
+		return "", fmt.Errorf("service %s not found", name)
+	}
+	if err := svc.restart(ctx, c.state); err != nil {
+		return "", err
+	}
+	if name != ServiceGateway && c.gateway != nil {
+		c.gateway.updateTarget(name, "http://"+svc.addr)
+	}
+	return svc.addr, nil
+}
+
+func (c *Cluster) GatewayURL() string {
+	gw := c.services[ServiceGateway]
+	if gw == nil {
+		return ""
+	}
+	return "http://" + gw.addr
+}
+
+func (c *Cluster) ServiceURL(name ServiceName) string {
+	svc := c.services[name]
+	if svc == nil {
+		return ""
+	}
+	return "http://" + svc.addr
+}

--- a/tests/support/cluster/state.go
+++ b/tests/support/cluster/state.go
@@ -1,0 +1,425 @@
+package cluster
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+type lendingPosition struct {
+	Account      string `json:"account"`
+	Supplied     int64  `json:"supplied"`
+	Borrowed     int64  `json:"borrowed"`
+	HealthFactor string `json:"health_factor"`
+}
+
+type lendingResponse struct {
+	Position lendingPosition `json:"position"`
+}
+
+type swapResponse struct {
+	Account string `json:"account"`
+	Balance int64  `json:"balance"`
+}
+
+type proposalStatus string
+
+const (
+	proposalStatusVoting  proposalStatus = "voting"
+	proposalStatusApplied proposalStatus = "applied"
+)
+
+type proposal struct {
+	ID          int            `json:"id"`
+	Title       string         `json:"title"`
+	Description string         `json:"description"`
+	Status      proposalStatus `json:"status"`
+	YesVotes    int            `json:"yes_votes"`
+	NoVotes     int            `json:"no_votes"`
+	Votes       map[string]string
+}
+
+type proposalResponse struct {
+	Proposal proposal `json:"proposal"`
+}
+
+type applyResponse struct {
+	ProposalID int   `json:"proposal_id"`
+	Height     int64 `json:"height"`
+}
+
+type consensusSnapshot struct {
+	Height    int64 `json:"height"`
+	Proposals []int `json:"proposals"`
+}
+
+type State struct {
+	mu sync.Mutex
+
+	lendingPositions map[string]lendingPosition
+	lendingRequests  map[string]lendingResponse
+
+	swapBalances map[string]int64
+	swapRequests map[string]swapResponse
+
+	proposals       map[int]*proposal
+	proposalSeq     int
+	proposalRequest map[string]proposalResponse
+	voteRequest     map[string]proposalResponse
+	applyRequest    map[string]applyResponse
+
+	consensusHeight  int64
+	appliedProposals []int
+}
+
+func newState() *State {
+	return &State{
+		lendingPositions: make(map[string]lendingPosition),
+		lendingRequests:  make(map[string]lendingResponse),
+		swapBalances:     make(map[string]int64),
+		swapRequests:     make(map[string]swapResponse),
+		proposals:        make(map[int]*proposal),
+		proposalRequest:  make(map[string]proposalResponse),
+		voteRequest:      make(map[string]proposalResponse),
+		applyRequest:     make(map[string]applyResponse),
+		appliedProposals: make([]int, 0, 8),
+	}
+}
+
+func (s *State) supply(account, reqID string, amount int64) (lendingResponse, error) {
+	if err := validateAccount(account); err != nil {
+		return lendingResponse{}, err
+	}
+	if amount <= 0 {
+		return lendingResponse{}, fmt.Errorf("amount must be positive")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if reqID != "" {
+		if resp, ok := s.lendingRequests[reqID]; ok {
+			return resp, nil
+		}
+	}
+
+	pos := s.getPosition(account)
+	pos.Supplied += amount
+	pos.HealthFactor = computeHealth(pos.Supplied, pos.Borrowed)
+	s.lendingPositions[account] = pos
+
+	resp := lendingResponse{Position: pos}
+	if reqID != "" {
+		s.lendingRequests[reqID] = resp
+	}
+	return resp, nil
+}
+
+func (s *State) borrow(account, reqID string, amount int64) (lendingResponse, error) {
+	if err := validateAccount(account); err != nil {
+		return lendingResponse{}, err
+	}
+	if amount <= 0 {
+		return lendingResponse{}, fmt.Errorf("amount must be positive")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if reqID != "" {
+		if resp, ok := s.lendingRequests[reqID]; ok {
+			return resp, nil
+		}
+	}
+
+	pos := s.getPosition(account)
+	available := pos.Supplied - pos.Borrowed
+	if available < amount {
+		return lendingResponse{}, fmt.Errorf("insufficient collateral: available %d", available)
+	}
+	pos.Borrowed += amount
+	pos.HealthFactor = computeHealth(pos.Supplied, pos.Borrowed)
+	s.lendingPositions[account] = pos
+
+	resp := lendingResponse{Position: pos}
+	if reqID != "" {
+		s.lendingRequests[reqID] = resp
+	}
+	return resp, nil
+}
+
+func (s *State) repay(account, reqID string, amount int64) (lendingResponse, error) {
+	if err := validateAccount(account); err != nil {
+		return lendingResponse{}, err
+	}
+	if amount <= 0 {
+		return lendingResponse{}, fmt.Errorf("amount must be positive")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if reqID != "" {
+		if resp, ok := s.lendingRequests[reqID]; ok {
+			return resp, nil
+		}
+	}
+
+	pos := s.getPosition(account)
+	if pos.Borrowed == 0 {
+		return lendingResponse{}, fmt.Errorf("nothing to repay")
+	}
+	if amount > pos.Borrowed {
+		amount = pos.Borrowed
+	}
+	pos.Borrowed -= amount
+	pos.HealthFactor = computeHealth(pos.Supplied, pos.Borrowed)
+	s.lendingPositions[account] = pos
+
+	resp := lendingResponse{Position: pos}
+	if reqID != "" {
+		s.lendingRequests[reqID] = resp
+	}
+	return resp, nil
+}
+
+func (s *State) position(account string) lendingResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	pos := s.getPosition(account)
+	return lendingResponse{Position: pos}
+}
+
+func (s *State) mint(account, reqID string, amount int64) (swapResponse, error) {
+	if err := validateAccount(account); err != nil {
+		return swapResponse{}, err
+	}
+	if amount <= 0 {
+		return swapResponse{}, fmt.Errorf("amount must be positive")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if reqID != "" {
+		if resp, ok := s.swapRequests[reqID]; ok {
+			return resp, nil
+		}
+	}
+
+	balance := s.swapBalances[account]
+	balance += amount
+	s.swapBalances[account] = balance
+	resp := swapResponse{Account: account, Balance: balance}
+	if reqID != "" {
+		s.swapRequests[reqID] = resp
+	}
+	return resp, nil
+}
+
+func (s *State) redeem(account, reqID string, amount int64) (swapResponse, error) {
+	if err := validateAccount(account); err != nil {
+		return swapResponse{}, err
+	}
+	if amount <= 0 {
+		return swapResponse{}, fmt.Errorf("amount must be positive")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if reqID != "" {
+		if resp, ok := s.swapRequests[reqID]; ok {
+			return resp, nil
+		}
+	}
+
+	balance := s.swapBalances[account]
+	if amount > balance {
+		return swapResponse{}, fmt.Errorf("insufficient balance: %d", balance)
+	}
+	balance -= amount
+	s.swapBalances[account] = balance
+	resp := swapResponse{Account: account, Balance: balance}
+	if reqID != "" {
+		s.swapRequests[reqID] = resp
+	}
+	return resp, nil
+}
+
+func (s *State) balance(account string) swapResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	balance := s.swapBalances[account]
+	return swapResponse{Account: account, Balance: balance}
+}
+
+func (s *State) propose(reqID, title, description string) (proposalResponse, error) {
+	if strings.TrimSpace(title) == "" {
+		return proposalResponse{}, fmt.Errorf("title required")
+	}
+	if strings.TrimSpace(description) == "" {
+		return proposalResponse{}, fmt.Errorf("description required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if reqID != "" {
+		if resp, ok := s.proposalRequest[reqID]; ok {
+			return resp, nil
+		}
+	}
+
+	s.proposalSeq++
+	proposal := &proposal{
+		ID:          s.proposalSeq,
+		Title:       title,
+		Description: description,
+		Status:      proposalStatusVoting,
+		Votes:       make(map[string]string),
+	}
+	s.proposals[proposal.ID] = proposal
+
+	resp := proposalResponse{Proposal: *proposal}
+	if reqID != "" {
+		s.proposalRequest[reqID] = resp
+	}
+	return resp, nil
+}
+
+func (s *State) vote(reqID string, id int, voter, option string) (proposalResponse, error) {
+	if err := validateAccount(voter); err != nil {
+		return proposalResponse{}, err
+	}
+	option = strings.ToLower(strings.TrimSpace(option))
+	if option != "yes" && option != "no" {
+		return proposalResponse{}, fmt.Errorf("invalid vote option: %s", option)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if reqID != "" {
+		if resp, ok := s.voteRequest[reqID]; ok {
+			return resp, nil
+		}
+	}
+
+	prop, ok := s.proposals[id]
+	if !ok {
+		return proposalResponse{}, fmt.Errorf("proposal %d not found", id)
+	}
+	if prop.Status != proposalStatusVoting {
+		return proposalResponse{}, fmt.Errorf("proposal %d not in voting period", id)
+	}
+
+	prev, hadPrev := prop.Votes[voter]
+	if hadPrev {
+		if prev == option {
+			resp := proposalResponse{Proposal: *prop}
+			if reqID != "" {
+				s.voteRequest[reqID] = resp
+			}
+			return resp, nil
+		}
+		if prev == "yes" {
+			prop.YesVotes--
+		} else if prev == "no" {
+			prop.NoVotes--
+		}
+	}
+	prop.Votes[voter] = option
+	if option == "yes" {
+		prop.YesVotes++
+	} else {
+		prop.NoVotes++
+	}
+
+	resp := proposalResponse{Proposal: *prop}
+	if reqID != "" {
+		s.voteRequest[reqID] = resp
+	}
+	return resp, nil
+}
+
+func (s *State) apply(reqID string, id int) (applyResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if reqID != "" {
+		if resp, ok := s.applyRequest[reqID]; ok {
+			return resp, nil
+		}
+	}
+
+	prop, ok := s.proposals[id]
+	if !ok {
+		return applyResponse{}, fmt.Errorf("proposal %d not found", id)
+	}
+	if prop.Status != proposalStatusVoting {
+		if prop.Status == proposalStatusApplied {
+			resp := applyResponse{ProposalID: id, Height: s.consensusHeight}
+			if reqID != "" {
+				s.applyRequest[reqID] = resp
+			}
+			return resp, nil
+		}
+		return applyResponse{}, fmt.Errorf("proposal %d cannot be applied", id)
+	}
+	if prop.YesVotes <= prop.NoVotes {
+		return applyResponse{}, fmt.Errorf("proposal %d lacks approval", id)
+	}
+
+	s.consensusHeight++
+	prop.Status = proposalStatusApplied
+	s.appliedProposals = append(s.appliedProposals, prop.ID)
+
+	resp := applyResponse{ProposalID: prop.ID, Height: s.consensusHeight}
+	if reqID != "" {
+		s.applyRequest[reqID] = resp
+	}
+	return resp, nil
+}
+
+func (s *State) proposalByID(id int) (proposalResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prop, ok := s.proposals[id]
+	if !ok {
+		return proposalResponse{}, fmt.Errorf("proposal %d not found", id)
+	}
+	return proposalResponse{Proposal: *prop}, nil
+}
+
+func (s *State) consensusState() consensusSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	proposals := make([]int, len(s.appliedProposals))
+	copy(proposals, s.appliedProposals)
+	sort.Ints(proposals)
+	return consensusSnapshot{Height: s.consensusHeight, Proposals: proposals}
+}
+
+func (s *State) getPosition(account string) lendingPosition {
+	pos, ok := s.lendingPositions[account]
+	if !ok {
+		pos = lendingPosition{Account: account, Supplied: 0, Borrowed: 0, HealthFactor: computeHealth(0, 0)}
+	}
+	return pos
+}
+
+func validateAccount(account string) error {
+	account = strings.TrimSpace(account)
+	if account == "" {
+		return fmt.Errorf("account required")
+	}
+	if len(account) < 4 {
+		return fmt.Errorf("account must be at least 4 characters")
+	}
+	return nil
+}
+
+func computeHealth(supplied, borrowed int64) string {
+	if borrowed <= 0 {
+		return "safe"
+	}
+	ratio := float64(supplied) / float64(borrowed)
+	return strconv.FormatFloat(ratio, 'f', 2, 64)
+}


### PR DESCRIPTION
## Summary
- add an in-process service cluster harness that simulates consensusd, p2pd, lendingd, swapd, governd, and the gateway
- add end-to-end coverage for lending, swap, and governance flows via the gateway along with chaos recovery tests
- document how to run the new suites locally and in CI

## Testing
- go test ./tests/e2e ./tests/chaos

------
https://chatgpt.com/codex/tasks/task_e_68d840cc70a8832d937d6ffb3872baf5