### PR TITLE
Add config validation scaffolding

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -1,0 +1,33 @@
+package config
+
+// Governance captures global governance policy knobs that must be validated
+// before applying runtime configuration updates.
+type Governance struct {
+	QuorumBPS        uint32
+	PassThresholdBPS uint32
+	VotingPeriodSecs uint64
+}
+
+// Slashing defines the allowed window bounds for penalty evaluation.
+type Slashing struct {
+	MinWindowSecs uint64
+	MaxWindowSecs uint64
+}
+
+// Mempool controls global transaction admission limits.
+type Mempool struct {
+	MaxBytes int64
+}
+
+// Blocks captures block production limits for transaction counts.
+type Blocks struct {
+	MaxTxs int64
+}
+
+// Global bundles the runtime configuration values enforced by ValidateConfig.
+type Global struct {
+	Governance Governance
+	Slashing   Slashing
+	Mempool    Mempool
+	Blocks     Blocks
+}

--- a/config/validate.go
+++ b/config/validate.go
@@ -1,0 +1,26 @@
+package config
+
+import "fmt"
+
+var (
+	MinVotingPeriodSeconds = uint64(3600)
+)
+
+func ValidateConfig(g Global) error {
+	if g.Governance.QuorumBPS < g.Governance.PassThresholdBPS {
+		return fmt.Errorf("governance: quorum_bps < pass_threshold_bps")
+	}
+	if g.Governance.VotingPeriodSecs < MinVotingPeriodSeconds {
+		return fmt.Errorf("governance: voting_period_seconds too small")
+	}
+	if g.Slashing.MinWindowSecs == 0 || g.Slashing.MinWindowSecs > g.Slashing.MaxWindowSecs {
+		return fmt.Errorf("slashing: min_window > max_window or zero")
+	}
+	if g.Mempool.MaxBytes <= 0 {
+		return fmt.Errorf("mempool: max_bytes <= 0")
+	}
+	if g.Blocks.MaxTxs <= 0 {
+		return fmt.Errorf("blocks: max_txs <= 0")
+	}
+	return nil
+}

--- a/tests/config/invariants_test.go
+++ b/tests/config/invariants_test.go
@@ -1,0 +1,59 @@
+package config_test
+
+import (
+	"testing"
+
+	"nhbchain/config"
+)
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.Global
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			cfg: config.Global{
+				Governance: config.Governance{
+					QuorumBPS:        6000,
+					PassThresholdBPS: 5000,
+					VotingPeriodSecs: config.MinVotingPeriodSeconds,
+				},
+				Slashing: config.Slashing{
+					MinWindowSecs: 1,
+					MaxWindowSecs: 10,
+				},
+				Mempool: config.Mempool{MaxBytes: 1},
+				Blocks:  config.Blocks{MaxTxs: 1},
+			},
+		},
+		{
+			name: "invalid quorum",
+			cfg: config.Global{
+				Governance: config.Governance{
+					QuorumBPS:        4000,
+					PassThresholdBPS: 5000,
+					VotingPeriodSecs: config.MinVotingPeriodSeconds,
+				},
+				Slashing: config.Slashing{
+					MinWindowSecs: 1,
+					MaxWindowSecs: 10,
+				},
+				Mempool: config.Mempool{MaxBytes: 1},
+				Blocks:  config.Blocks{MaxTxs: 1},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := config.ValidateConfig(tc.cfg)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateConfig() error = %v, wantErr %t", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add lightweight config type definitions for governance, slashing, mempool, and block limits
- implement ValidateConfig with base invariant checks and a default minimum voting period
- cover one passing and one failing scenario with a table-driven test stub

## Testing
- `go test ./tests/config -run TestValidateConfig -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68d8559cff14832db0de0b7ea17bfa06