### PR TITLE
docs: reorganize to service topology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,11 @@ up:
 
 down:
 	docker compose -f deploy/compose/docker-compose.yml down -v
+
+.PHONY: docs
+docs\:%:
+	@if [ "$*" = "verify" ]; then \
+	go run ./tools/docs/verify.go; \
+	else \
+	echo "unknown docs task $*"; exit 1; \
+	fi

--- a/docs/cookbooks/developers.md
+++ b/docs/cookbooks/developers.md
@@ -1,0 +1,406 @@
+# Developer Cookbooks
+
+The following quickstarts demonstrate the new service topology using real code
+snippets that compile as part of `make docs:verify`.
+
+## First transaction
+
+1. Export your consensus endpoint (`CONSENSUSD_GRPC_ADDR`) and funding key.
+2. Use the SDK helpers to assemble a lending supply transaction.
+3. Submit the signed envelope to the consensus service.
+
+<!-- embed:examples/docs/go/first_transaction/main.go -->
+```go
+package main
+
+import (
+        "context"
+        "fmt"
+        "log"
+        "os"
+        "time"
+
+        "nhbchain/crypto"
+        cons "nhbchain/sdk/consensus"
+        "nhbchain/sdk/lending"
+)
+
+func main() {
+        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+        defer cancel()
+
+        endpoint := os.Getenv("CONSENSUSD_GRPC_ADDR")
+        if endpoint == "" {
+                endpoint = "localhost:9090"
+        }
+
+        client, err := cons.Dial(ctx, endpoint)
+        if err != nil {
+                log.Fatalf("dial consensus: %v", err)
+        }
+        defer client.Close()
+
+        key, err := crypto.GeneratePrivateKey()
+        if err != nil {
+                log.Fatalf("generate key: %v", err)
+        }
+        sender := key.PubKey().Address().String()
+
+        supplyMsg, err := lending.NewMsgSupply(sender, "usd-pool-1", "1000000")
+        if err != nil {
+                log.Fatalf("build supply msg: %v", err)
+        }
+
+        envelope, err := cons.NewTx(supplyMsg, 1, "localnet", "1000", "znhb", sender, "first transaction demo")
+        if err != nil {
+                log.Fatalf("build envelope: %v", err)
+        }
+
+        signed, err := cons.Sign(envelope, key)
+        if err != nil {
+                log.Fatalf("sign envelope: %v", err)
+        }
+
+        if err := client.SubmitEnvelope(ctx, signed); err != nil {
+                log.Fatalf("submit envelope: %v", err)
+        }
+        fmt.Printf("broadcasted supply from %s to pool %s\n", sender, supplyMsg.GetPoolId())
+}
+```
+
+<!-- embed:examples/docs/ts/first-transaction.ts -->
+```ts
+import path from 'node:path';
+import process from 'node:process';
+import { credentials, ClientUnaryCall, ServiceError, Metadata } from '@grpc/grpc-js';
+import { loadPackageDefinition } from '@grpc/grpc-js';
+import { loadSync } from '@grpc/proto-loader';
+
+type LendingServiceClient = {
+  SupplyAsset(
+    request: { account: string; market?: { symbol: string }; amount: string },
+    metadata: Metadata,
+    callback: (err: ServiceError | null, response: { position?: unknown }) => void
+  ): ClientUnaryCall;
+};
+
+type LendingServiceCtor = new (address: string, creds: ReturnType<typeof credentials.createInsecure>) => LendingServiceClient;
+
+const protoRoot = path.resolve(__dirname, '../../../proto/lending/v1/lending.proto');
+const definition = loadSync(protoRoot, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+});
+
+const pkg = loadPackageDefinition(definition) as unknown as {
+  lending: {
+    v1: {
+      LendingService: LendingServiceCtor;
+    };
+  };
+};
+
+const endpoint = process.env.LENDING_GRPC_ADDR ?? 'localhost:9444';
+const client = new pkg.lending.v1.LendingService(endpoint, credentials.createInsecure());
+
+client.SupplyAsset(
+  {
+    account: process.env.LENDING_ACCOUNT ?? 'nhb1exampleaddress',
+    market: { symbol: 'usd-pool-1' },
+    amount: '1000000'
+  },
+  new Metadata(),
+  (err, resp) => {
+    if (err) {
+      console.error('supply asset failed', err);
+      return;
+    }
+    console.log('submitted first transaction, position snapshot:', resp.position ?? {});
+  }
+);
+```
+
+## Query positions
+
+1. Call the consensus query API for the lending module.
+2. Parse the JSON payload into a friendly structure.
+3. Render the position summary to standard out.
+
+<!-- embed:examples/queries/lending_positions.go -->
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"nhbchain/sdk/consensus"
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	endpoint := os.Getenv("CONSENSUSD_GRPC_ADDR")
+	if endpoint == "" {
+		endpoint = "localhost:9090"
+	}
+	addr := os.Getenv("LENDING_ADDRESS")
+	if addr == "" {
+		log.Fatal("set LENDING_ADDRESS (bech32 or 0x hex) to query positions")
+	}
+
+	client, err := consensus.Dial(ctx, endpoint)
+	if err != nil {
+		log.Fatalf("dial consensus service: %v", err)
+	}
+	defer client.Close()
+
+	value, _, err := client.QueryState(ctx, "lending", fmt.Sprintf("positions/%s", addr))
+	if err != nil {
+		log.Fatalf("query positions: %v", err)
+	}
+	if len(value) == 0 {
+		fmt.Println("no active positions for address")
+		return
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal(value, &decoded); err != nil {
+		log.Fatalf("decode response: %v", err)
+	}
+	pretty, err := json.MarshalIndent(decoded, "", "  ")
+	if err != nil {
+		log.Fatalf("format response: %v", err)
+	}
+	fmt.Printf("Positions for %s:\n%s\n", addr, string(pretty))
+}
+```
+
+<!-- embed:examples/docs/ts/query-positions.ts -->
+```ts
+import path from 'node:path';
+import process from 'node:process';
+import { credentials, ClientUnaryCall, ServiceError, Metadata } from '@grpc/grpc-js';
+import { loadPackageDefinition } from '@grpc/grpc-js';
+import { loadSync } from '@grpc/proto-loader';
+
+type LendingServiceClient = {
+  GetPosition(
+    request: { account: string },
+    metadata: Metadata,
+    callback: (err: ServiceError | null, response: { position?: unknown }) => void
+  ): ClientUnaryCall;
+};
+
+type LendingServiceCtor = new (address: string, creds: ReturnType<typeof credentials.createInsecure>) => LendingServiceClient;
+
+const protoRoot = path.resolve(__dirname, '../../../proto/lending/v1/lending.proto');
+const definition = loadSync(protoRoot, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+});
+
+const pkg = loadPackageDefinition(definition) as unknown as {
+  lending: {
+    v1: {
+      LendingService: LendingServiceCtor;
+    };
+  };
+};
+
+const endpoint = process.env.LENDING_GRPC_ADDR ?? 'localhost:9444';
+const client = new pkg.lending.v1.LendingService(endpoint, credentials.createInsecure());
+
+client.GetPosition(
+  { account: process.env.LENDING_ACCOUNT ?? 'nhb1exampleaddress' },
+  new Metadata(),
+  (err, resp) => {
+    if (err) {
+      console.error('position query failed', err);
+      return;
+    }
+    console.log('active positions', JSON.stringify(resp.position ?? {}, null, 2));
+  }
+);
+```
+
+## Publish a price oracle update
+
+1. Establish a streaming session with the price oracle service.
+2. Sign and send a price observation payload.
+3. Await acknowledgement and log the resulting attestation identifier.
+
+<!-- embed:examples/docs/go/price_oracle_publish/main.go -->
+```go
+package main
+
+import (
+        "context"
+        "encoding/json"
+        "fmt"
+        "log"
+        "os"
+        "time"
+
+        "google.golang.org/grpc"
+        "google.golang.org/grpc/credentials/insecure"
+
+        networkv1 "nhbchain/proto/network/v1"
+)
+
+func main() {
+        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+        defer cancel()
+
+        endpoint := os.Getenv("ORACLE_GRPC_ADDR")
+        if endpoint == "" {
+                endpoint = "localhost:9555"
+        }
+
+        conn, err := grpc.DialContext(ctx, endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+        if err != nil {
+                log.Fatalf("dial price oracle: %v", err)
+        }
+        defer conn.Close()
+
+        client := networkv1.NewNetworkServiceClient(conn)
+        stream, err := client.Gossip(ctx)
+        if err != nil {
+                log.Fatalf("open gossip stream: %v", err)
+        }
+        defer stream.CloseSend()
+
+        payload, err := json.Marshal(map[string]any{
+                "symbol":     "NHB/USD",
+                "price":      "1.0002",
+                "timestamp":  time.Now().UTC().Format(time.RFC3339),
+                "publisherId": "oracle-publisher-1",
+        })
+        if err != nil {
+                log.Fatalf("marshal price payload: %v", err)
+        }
+
+        msg := &networkv1.GossipRequest{
+                Envelope: &networkv1.NetworkEnvelope{
+                        Event: &networkv1.NetworkEnvelope_Gossip{
+                                Gossip: &networkv1.GossipMessage{
+                                        Type:    7001,
+                                        Payload: payload,
+                                },
+                        },
+                },
+        }
+        if err := stream.Send(msg); err != nil {
+                log.Fatalf("send price gossip: %v", err)
+        }
+
+        ack, err := stream.Recv()
+        if err != nil {
+                log.Fatalf("receive oracle ack: %v", err)
+        }
+        ackEnvelope := ack.GetEnvelope()
+        if ackEnvelope == nil {
+                fmt.Println("oracle acknowledged price update with empty envelope")
+                return
+        }
+        if gossip := ackEnvelope.GetGossip(); gossip != nil {
+                fmt.Printf("oracle acknowledged price update: %s\n", string(gossip.GetPayload()))
+        } else {
+                fmt.Println("oracle acknowledged price update with empty payload")
+        }
+}
+```
+
+<!-- embed:examples/docs/ts/price-oracle-publish.ts -->
+```ts
+import path from 'node:path';
+import process from 'node:process';
+import {
+  credentials,
+  ClientDuplexStream,
+  ChannelCredentials,
+  ServiceError
+} from '@grpc/grpc-js';
+import { loadPackageDefinition } from '@grpc/grpc-js';
+import { loadSync } from '@grpc/proto-loader';
+
+type GossipEnvelope = {
+  envelope?: {
+    gossip?: {
+      type?: number;
+      payload?: Buffer;
+    };
+  };
+};
+
+type NetworkServiceClient = {
+  Gossip(): ClientDuplexStream<GossipEnvelope, GossipEnvelope>;
+};
+
+type NetworkServiceCtor = new (address: string, creds: ChannelCredentials) => NetworkServiceClient;
+
+const protoRoot = path.resolve(__dirname, '../../../proto/network/v1/network.proto');
+const definition = loadSync(protoRoot, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+  bytes: Buffer
+});
+
+const pkg = loadPackageDefinition(definition) as unknown as {
+  network: {
+    v1: {
+      NetworkService: NetworkServiceCtor;
+    };
+  };
+};
+
+const endpoint = process.env.ORACLE_GRPC_ADDR ?? 'localhost:9555';
+const client = new pkg.network.v1.NetworkService(endpoint, credentials.createInsecure());
+const stream = client.Gossip();
+
+stream.on('data', (msg: GossipEnvelope) => {
+  const payload = msg.envelope?.gossip?.payload;
+  if (payload) {
+    console.log('oracle ack payload', payload.toString('utf8'));
+  } else {
+    console.log('oracle ack with empty payload');
+  }
+  stream.end();
+});
+
+stream.on('error', (err: ServiceError) => {
+  console.error('oracle gossip error', err);
+});
+
+const pricePayload = Buffer.from(
+  JSON.stringify({
+    symbol: 'NHB/USD',
+    price: '1.0002',
+    timestamp: new Date().toISOString(),
+    publisherId: process.env.ORACLE_PUBLISHER_ID ?? 'oracle-publisher-1'
+  }),
+  'utf8'
+);
+
+stream.write({
+  envelope: {
+    gossip: {
+      type: 7001,
+      payload: pricePayload
+    }
+  }
+});
+```

--- a/docs/cookbooks/operators.md
+++ b/docs/cookbooks/operators.md
@@ -1,0 +1,54 @@
+# Operator Cookbooks
+
+These guides target operators responsible for provisioning and maintaining the
+new service-oriented topology.
+
+## Run a validator
+
+1. Provision infrastructure that satisfies the recommended CPU, RAM, and SSD
+   throughput targets.
+2. Deploy the consensus service container and point it at your validator key
+   material.
+3. Launch a colocated `p2pd` instance so the validator can participate in the
+   gossip mesh.
+4. Expose only the gateway and telemetry ports through the load balancer.
+
+```
+docker run --rm \
+  -v $PWD/validator.keys:/keys \
+  -e CONSENSUS_DB_DSN=postgres://validator@db/nhb \
+  -e CONSENSUS_PRIV_KEY=/keys/validator.key \
+  -e CONSENSUS_P2P_ADDR=/ip4/0.0.0.0/tcp/26656 \
+  ghcr.io/nhbchain/consensus:latest
+```
+
+## Run `p2pd`
+
+1. Configure persistent peers and seed nodes in `p2pd.toml`.
+2. Mount the libp2p key so the daemon preserves its node identity.
+3. Co-locate `p2pd` with every consensus service replica and expose `26656`.
+
+```
+docker run --rm \
+  -v $PWD/p2pd.toml:/etc/nhb/p2pd.toml \
+  -v $PWD/p2p.keys:/var/lib/p2pd \
+  -e P2PD_CONFIG=/etc/nhb/p2pd.toml \
+  --network host \
+  ghcr.io/nhbchain/p2pd:latest
+```
+
+## Upgrade services
+
+1. Drain traffic from the gateway by removing the instance from the load
+   balancer.
+2. Deploy the new container tag for each service, starting with stateless
+   gateways, then stateful consensus nodes, and finally domain services.
+3. Run smoke tests against the gateway and lending service.
+4. Rotate traffic back and monitor the dashboards for regressions.
+
+```
+kubectl rollout restart deployment/nhb-gateway
+kubectl rollout status deployment/nhb-gateway
+kubectl rollout restart statefulset/nhb-consensus
+kubectl rollout restart deployment/nhb-lending
+```

--- a/docs/escrow/hardened-engine.md
+++ b/docs/escrow/hardened-engine.md
@@ -73,7 +73,7 @@ threshold at creation time—and verifying that the native transaction sender is
 authorised. The policy is persisted alongside the escrow record when the
 `Create` operation runs so later `TxTypeArbitrate*` submissions can enforce the
 same governance-managed committee the RPC flows rely on. See
-[`docs/rpc_escrow_module.md`](../rpc_escrow_module.md) and
+[`docs/services/escrow.md`](../services/escrow.md) and
 [`docs/escrow/escrow.md`](./escrow.md) for additional context on how arbitrator
 policies are registered and frozen during escrow creation.
 

--- a/docs/gateway/overview.md
+++ b/docs/gateway/overview.md
@@ -11,7 +11,7 @@ internally to dedicated services:
 | `api.nhbcoin.net` | Historical JSON-RPC host (deprecated) | Gateway `/rpc` endpoint |
 | `nhbcoin.net` | On-chain service endpoints (`/v1/...`) | Gateway reverse proxy |
 
-The gateway replaces the previous monolithic JSON-RPC server. Traffic is routed
+The gateway supersedes the legacy JSON-RPC node in the service-oriented topology. Traffic is routed
 according to the following prefixes:
 
 - `/v1/lending/*` → `lendingd`

--- a/docs/identity/identity-gateway.md
+++ b/docs/identity/identity-gateway.md
@@ -227,7 +227,7 @@ curl -X POST "$GATEWAY/identity/avatars/upload" \
 
 ## OpenAPI Specification
 
-A machine-readable schema for these endpoints is provided at [`./openapi/identity.yaml`](./openapi/identity.yaml). Use it with
+A machine-readable schema for these endpoints is provided at [`../openapi/identity.yaml`](../openapi/identity.yaml). Use it with
 `redocly lint` or `swagger-cli validate` to ensure compatibility.
 
 ## Related Docs

--- a/docs/identity/identity.md
+++ b/docs/identity/identity.md
@@ -12,7 +12,7 @@ identity gateway service. Together they allow wallets, gateways, and merchants t
 * Deterministic resolution of `@aliases` to rich metadata (primary settlement address, address set, avatar, timestamps).
 * Rich sender safety cues (avatar, created-at timestamp, address fingerprint).
 * Pay-by-email flows that bridge new users through claimable escrows.
-* A consistent UX that complements existing escrow flows (see [Escrow Guide](./escrow.md)).
+* A consistent UX that complements existing escrow flows (see [Escrow Guide](../escrow/escrow.md)).
 
 ## Terminology
 
@@ -108,7 +108,7 @@ type Claimable struct {
 * Funds are held in the identity escrow submodule. Upon `identity_claim`, the amount is released to the claimant's address once
   the provided preimage matches `RecipientHint`.
 * Events emitted: `identity.claimable.created`, `identity.claimable.claimed`, `identity.claimable.expired`.
-* Claimables integrate with the [Escrow module](./escrow.md#1-overview) for audit and settlement guarantees.
+* Claimables integrate with the [Escrow module](../escrow/escrow.md#1-overview) for audit and settlement guarantees.
 
 ### Pay-by-Username Flow
 

--- a/docs/identity/pay-by-username.md
+++ b/docs/identity/pay-by-username.md
@@ -107,7 +107,7 @@ znhb://pay?to=@frankrocks&amount=25.75&token=NHB&memo=Lunch
 * **Fingerprint**: Render a short checksum of the primary address (e.g., BLAKE3 6 chars) to catch last-minute swaps.
 * **Version watch**: If `identity_get` shows `updatedAt` within the last minute, display warning banner.
 * **Claimable context**: When paying by email, indicate "Funds held until frank@example.com claims by Jun 18".
-* **Escrow link**: Provide "View escrow" CTA linking to [Escrow module docs](./escrow.md) for transparency.
+* **Escrow link**: Provide "View escrow" CTA linking to [Escrow module docs](../escrow/escrow.md) for transparency.
 
 ## 5. Developer Checklist
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,53 @@
+# NHBChain Platform Overview
+
+The NHBChain platform is now delivered as a **service-oriented topology**. Each
+service exposes a narrowly scoped API, deploys independently, and communicates
+through authenticated gRPC streams. The diagram below illustrates the default
+production topology.
+
+```
+┌─────────────────┐        ┌──────────────────┐        ┌───────────────────┐
+│  Client Wallets │  gRPC  │  Gateway Service │  gRPC  │ Consensus Service │
+└─────────────────┘  REST  └──────────────────┘  gRPC  └───────────────────┘
+          ▲                     ▲      ▲                    ▲
+          │                     │      │                    │
+          │                     │      │            ┌─────────────────┐
+          │                     │      │            │  State Service  │
+          │                     │      │            └─────────────────┘
+          │                     │      │                    ▲
+          │                     │      │                    │
+          │                     │      │            ┌─────────────────┐
+          │                     │      └────────────│  Lending Svc    │
+          │                     │                   └─────────────────┘
+          │                     │            ┌─────────────────────────┐
+          └───────────┬─────────┴────────────│  Price Oracle Service   │
+                      │                      └─────────────────────────┘
+                      │
+              ┌──────────────┐
+              │  P2P Daemon  │
+              └──────────────┘
+```
+
+The gateway terminates HTTP requests and forwards signed transactions to the
+consensus service. Domain services such as lending or price oracle subscribe to
+state updates and expose module-specific gRPC APIs. Operators run the P2P daemon
+(`p2pd`) to gossip network events and seed validators.
+
+## Glossary
+
+- **Gateway Service** – Authenticates REST clients, translates requests into
+  signed envelopes, and proxies consensus queries.
+- **Consensus Service** – Authoritative ledger component that finalises blocks,
+  exposes state queries, and accepts signed envelopes from gateways and
+  services.
+- **State Service** – Materialises module state into queryable projections for
+  analytics and dashboards.
+- **Domain Services** – Independent services (lending, swap, price oracle,
+  identity, etc.) that encapsulate module-specific logic.
+- **P2P Daemon (`p2pd`)** – Maintains gossip mesh connectivity and supplies
+  validator peers with fresh network metadata.
+- **Operator Control Plane** – Automation scripts, Helm charts, and Terraform
+  bundles that provision, upgrade, and monitor services as isolated workloads.
+
+Use the [cookbooks](./cookbooks/developers.md) for task-driven guides and the
+[service references](./services/index.md) for API-by-API details.

--- a/docs/migrate/monolith-to-gateway.md
+++ b/docs/migrate/monolith-to-gateway.md
@@ -1,6 +1,6 @@
-# Migrating from the Monolithic JSON-RPC Server
+# Migrating from the Legacy JSON-RPC Node
 
-The API gateway keeps the public JSON-RPC surface available under `/rpc` while
+The gateway keeps the public JSON-RPC surface available under `/rpc` while
 backfilling requests to dedicated services. New integrations should migrate to
 the service-specific REST and gRPC surfaces exposed behind the gateway.
 
@@ -38,8 +38,8 @@ the service-specific REST and gRPC surfaces exposed behind the gateway.
 | `consensus_validators` | `/v1/consensus/validators` | `GET` | `consensusd` |
 | `consensus_block` | `/v1/consensus/block` | `POST` | `consensusd` |
 
-Legacy JSON-RPC clients can continue posting to `/rpc`. The gateway converts
-the request into the corresponding REST call shown above, forwards it to the
+Legacy JSON-RPC clients can continue posting to `/rpc`. The gateway converts the
+request into the corresponding REST call shown above, forwards it to the
 appropriate service, and wraps the response back into a JSON-RPC envelope.
 
 ## Authentication and Rate Limits

--- a/docs/migrate/services.md
+++ b/docs/migrate/services.md
@@ -1,0 +1,47 @@
+# Migration Guide: Service-Oriented Topology
+
+This guide walks through migrating from the legacy JSON-RPC node to the new
+service-oriented topology.
+
+## 1. Prepare infrastructure
+
+- Allocate separate compute for the gateway, consensus, lending, price oracle,
+  and state services. Each can be scaled independently after cutover.
+- Deploy a managed Postgres cluster and Redis instance to back the stateful
+  services.
+
+## 2. Bootstrap consensus + `p2pd`
+
+- Promote a validator key and provision the consensus service container.
+- Launch `p2pd` next to every consensus node using the new `p2pd.toml` schema.
+- Allow gossip ports (`26656`) between validators and seeds.
+
+## 3. Stand up gateways
+
+- Deploy at least two gateway replicas behind your edge load balancer.
+- Configure JWT signing keys and consensus endpoints via environment variables.
+- Update DNS to point wallets and partner applications at the gateway tier.
+
+## 4. Bring up domain services
+
+- Configure the lending service with oracle endpoints and market metadata.
+- Provision the price oracle service with publisher API keys and threshold
+  policies.
+- Connect both services to consensus using mTLS identities.
+
+## 5. Drain the legacy node
+
+- Freeze the legacy JSON-RPC node by rejecting external RPC requests.
+- Replay the last 1,000 blocks into the new consensus service to validate state
+  parity.
+- Switch traffic from the legacy node to the gateway using a weighted load
+  balancer change.
+
+## 6. Validate + monitor
+
+- Run the developer cookbooks (first transaction, position query, price oracle
+  publish) against production endpoints.
+- Monitor consensus, gateway, and oracle dashboards for error spikes.
+- Decommission the legacy node after 24 hours of stable metrics.
+
+For detailed service configuration, refer to the [service directory](../services/index.md).

--- a/docs/overview/README.md
+++ b/docs/overview/README.md
@@ -1,11 +1,13 @@
 # NHBChain Documentation Index
 
+> **New topology:** The legacy JSON-RPC node has been decomposed into services. Start with the [platform overview](../index.md) and the [service directory](../services/index.md).
+
 ## Core Modules
 
-* [Escrow & P2P Developer Guide](./escrow.md)
+* [Escrow & P2P Developer Guide](../escrow/escrow.md)
 * [NHBCHAIN Escrow Gateway](../escrow/nhbchain-escrow-gateway.md)
-* [Loyalty Module](./loyalty.md)
-* [Staking & Delegation](./staking.md)
+* [Loyalty Module](../loyalty/loyalty.md)
+* [Staking & Delegation](../staking/staking.md)
 
 ## Governance & Proposals
 
@@ -34,15 +36,15 @@ The governance module coordinates configuration changes across the network.
 
 The identity subsystem introduces human-readable aliases, email discovery, avatars, and claimables for pay-by-username UX.
 
-* [Identity Concepts & State Model](./identity.md)
-* [JSON-RPC API Reference](./identity-api.md)
-* [Gateway REST API](./identity-gateway.md)
-* [Pay-by-Username & Email Flows](./pay-by-username.md)
-* [Avatar Specification](./avatars.md)
-* [CLI Usage (`nhb-cli id`)](./identity-cli.md)
-* [Security, Privacy & Compliance Brief](./identity-security-compliance.md)
-* [OpenAPI 3.1 Schema](./openapi/identity.yaml)
-* [HTTP Examples](./examples/identity)
+* [Identity Concepts & State Model](../identity/identity.md)
+* [JSON-RPC API Reference](../identity/identity-api.md)
+* [Gateway REST API](../identity/identity-gateway.md)
+* [Pay-by-Username & Email Flows](../identity/pay-by-username.md)
+* [Avatar Specification](../identity/avatars.md)
+* [CLI Usage (`nhb-cli id`)](../identity/identity-cli.md)
+* [Security, Privacy & Compliance Brief](../identity/identity-security-compliance.md)
+* [OpenAPI 3.1 Schema](../openapi/identity.yaml)
+* [HTTP Examples](../examples/identity)
 
 ### 10-Minute Quickstart
 
@@ -53,5 +55,5 @@ The identity subsystem introduces human-readable aliases, email discovery, avata
 5. **Test pay-by-username** in a wallet by resolving your alias and sending a small transfer.
 6. **Simulate pay-by-email** by creating a claimable and claiming it with a second account.
 
-For escrow integration details, see [escrow.md](./escrow.md). Contributions and feedback are welcome via governance proposals or the
+For escrow integration details, see [escrow.md](../escrow/escrow.md). Contributions and feedback are welcome via governance proposals or the
 engineering forum.

--- a/docs/overview/nhbchain-net1.md
+++ b/docs/overview/nhbchain-net1.md
@@ -62,7 +62,7 @@ introduced in this work.
 
 ## Swap documentation expansion
 
-The swap gateway guide at [docs/swap/README.md](./swap/README.md) now includes:
+The swap gateway guide at [docs/swap/README.md](../swap/README.md) now includes:
 
 - **JSON-RPC integration** details for `swap_submitVoucher`, request/response
 examples, and operational error handling guidance.

--- a/docs/potso_rewards.md
+++ b/docs/potso_rewards.md
@@ -9,13 +9,13 @@ This document describes how the POTSO rewards module distributes epoch-based ZNH
 - **Inputs:**
   - Bonded ZNHB stake snapshots sourced from the POTSO staking subsystem.
   - Engagement meters representing user activity (transactions, escrow touchpoints, uptime) recorded during the epoch. These
-    counters feed the composite weighting pipeline described in [`weights.md`](weights.md).
+    counters feed the composite weighting pipeline described in [`weights.md`](potso/weights.md).
 - **Budget:** Rewards are paid entirely from the treasury address configured in `potso.rewards.TreasuryAddress`. No new ZNHB is minted. If the treasury balance is below the configured emission for an epoch, payouts are scaled down pro-rata.
 
 ## Weighting Model
 
 Each participant’s payout weight combines stake share and the composite
-engagement share produced by the [POTSO weighting pipeline](weights.md):
+engagement share produced by the [POTSO weighting pipeline](potso/weights.md):
 
 ```
 w_i = α * stakeShare_i + (1 − α) * engagementShare_i

--- a/docs/services/escrow.md
+++ b/docs/services/escrow.md
@@ -1,6 +1,6 @@
-# Escrow RPC Module
+# Escrow Service API
 
-The `escrow` module surfaces read-only helpers for governance tooling and arbitration dashboards. It complements the transactional `escrow_*` endpoints by exposing realm metadata, deterministic escrow snapshots (including frozen arbitrator policies), and the raw event feed used by downstream indexers.
+The Escrow service exposes read-only helpers for governance tooling and arbitration dashboards. It complements transactional `escrow_*` endpoints by exposing realm metadata, deterministic escrow snapshots (including frozen arbitrator policies), and the raw event feed consumed by downstream indexers.
 
 ## Methods
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,0 +1,72 @@
+# Service Directory
+
+Each NHBChain workload is deployed as an independently scalable service. Use the
+following references to configure, monitor, and integrate with each component.
+
+## Gateway Service
+
+- **Endpoint:** HTTPS / REST + gRPC streaming.
+- **Responsibilities:** Request authentication, REST to gRPC translation, rate
+  limiting, and transaction memo enrichment.
+- **Key configuration:** `GATEWAY_BIND`, `GATEWAY_RATE_LIMIT`,
+  `CONSENSUS_GRPC_ENDPOINT`.
+- **Operational notes:** Deploy at least two replicas behind your public load
+  balancer. Gateways should be stateless and read the validator set from the
+  consensus service on startup.
+
+## Consensus Service
+
+- **Endpoint:** gRPC on `9090` by default.
+- **Responsibilities:** Validates signed envelopes, executes transactions,
+  materialises blocks, and exposes deterministic state queries.
+- **Key configuration:** `CONSENSUS_DB_DSN`, `CONSENSUS_P2P_ADDR`,
+  `P2P_SEEDS`.
+- **Operational notes:** Validators run the consensus service co-located with a
+  `p2pd` instance. Horizontally scale read-only replicas for query workloads.
+
+## State Service
+
+- **Endpoint:** gRPC and GraphQL for denormalised projections.
+- **Responsibilities:** Subscribes to block events, projects module state into
+  Postgres, and serves analytical queries.
+- **Key configuration:** `STATE_EVENT_STREAM`, `STATE_GRAPHQL_PORT`,
+  `STATE_RETENTION_DAYS`.
+- **Operational notes:** Scale according to dashboard load. Downstream caches
+  should treat the state service as the source of truth for complex reporting.
+
+## Lending Service
+
+- **Endpoint:** gRPC on `9444` (configurable).
+- **Responsibilities:** Enforces lending business logic, risk limits, and emits
+  health factor telemetry per account.
+- **Key configuration:** `LENDING_CONSENSUS_ENDPOINT`,
+  `LENDING_PRICE_ORACLE_ENDPOINT`, `LENDING_MARKET_CONFIG`.
+- **Operational notes:** Co-locate near the consensus service to minimise
+  envelope latency. Configure circuit breakers for price oracle unavailability.
+
+## Price Oracle Service
+
+- **Endpoint:** gRPC streaming on `9555`.
+- **Responsibilities:** Aggregates publisher feeds, normalises price updates,
+  and signs attestations for downstream services.
+- **Key configuration:** `ORACLE_PUBLISHERS`, `ORACLE_MIN_SIGNERS`,
+  `ORACLE_CONSENSUS_ENDPOINT`.
+- **Operational notes:** Run at least three replicas across availability zones.
+  Publishers should use mTLS identities issued by the operator.
+
+## P2P Daemon (`p2pd`)
+
+- **Endpoint:** libp2p gossip ports (default `26656`).
+- **Responsibilities:** Maintains the gossip mesh, exchanges seed lists, and
+  propagates consensus metadata to validators and observers.
+- **Operational notes:** Operators deploy `p2pd` alongside every consensus node
+  and at edge locations serving RPC read replicas.
+
+Refer to the [migration guide](../migrate/services.md) when upgrading from the
+legacy JSON-RPC topology.
+
+---
+
+Additional module references:
+
+- [Escrow Service API](./escrow.md)

--- a/examples/docs/go/first_transaction/main.go
+++ b/examples/docs/go/first_transaction/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+        "context"
+        "fmt"
+        "log"
+        "os"
+        "time"
+
+        "nhbchain/crypto"
+        cons "nhbchain/sdk/consensus"
+        "nhbchain/sdk/lending"
+)
+
+func main() {
+        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+        defer cancel()
+
+        endpoint := os.Getenv("CONSENSUSD_GRPC_ADDR")
+        if endpoint == "" {
+                endpoint = "localhost:9090"
+        }
+
+        client, err := cons.Dial(ctx, endpoint)
+        if err != nil {
+                log.Fatalf("dial consensus: %v", err)
+        }
+        defer client.Close()
+
+        key, err := crypto.GeneratePrivateKey()
+        if err != nil {
+                log.Fatalf("generate key: %v", err)
+        }
+        sender := key.PubKey().Address().String()
+
+        supplyMsg, err := lending.NewMsgSupply(sender, "usd-pool-1", "1000000")
+        if err != nil {
+                log.Fatalf("build supply msg: %v", err)
+        }
+
+        envelope, err := cons.NewTx(supplyMsg, 1, "localnet", "1000", "znhb", sender, "first transaction demo")
+        if err != nil {
+                log.Fatalf("build envelope: %v", err)
+        }
+
+        signed, err := cons.Sign(envelope, key)
+        if err != nil {
+                log.Fatalf("sign envelope: %v", err)
+        }
+
+        if err := client.SubmitEnvelope(ctx, signed); err != nil {
+                log.Fatalf("submit envelope: %v", err)
+        }
+        fmt.Printf("broadcasted supply from %s to pool %s\n", sender, supplyMsg.GetPoolId())
+}

--- a/examples/docs/go/price_oracle_publish/main.go
+++ b/examples/docs/go/price_oracle_publish/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+        "context"
+        "encoding/json"
+        "fmt"
+        "log"
+        "os"
+        "time"
+
+        "google.golang.org/grpc"
+        "google.golang.org/grpc/credentials/insecure"
+
+        networkv1 "nhbchain/proto/network/v1"
+)
+
+func main() {
+        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+        defer cancel()
+
+        endpoint := os.Getenv("ORACLE_GRPC_ADDR")
+        if endpoint == "" {
+                endpoint = "localhost:9555"
+        }
+
+        conn, err := grpc.DialContext(ctx, endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+        if err != nil {
+                log.Fatalf("dial price oracle: %v", err)
+        }
+        defer conn.Close()
+
+        client := networkv1.NewNetworkServiceClient(conn)
+        stream, err := client.Gossip(ctx)
+        if err != nil {
+                log.Fatalf("open gossip stream: %v", err)
+        }
+        defer stream.CloseSend()
+
+        payload, err := json.Marshal(map[string]any{
+                "symbol":     "NHB/USD",
+                "price":      "1.0002",
+                "timestamp":  time.Now().UTC().Format(time.RFC3339),
+                "publisherId": "oracle-publisher-1",
+        })
+        if err != nil {
+                log.Fatalf("marshal price payload: %v", err)
+        }
+
+        msg := &networkv1.GossipRequest{
+                Envelope: &networkv1.NetworkEnvelope{
+                        Event: &networkv1.NetworkEnvelope_Gossip{
+                                Gossip: &networkv1.GossipMessage{
+                                        Type:    7001,
+                                        Payload: payload,
+                                },
+                        },
+                },
+        }
+        if err := stream.Send(msg); err != nil {
+                log.Fatalf("send price gossip: %v", err)
+        }
+
+        ack, err := stream.Recv()
+        if err != nil {
+                log.Fatalf("receive oracle ack: %v", err)
+        }
+        ackEnvelope := ack.GetEnvelope()
+        if ackEnvelope == nil {
+                fmt.Println("oracle acknowledged price update with empty envelope")
+                return
+        }
+        if gossip := ackEnvelope.GetGossip(); gossip != nil {
+                fmt.Printf("oracle acknowledged price update: %s\n", string(gossip.GetPayload()))
+        } else {
+                fmt.Println("oracle acknowledged price update with empty payload")
+        }
+}

--- a/examples/docs/ts/first-transaction.ts
+++ b/examples/docs/ts/first-transaction.ts
@@ -1,0 +1,51 @@
+import path from 'node:path';
+import process from 'node:process';
+import { credentials, ClientUnaryCall, ServiceError, Metadata } from '@grpc/grpc-js';
+import { loadPackageDefinition } from '@grpc/grpc-js';
+import { loadSync } from '@grpc/proto-loader';
+
+type LendingServiceClient = {
+  SupplyAsset(
+    request: { account: string; market?: { symbol: string }; amount: string },
+    metadata: Metadata,
+    callback: (err: ServiceError | null, response: { position?: unknown }) => void
+  ): ClientUnaryCall;
+};
+
+type LendingServiceCtor = new (address: string, creds: ReturnType<typeof credentials.createInsecure>) => LendingServiceClient;
+
+const protoRoot = path.resolve(__dirname, '../../../proto/lending/v1/lending.proto');
+const definition = loadSync(protoRoot, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+});
+
+const pkg = loadPackageDefinition(definition) as unknown as {
+  lending: {
+    v1: {
+      LendingService: LendingServiceCtor;
+    };
+  };
+};
+
+const endpoint = process.env.LENDING_GRPC_ADDR ?? 'localhost:9444';
+const client = new pkg.lending.v1.LendingService(endpoint, credentials.createInsecure());
+
+client.SupplyAsset(
+  {
+    account: process.env.LENDING_ACCOUNT ?? 'nhb1exampleaddress',
+    market: { symbol: 'usd-pool-1' },
+    amount: '1000000'
+  },
+  new Metadata(),
+  (err, resp) => {
+    if (err) {
+      console.error('supply asset failed', err);
+      return;
+    }
+    console.log('submitted first transaction, position snapshot:', resp.position ?? {});
+  }
+);

--- a/examples/docs/ts/price-oracle-publish.ts
+++ b/examples/docs/ts/price-oracle-publish.ts
@@ -1,0 +1,80 @@
+import path from 'node:path';
+import process from 'node:process';
+import {
+  credentials,
+  ClientDuplexStream,
+  ChannelCredentials,
+  ServiceError
+} from '@grpc/grpc-js';
+import { loadPackageDefinition } from '@grpc/grpc-js';
+import { loadSync } from '@grpc/proto-loader';
+
+type GossipEnvelope = {
+  envelope?: {
+    gossip?: {
+      type?: number;
+      payload?: Buffer;
+    };
+  };
+};
+
+type NetworkServiceClient = {
+  Gossip(): ClientDuplexStream<GossipEnvelope, GossipEnvelope>;
+};
+
+type NetworkServiceCtor = new (address: string, creds: ChannelCredentials) => NetworkServiceClient;
+
+const protoRoot = path.resolve(__dirname, '../../../proto/network/v1/network.proto');
+const definition = loadSync(protoRoot, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+  bytes: Buffer
+});
+
+const pkg = loadPackageDefinition(definition) as unknown as {
+  network: {
+    v1: {
+      NetworkService: NetworkServiceCtor;
+    };
+  };
+};
+
+const endpoint = process.env.ORACLE_GRPC_ADDR ?? 'localhost:9555';
+const client = new pkg.network.v1.NetworkService(endpoint, credentials.createInsecure());
+const stream = client.Gossip();
+
+stream.on('data', (msg: GossipEnvelope) => {
+  const payload = msg.envelope?.gossip?.payload;
+  if (payload) {
+    console.log('oracle ack payload', payload.toString('utf8'));
+  } else {
+    console.log('oracle ack with empty payload');
+  }
+  stream.end();
+});
+
+stream.on('error', (err: ServiceError) => {
+  console.error('oracle gossip error', err);
+});
+
+const pricePayload = Buffer.from(
+  JSON.stringify({
+    symbol: 'NHB/USD',
+    price: '1.0002',
+    timestamp: new Date().toISOString(),
+    publisherId: process.env.ORACLE_PUBLISHER_ID ?? 'oracle-publisher-1'
+  }),
+  'utf8'
+);
+
+stream.write({
+  envelope: {
+    gossip: {
+      type: 7001,
+      payload: pricePayload
+    }
+  }
+});

--- a/examples/docs/ts/query-positions.ts
+++ b/examples/docs/ts/query-positions.ts
@@ -1,0 +1,47 @@
+import path from 'node:path';
+import process from 'node:process';
+import { credentials, ClientUnaryCall, ServiceError, Metadata } from '@grpc/grpc-js';
+import { loadPackageDefinition } from '@grpc/grpc-js';
+import { loadSync } from '@grpc/proto-loader';
+
+type LendingServiceClient = {
+  GetPosition(
+    request: { account: string },
+    metadata: Metadata,
+    callback: (err: ServiceError | null, response: { position?: unknown }) => void
+  ): ClientUnaryCall;
+};
+
+type LendingServiceCtor = new (address: string, creds: ReturnType<typeof credentials.createInsecure>) => LendingServiceClient;
+
+const protoRoot = path.resolve(__dirname, '../../../proto/lending/v1/lending.proto');
+const definition = loadSync(protoRoot, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true
+});
+
+const pkg = loadPackageDefinition(definition) as unknown as {
+  lending: {
+    v1: {
+      LendingService: LendingServiceCtor;
+    };
+  };
+};
+
+const endpoint = process.env.LENDING_GRPC_ADDR ?? 'localhost:9444';
+const client = new pkg.lending.v1.LendingService(endpoint, credentials.createInsecure());
+
+client.GetPosition(
+  { account: process.env.LENDING_ACCOUNT ?? 'nhb1exampleaddress' },
+  new Metadata(),
+  (err, resp) => {
+    if (err) {
+      console.error('position query failed', err);
+      return;
+    }
+    console.log('active positions', JSON.stringify(resp.position ?? {}, null, 2));
+  }
+);

--- a/examples/docs/tsconfig.json
+++ b/examples/docs/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "outDir": "./dist"
+  },
+  "include": ["ts/**/*.ts"]
+}

--- a/examples/lending-dapp/pages/index.tsx
+++ b/examples/lending-dapp/pages/index.tsx
@@ -9,7 +9,7 @@ const documentationLinks = [
   },
   {
     label: 'RPC Reference',
-    href: '/docs/rpc',
+    href: '/docs/services',
     helper: 'Complete API surface for interacting with NHBChain from custom dApps.'
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@connectrpc/connect": "^2.1.0",
         "@connectrpc/connect-node": "^2.1.0",
         "@grpc/grpc-js": "^1.14.0",
+        "@grpc/proto-loader": "^0.7.10",
         "ts-proto": "^2.7.7"
       }
     },
@@ -61,7 +62,7 @@
         "node": ">=12.10.0"
       }
     },
-    "node_modules/@grpc/proto-loader": {
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
       "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
@@ -71,6 +72,25 @@
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
         "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nhbchain",
   "version": "1.0.0",
-  "description": "Welcome to the official Go implementation of the NHBCoin Layer 1 (L1) blockchain. This repository hosts the production codebase used to run validator and full nodes that power NHBCoin—a purpose-built payment rail engineered for instant settlement, mainstream usability, and institutional-grade compliance.",
+  "description": "Welcome to the official Go implementation of the NHBCoin Layer 1 (L1) blockchain. This repository hosts the production codebase used to run validator and full nodes that power NHBCoin\u2014a purpose-built payment rail engineered for instant settlement, mainstream usability, and institutional-grade compliance.",
   "main": "index.js",
   "directories": {
     "doc": "docs",
@@ -20,6 +20,7 @@
     "@connectrpc/connect": "^2.1.0",
     "@connectrpc/connect-node": "^2.1.0",
     "@grpc/grpc-js": "^1.14.0",
-    "ts-proto": "^2.7.7"
+    "ts-proto": "^2.7.7",
+    "@grpc/proto-loader": "^0.7.10"
   }
 }

--- a/tools/docs/verify.go
+++ b/tools/docs/verify.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type snippet struct {
+	lang string
+	file string
+}
+
+var linkRE = regexp.MustCompile(`!?\[[^\]]*\]\(([^)]+)\)`)
+
+func main() {
+	snippets := make([]snippet, 0)
+	if err := filepath.WalkDir("docs", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		fileSnippets, err := processDoc(path)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		snippets = append(snippets, fileSnippets...)
+		if err := checkLinks(path); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "docs verification failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := buildSnippets(snippets); err != nil {
+		fmt.Fprintf(os.Stderr, "docs verification failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func processDoc(path string) ([]snippet, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	snippets := make([]snippet, 0)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "<!-- embed:") || !strings.HasSuffix(line, "-->") {
+			continue
+		}
+		embedPath := strings.TrimSuffix(strings.TrimPrefix(line, "<!-- embed:"), " -->")
+		langLine, err := readLine(scanner)
+		if err != nil {
+			return nil, fmt.Errorf("embed %s missing code fence: %w", embedPath, err)
+		}
+		if !strings.HasPrefix(langLine, "```") {
+			return nil, fmt.Errorf("embed %s expected code fence, got %q", embedPath, langLine)
+		}
+		lang := strings.TrimPrefix(langLine, "```")
+		blockLines := make([]string, 0)
+		closed := false
+		for scanner.Scan() {
+			text := scanner.Text()
+			if text == "```" {
+				closed = true
+				break
+			}
+			blockLines = append(blockLines, text)
+		}
+		if scanner.Err() != nil {
+			return nil, scanner.Err()
+		}
+		if !closed {
+			return nil, fmt.Errorf("embed %s missing closing fence", embedPath)
+		}
+		expected, err := os.ReadFile(embedPath)
+		if err != nil {
+			return nil, fmt.Errorf("embed %s read: %w", embedPath, err)
+		}
+		normalizedDoc := normalizeBlock(blockLines)
+		normalizedFile := normalizeBlock(strings.Split(strings.TrimRight(string(expected), "\n"), "\n"))
+		if !bytes.Equal([]byte(strings.Join(normalizedDoc, "\n")), []byte(strings.Join(normalizedFile, "\n"))) {
+			return nil, fmt.Errorf("embed %s out of sync", embedPath)
+		}
+		snippets = append(snippets, snippet{lang: lang, file: embedPath})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return snippets, nil
+}
+
+func normalizeBlock(lines []string) []string {
+	out := make([]string, len(lines))
+	for i, line := range lines {
+		out[i] = strings.TrimRight(line, "\r")
+	}
+	return out
+}
+
+func readLine(scanner *bufio.Scanner) (string, error) {
+	if scanner.Scan() {
+		return scanner.Text(), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("unexpected EOF")
+}
+
+func buildSnippets(snippets []snippet) error {
+	goFiles := make([]string, 0)
+	hasTS := false
+	for _, snip := range snippets {
+		switch strings.TrimSpace(snip.lang) {
+		case "go":
+			goFiles = append(goFiles, snip.file)
+		case "ts", "typescript":
+			hasTS = true
+		}
+	}
+	for _, file := range goFiles {
+		cmd := exec.Command("go", "build", "-o", os.DevNull, file)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("go build %s: %w", file, err)
+		}
+	}
+	if hasTS {
+		cmd := exec.Command("npx", "tsc", "--noEmit", "--project", "examples/docs/tsconfig.json")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("ts compile snippets: %w", err)
+		}
+	}
+	return nil
+}
+func checkLinks(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	matches := linkRE.FindAllSubmatch(data, -1)
+	for _, match := range matches {
+		target := string(match[1])
+		if target == "" {
+			continue
+		}
+		if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") ||
+			strings.HasPrefix(target, "mailto:") || strings.HasPrefix(target, "#") ||
+			strings.HasPrefix(target, "tel:") {
+			continue
+		}
+		if strings.HasPrefix(target, "data:") {
+			continue
+		}
+		clean := target
+		if idx := strings.IndexByte(clean, '#'); idx >= 0 {
+			clean = clean[:idx]
+		}
+		if clean == "" {
+			continue
+		}
+		if strings.HasPrefix(clean, "/") {
+			// Treat as site-absolute and skip.
+			continue
+		}
+		resolved := filepath.Clean(filepath.Join(dir, clean))
+		if _, err := os.Stat(resolved); err != nil {
+			return fmt.Errorf("broken relative link %q", target)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add a service-oriented landing page and service directory, replacing legacy RPC references
- rewrite developer and operator quickstarts with Go and TypeScript snippets sourced from the examples workspace
- introduce docs verification tooling that enforces embedded snippet sync, link checking, and example compilation

## Testing
- make docs:verify

------
https://chatgpt.com/codex/tasks/task_e_68d8433a87b0832dae26bb1e0537f698