### PR TITLE
Add quota configuration structs and quota check helper

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -33,6 +33,23 @@ type Pauses struct {
 	POTSO   bool
 }
 
+// Quota defines rate limits for module interactions on a per-address basis.
+type Quota struct {
+	MaxRequestsPerMin uint32
+	MaxNHBPerEpoch    uint64 // in gwei or base units
+	EpochSeconds      uint32 // e.g., 3600
+}
+
+// Quotas groups quotas for each module.
+type Quotas struct {
+	Lending Quota
+	Swap    Quota
+	Escrow  Quota
+	Trade   Quota
+	Loyalty Quota
+	POTSO   Quota
+}
+
 // Global bundles the runtime configuration values enforced by ValidateConfig.
 type Global struct {
 	Governance Governance
@@ -40,4 +57,5 @@ type Global struct {
 	Mempool    Mempool
 	Blocks     Blocks
 	Pauses     Pauses
+	Quotas     Quotas
 }

--- a/native/common/quota.go
+++ b/native/common/quota.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"errors"
+	"math"
+)
+
+var (
+	ErrQuotaRequestsExceeded = errors.New("quota requests exceeded")
+	ErrQuotaNHBCapExceeded   = errors.New("quota nhb cap exceeded")
+	ErrQuotaCounterOverflow  = errors.New("quota counter overflow")
+)
+
+// QuotaNow captures the current quota usage counters for an address.
+type QuotaNow struct {
+	ReqCount uint32
+	NHBUsed  uint64
+	EpochID  uint64
+}
+
+// Quota defines the limits enforced for a module interaction per address.
+type Quota struct {
+	MaxRequestsPerMin uint32
+	MaxNHBPerEpoch    uint64
+	EpochSeconds      uint32
+}
+
+// CheckQuota verifies whether the additional request and NHB usage fit within the
+// configured quota. The returned QuotaNow reflects the updated counters when the
+// quota is not exceeded.
+func CheckQuota(q Quota, nowEpoch uint64, prev QuotaNow, addReq uint32, addNHB uint64) (QuotaNow, error) {
+	next := prev
+	if prev.EpochID != nowEpoch {
+		next = QuotaNow{EpochID: nowEpoch}
+	}
+
+	if addReq > 0 {
+		if next.ReqCount > math.MaxUint32-addReq {
+			return prev, ErrQuotaCounterOverflow
+		}
+		next.ReqCount += addReq
+	}
+	if q.MaxRequestsPerMin > 0 && next.ReqCount > q.MaxRequestsPerMin {
+		return prev, ErrQuotaRequestsExceeded
+	}
+
+	if addNHB > 0 {
+		if next.NHBUsed > math.MaxUint64-addNHB {
+			return prev, ErrQuotaCounterOverflow
+		}
+		next.NHBUsed += addNHB
+	}
+	if q.MaxNHBPerEpoch > 0 && next.NHBUsed > q.MaxNHBPerEpoch {
+		return prev, ErrQuotaNHBCapExceeded
+	}
+
+	return next, nil
+}

--- a/native/common/quota_test.go
+++ b/native/common/quota_test.go
@@ -1,0 +1,64 @@
+package common
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCheckQuotaRequestLimit(t *testing.T) {
+	q := Quota{MaxRequestsPerMin: 10}
+	prev := QuotaNow{EpochID: 1}
+
+	next, err := CheckQuota(q, 1, prev, 10, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if next.ReqCount != 10 {
+		t.Fatalf("unexpected request count: %d", next.ReqCount)
+	}
+
+	denied, err := CheckQuota(q, 1, next, 1, 0)
+	if !errors.Is(err, ErrQuotaRequestsExceeded) {
+		t.Fatalf("expected ErrQuotaRequestsExceeded, got %v", err)
+	}
+	if denied != next {
+		t.Fatalf("expected counters to remain unchanged on denial")
+	}
+
+	rollover, err := CheckQuota(q, 2, next, 1, 0)
+	if err != nil {
+		t.Fatalf("unexpected error after epoch rollover: %v", err)
+	}
+	if rollover.EpochID != 2 || rollover.ReqCount != 1 {
+		t.Fatalf("unexpected state after rollover: %+v", rollover)
+	}
+}
+
+func TestCheckQuotaNHB(t *testing.T) {
+	q := Quota{MaxNHBPerEpoch: 1000}
+	prev := QuotaNow{EpochID: 5}
+
+	next, err := CheckQuota(q, 5, prev, 0, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if next.NHBUsed != 1000 {
+		t.Fatalf("unexpected nhb used: %d", next.NHBUsed)
+	}
+
+	denied, err := CheckQuota(q, 5, next, 0, 1)
+	if !errors.Is(err, ErrQuotaNHBCapExceeded) {
+		t.Fatalf("expected ErrQuotaNHBCapExceeded, got %v", err)
+	}
+	if denied != next {
+		t.Fatalf("expected counters to remain unchanged on denial")
+	}
+
+	rollover, err := CheckQuota(q, 6, next, 0, 500)
+	if err != nil {
+		t.Fatalf("unexpected error after epoch rollover: %v", err)
+	}
+	if rollover.NHBUsed != 500 {
+		t.Fatalf("unexpected nhb used after rollover: %d", rollover.NHBUsed)
+	}
+}


### PR DESCRIPTION
## Summary
- add quota configuration structs to the global runtime configuration
- implement a pure quota checking helper with overflow protection
- cover quota boundaries and epoch rollover with unit tests

## Testing
- `go test ./native/common`


------
https://chatgpt.com/codex/tasks/task_e_68d86ffd327c832daf66dcf8704807c5