### PR TITLE
Add module pause guard and module pause wiring

### DIFF
--- a/cmd/consensusd/main.go
+++ b/cmd/consensusd/main.go
@@ -208,6 +208,8 @@ func main() {
 	node.SetSwapOracle(aggregator)
 	node.SetSwapManualOracle(manualOracle)
 
+	node.SetModulePauses(cfg.Global.Pauses)
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 

--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,7 @@ func defaultGlobalConfig() Global {
 		},
 		Mempool: Mempool{MaxBytes: 16 << 20},
 		Blocks:  Blocks{MaxTxs: 5000},
+		Pauses:  Pauses{},
 	}
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -24,10 +24,20 @@ type Blocks struct {
 	MaxTxs int64
 }
 
+type Pauses struct {
+	Lending bool
+	Swap    bool
+	Escrow  bool
+	Trade   bool
+	Loyalty bool
+	POTSO   bool
+}
+
 // Global bundles the runtime configuration values enforced by ValidateConfig.
 type Global struct {
 	Governance Governance
 	Slashing   Slashing
 	Mempool    Mempool
 	Blocks     Blocks
+	Pauses     Pauses
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -19,6 +19,7 @@ import (
 	nhbstate "nhbchain/core/state"
 	"nhbchain/core/types"
 	"nhbchain/crypto"
+	nativecommon "nhbchain/native/common"
 	"nhbchain/native/escrow"
 	"nhbchain/native/governance"
 	"nhbchain/native/loyalty"
@@ -66,6 +67,7 @@ type StateProcessor struct {
 	LoyaltyEngine      *loyalty.Engine
 	EscrowEngine       *escrow.Engine
 	TradeEngine        *escrow.TradeEngine
+	pauses             nativecommon.PauseView
 	escrowFeeTreasury  [20]byte
 	usernameToAddr     map[string][]byte
 	ValidatorSet       map[string]*big.Int
@@ -124,6 +126,22 @@ func NewStateProcessor(tr *trie.Trie) (*StateProcessor, error) {
 		return nil, err
 	}
 	return sp, nil
+}
+
+func (sp *StateProcessor) SetPauseView(p nativecommon.PauseView) {
+	if sp == nil {
+		return
+	}
+	sp.pauses = p
+	if sp.EscrowEngine != nil {
+		sp.EscrowEngine.SetPauses(p)
+	}
+	if sp.TradeEngine != nil {
+		sp.TradeEngine.SetPauses(p)
+	}
+	if sp.LoyaltyEngine != nil {
+		sp.LoyaltyEngine.SetPauses(p)
+	}
 }
 
 // SetEscrowFeeTreasury configures the address receiving escrow fees during

--- a/native/common/guard.go
+++ b/native/common/guard.go
@@ -1,0 +1,19 @@
+package common
+
+import "errors"
+
+var ErrModulePaused = errors.New("module paused")
+
+type PauseView interface {
+	IsPaused(module string) bool
+}
+
+func Guard(p PauseView, module string) error {
+	if p == nil || module == "" {
+		return nil
+	}
+	if p.IsPaused(module) {
+		return ErrModulePaused
+	}
+	return nil
+}

--- a/native/lending/engine_guard_test.go
+++ b/native/lending/engine_guard_test.go
@@ -1,0 +1,56 @@
+package lending
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	nativecommon "nhbchain/native/common"
+)
+
+type stubPauseView struct {
+	modules map[string]bool
+}
+
+func (s stubPauseView) IsPaused(module string) bool {
+	if s.modules == nil {
+		return false
+	}
+	return s.modules[module]
+}
+
+func TestSupplyGuardBlocksMutation(t *testing.T) {
+	moduleAddr := makeAddress(crypto.NHBPrefix, 0xAA)
+	collateralAddr := makeAddress(crypto.ZNHBPrefix, 0xBB)
+	supplier := makeAddress(crypto.NHBPrefix, 0xCC)
+
+	engine := NewEngine(moduleAddr, collateralAddr, RiskParameters{})
+	engine.SetPauses(stubPauseView{modules: map[string]bool{"lending": true}})
+
+	state := newMockEngineState()
+	state.market = &Market{
+		TotalNHBSupplied:  big.NewInt(0),
+		TotalSupplyShares: big.NewInt(0),
+		TotalNHBBorrowed:  big.NewInt(0),
+		SupplyIndex:       big.NewInt(1),
+		BorrowIndex:       big.NewInt(1),
+	}
+	state.accounts[state.key(supplier)] = &types.Account{BalanceNHB: big.NewInt(500), BalanceZNHB: big.NewInt(0)}
+	state.accounts[state.key(moduleAddr)] = &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0)}
+
+	engine.SetState(state)
+	engine.SetPoolID("default")
+
+	if _, err := engine.Supply(supplier, big.NewInt(100)); !errors.Is(err, nativecommon.ErrModulePaused) {
+		t.Fatalf("expected ErrModulePaused, got %v", err)
+	}
+
+	if balance := state.accounts[state.key(supplier)].BalanceNHB; balance.Cmp(big.NewInt(500)) != 0 {
+		t.Fatalf("expected supplier balance to remain 500, got %s", balance)
+	}
+	if supplied := state.market.TotalNHBSupplied; supplied.Sign() != 0 {
+		t.Fatalf("expected market supply unchanged, got %s", supplied)
+	}
+}

--- a/native/loyalty/loyalty.go
+++ b/native/loyalty/loyalty.go
@@ -1,16 +1,31 @@
 package loyalty
 
+import nativecommon "nhbchain/native/common"
+
 // Engine represents the native loyalty and rewards module.
-type Engine struct{}
+type Engine struct {
+	pauses nativecommon.PauseView
+}
 
 // NewEngine creates a new loyalty engine instance.
 func NewEngine() *Engine { return &Engine{} }
+
+// SetPauses configures the pause view to guard reward processing.
+func (e *Engine) SetPauses(p nativecommon.PauseView) {
+	if e == nil {
+		return
+	}
+	e.pauses = p
+}
 
 // OnTransactionSuccess evaluates and applies applicable loyalty rewards for the
 // supplied transaction context. Base rewards are processed first followed by
 // program-specific rewards when the state implementation supports them.
 func (e *Engine) OnTransactionSuccess(st BaseRewardState, ctx *BaseRewardContext) {
 	if st == nil || ctx == nil {
+		return
+	}
+	if err := nativecommon.Guard(e.pauses, moduleName); err != nil {
 		return
 	}
 	e.ApplyBaseReward(st, ctx)

--- a/native/loyalty/registry_business.go
+++ b/native/loyalty/registry_business.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	nativecommon "nhbchain/native/common"
 )
 
 var zeroBusinessID BusinessID
@@ -14,6 +16,9 @@ func (r *Registry) RegisterBusiness(owner [20]byte, name string) (BusinessID, er
 	trimmed := strings.TrimSpace(name)
 	if trimmed == "" {
 		return zeroBusinessID, fmt.Errorf("%w: name required", ErrInvalidBusiness)
+	}
+	if err := nativecommon.Guard(r.pauses, moduleName); err != nil {
+		return zeroBusinessID, err
 	}
 	id, err := r.nextBusinessID()
 	if err != nil {
@@ -35,6 +40,9 @@ func (r *Registry) RegisterBusiness(owner [20]byte, name string) (BusinessID, er
 }
 
 func (r *Registry) SetPaymaster(id BusinessID, caller [20]byte, newPaymaster [20]byte) error {
+	if err := nativecommon.Guard(r.pauses, moduleName); err != nil {
+		return err
+	}
 	business, ok := r.getBusiness(id)
 	if !ok {
 		return ErrBusinessNotFound
@@ -78,6 +86,9 @@ func (r *Registry) SetPaymaster(id BusinessID, caller [20]byte, newPaymaster [20
 }
 
 func (r *Registry) AddMerchantAddress(id BusinessID, addr [20]byte) error {
+	if err := nativecommon.Guard(r.pauses, moduleName); err != nil {
+		return err
+	}
 	business, ok := r.getBusiness(id)
 	if !ok {
 		return ErrBusinessNotFound
@@ -106,6 +117,9 @@ func (r *Registry) AddMerchantAddress(id BusinessID, addr [20]byte) error {
 }
 
 func (r *Registry) RemoveMerchantAddress(id BusinessID, addr [20]byte) error {
+	if err := nativecommon.Guard(r.pauses, moduleName); err != nil {
+		return err
+	}
 	business, ok := r.getBusiness(id)
 	if !ok {
 		return ErrBusinessNotFound

--- a/native/loyalty/registry_program.go
+++ b/native/loyalty/registry_program.go
@@ -1,5 +1,7 @@
 package loyalty
 
+import nativecommon "nhbchain/native/common"
+
 var (
 	programPrefix             = []byte("loyalty/program/")
 	programOwnerIndexPref     = []byte("loyalty/merchant/")
@@ -69,6 +71,9 @@ func ownerPaymasterKey(owner [20]byte) []byte {
 // PauseProgram transitions the specified program into an inactive state. The
 // caller must be either the program owner or hold the loyalty admin role.
 func (r *Registry) PauseProgram(caller [20]byte, id ProgramID) error {
+	if err := nativecommon.Guard(r.pauses, moduleName); err != nil {
+		return err
+	}
 	program := new(Program)
 	found, err := r.st.KVGet(programKey(id), program)
 	if err != nil {
@@ -94,6 +99,9 @@ func (r *Registry) PauseProgram(caller [20]byte, id ProgramID) error {
 // ResumeProgram reactivates the specified program. The caller must be either
 // the program owner or hold the loyalty admin role.
 func (r *Registry) ResumeProgram(caller [20]byte, id ProgramID) error {
+	if err := nativecommon.Guard(r.pauses, moduleName); err != nil {
+		return err
+	}
 	program := new(Program)
 	found, err := r.st.KVGet(programKey(id), program)
 	if err != nil {

--- a/rpc/modules/lending.go
+++ b/rpc/modules/lending.go
@@ -321,6 +321,7 @@ func (m *LendingModule) withEngine(poolID string, fn func(*lending.Engine, *lend
 	return m.node.WithState(func(manager *nhbstate.Manager) error {
 		adapter := &lendingStateAdapter{manager: manager, poolID: id}
 		engine := lending.NewEngine(m.node.LendingModuleAddress(), m.node.LendingCollateralAddress(), m.node.LendingRiskParameters())
+		engine.SetPauses(m.node)
 		engine.SetState(adapter)
 		engine.SetPoolID(id)
 		engine.SetInterestModel(m.node.LendingInterestModel())


### PR DESCRIPTION
## Summary
- add a pause guard helper and expose module pause flags through config
- wire pause state through the node, engines, and RPC entrypoints
- add a lending engine guard test to ensure paused modules do not mutate state

## Testing
- go test ./native/...


------
https://chatgpt.com/codex/tasks/task_e_68d8642153e0832dbd7c00f4ebe0e561