### PR TITLE
Fail fast on invalid consensus global config

### DIFF
--- a/cmd/consensusd/main.go
+++ b/cmd/consensusd/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"log"
 	"net"
 	"net/url"
 	"os"
@@ -78,6 +79,10 @@ func main() {
 	cfg, err := config.Load(*configFile)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to load config: %v", err))
+	}
+
+	if err := config.ValidateConfig(cfg.Global); err != nil {
+		log.Fatal("invalid configuration", "err", err)
 	}
 
 	allowAutogenesis, err := resolveAllowAutogenesis(cfg.AllowAutogenesis, allowAutogenesisCLISet, *allowAutogenesisFlag, os.LookupEnv)

--- a/cmd/consensusd/main_test.go
+++ b/cmd/consensusd/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"nhbchain/config"
+)
+
+const (
+	subprocessEnv = "CONSENSUSD_SUBPROCESS"
+	configPathEnv = "CONSENSUSD_CONFIG"
+)
+
+func TestConsensusdFailsOnInvalidGlobalConfig(t *testing.T) {
+	if os.Getenv(subprocessEnv) == "1" {
+		cfgPath := os.Getenv(configPathEnv)
+		if cfgPath == "" {
+			t.Fatalf("missing %s", configPathEnv)
+		}
+		os.Args = []string{"consensusd", "--config", cfgPath}
+		main()
+		return
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	keystorePath := filepath.Join(dir, "validator.keystore")
+	contents := fmt.Sprintf(`ListenAddress = "127.0.0.1:0"
+RPCAddress = "127.0.0.1:0"
+DataDir = %q
+GenesisFile = ""
+AllowAutogenesis = true
+ValidatorKeystorePath = %q
+
+[global.governance]
+QuorumBPS = 6000
+PassThresholdBPS = 5000
+VotingPeriodSecs = %d
+
+[global.slashing]
+MinWindowSecs = 1
+MaxWindowSecs = 10
+
+[global.mempool]
+MaxBytes = 100
+
+[global.blocks]
+MaxTxs = 0
+`, dir, keystorePath, config.MinVotingPeriodSeconds)
+	if err := os.WriteFile(cfgPath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestConsensusdFailsOnInvalidGlobalConfig$")
+	cmd.Env = append(os.Environ(), subprocessEnv+"=1", configPathEnv+"="+cfgPath)
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("expected consensusd to exit with error, output=%s", output.String())
+	} else if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr.ExitCode() == 0 {
+			t.Fatalf("expected non-zero exit code")
+		}
+	} else {
+		t.Fatalf("unexpected error type: %v", err)
+	}
+
+	if !strings.Contains(output.String(), "invalid configuration") {
+		t.Fatalf("expected output to mention invalid configuration, got %s", output.String())
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -259,3 +259,25 @@ func TestGovPolicyParsing(t *testing.T) {
 		t.Fatalf("expected error for invalid deposit")
 	}
 }
+
+func TestLoadSetsGlobalDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	keystorePath := filepath.Join(dir, "validator.keystore")
+	contents := fmt.Sprintf(`ListenAddress = "0.0.0.0:6001"
+ValidatorKeystorePath = "%s"
+`, keystorePath)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	want := defaultGlobalConfig()
+	if cfg.Global != want {
+		t.Fatalf("unexpected global defaults: %+v", cfg.Global)
+	}
+}


### PR DESCRIPTION
## Summary
- validate the global runtime configuration during consensusd startup and abort on errors
- populate default global settings when missing from the TOML configuration
- add regression tests covering default injection and the invalid MaxTxs boot failure

## Testing
- go test ./config ./cmd/consensusd

------
https://chatgpt.com/codex/tasks/task_e_68d85980bf5c832db6ba0faedf91f302