### PR TITLE
Persist and enforce module quotas

### DIFF
--- a/cmd/consensusd/main.go
+++ b/cmd/consensusd/main.go
@@ -23,6 +23,7 @@ import (
 	"nhbchain/consensus/service"
 	"nhbchain/core"
 	"nhbchain/crypto"
+	nativecommon "nhbchain/native/common"
 	"nhbchain/native/lending"
 	swap "nhbchain/native/swap"
 	"nhbchain/network"
@@ -37,6 +38,14 @@ const (
 	genesisPathEnv      = "NHB_GENESIS"
 	allowAutogenesisEnv = "NHB_ALLOW_AUTOGENESIS"
 )
+
+func convertQuota(q config.Quota) nativecommon.Quota {
+	return nativecommon.Quota{
+		MaxRequestsPerMin: q.MaxRequestsPerMin,
+		MaxNHBPerEpoch:    q.MaxNHBPerEpoch,
+		EpochSeconds:      q.EpochSeconds,
+	}
+}
 
 func main() {
 	configFile := flag.String("config", "./config.toml", "Path to the configuration file")
@@ -209,6 +218,14 @@ func main() {
 	node.SetSwapManualOracle(manualOracle)
 
 	node.SetModulePauses(cfg.Global.Pauses)
+	node.SetModuleQuotas(map[string]nativecommon.Quota{
+		"lending": convertQuota(cfg.Global.Quotas.Lending),
+		"swap":    convertQuota(cfg.Global.Quotas.Swap),
+		"escrow":  convertQuota(cfg.Global.Quotas.Escrow),
+		"trade":   convertQuota(cfg.Global.Quotas.Trade),
+		"loyalty": convertQuota(cfg.Global.Quotas.Loyalty),
+		"potso":   convertQuota(cfg.Global.Quotas.POTSO),
+	})
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/core/epochs.go
+++ b/core/epochs.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"math/big"
+	"time"
 
 	"nhbchain/core/epoch"
 	"nhbchain/core/events"
@@ -117,6 +118,9 @@ func (sp *StateProcessor) pruneEpochHistory() {
 }
 
 func (sp *StateProcessor) ProcessBlockLifecycle(height uint64, timestamp int64) error {
+	if err := sp.pruneQuotaCounters(time.Unix(timestamp, 0).UTC()); err != nil {
+		return err
+	}
 	if err := sp.maybeProcessPotsoRewards(height, timestamp); err != nil {
 		return err
 	}

--- a/core/quota_integration_test.go
+++ b/core/quota_integration_test.go
@@ -1,0 +1,122 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	nhbstate "nhbchain/core/state"
+	"nhbchain/core/types"
+	nativecommon "nhbchain/native/common"
+	systemquotas "nhbchain/native/system/quotas"
+	"nhbchain/storage"
+	statetrie "nhbchain/storage/trie"
+)
+
+func TestQuotaEnforcementHeartbeat(t *testing.T) {
+	db := storage.NewMemDB()
+	t.Cleanup(db.Close)
+	trie, err := statetrie.NewTrie(db, nil)
+	if err != nil {
+		t.Fatalf("new trie: %v", err)
+	}
+	sp, err := NewStateProcessor(trie)
+	if err != nil {
+		t.Fatalf("state processor: %v", err)
+	}
+
+	sp.SetQuotaConfig(map[string]nativecommon.Quota{
+		modulePotso: {MaxRequestsPerMin: 3, EpochSeconds: 60},
+	})
+
+	sender := make([]byte, 20)
+	sender[0] = 0x42
+	account := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0)}
+	if err := sp.setAccount(sender, account); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	start := time.Unix(1_700_000_000, 0).UTC()
+
+	sp.BeginBlock(1, start)
+	for i := 0; i < 3; i++ {
+		payload := types.HeartbeatPayload{DeviceID: "dev", Timestamp: start.Add(time.Duration(i+1) * time.Minute).Unix()}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal heartbeat: %v", err)
+		}
+		tx := &types.Transaction{Type: types.TxTypeHeartbeat, Data: data}
+		acc, err := sp.getAccount(sender)
+		if err != nil {
+			t.Fatalf("get account: %v", err)
+		}
+		if err := sp.handleNativeTransaction(tx, sender, acc); err != nil {
+			t.Fatalf("heartbeat %d: %v", i, err)
+		}
+	}
+
+	failPayload := types.HeartbeatPayload{DeviceID: "dev", Timestamp: start.Add(4 * time.Minute).Unix()}
+	failData, err := json.Marshal(failPayload)
+	if err != nil {
+		t.Fatalf("marshal fail heartbeat: %v", err)
+	}
+	failTx := &types.Transaction{Type: types.TxTypeHeartbeat, Data: failData}
+	acc, err := sp.getAccount(sender)
+	if err != nil {
+		t.Fatalf("get account for failure: %v", err)
+	}
+	if err := sp.handleNativeTransaction(failTx, sender, acc); err == nil || !errors.Is(err, nativecommon.ErrQuotaRequestsExceeded) {
+		t.Fatalf("expected quota error, got %v", err)
+	}
+
+	events := sp.Events()
+	if len(events) == 0 {
+		t.Fatalf("expected quota event")
+	}
+	last := events[len(events)-1]
+	if last.Type != "QuotaExceeded" {
+		t.Fatalf("unexpected event type: %s", last.Type)
+	}
+	if reason := last.Attributes["reason"]; reason != "requests" {
+		t.Fatalf("unexpected quota reason: %s", reason)
+	}
+
+	sp.EndBlock()
+	if err := sp.ProcessBlockLifecycle(1, start.Unix()); err != nil {
+		t.Fatalf("process block 1: %v", err)
+	}
+
+	sp.BeginBlock(2, start.Add(time.Minute))
+	nextPayload := types.HeartbeatPayload{DeviceID: "dev", Timestamp: start.Add(5 * time.Minute).Unix()}
+	nextData, err := json.Marshal(nextPayload)
+	if err != nil {
+		t.Fatalf("marshal next heartbeat: %v", err)
+	}
+	nextTx := &types.Transaction{Type: types.TxTypeHeartbeat, Data: nextData}
+	acc, err = sp.getAccount(sender)
+	if err != nil {
+		t.Fatalf("get account after rollover: %v", err)
+	}
+	if err := sp.handleNativeTransaction(nextTx, sender, acc); err != nil {
+		t.Fatalf("heartbeat after rollover: %v", err)
+	}
+	sp.EndBlock()
+	if err := sp.ProcessBlockLifecycle(2, start.Add(time.Minute).Unix()); err != nil {
+		t.Fatalf("process block 2: %v", err)
+	}
+
+	sp.BeginBlock(3, start.Add(2*time.Minute))
+	sp.EndBlock()
+	if err := sp.ProcessBlockLifecycle(3, start.Add(2*time.Minute).Unix()); err != nil {
+		t.Fatalf("process block 3: %v", err)
+	}
+
+	store := systemquotas.NewStore(nhbstate.NewManager(sp.Trie))
+	if _, ok, err := store.Load("potso", 0, sender); err != nil {
+		t.Fatalf("load counters: %v", err)
+	} else if ok {
+		t.Fatalf("expected epoch 0 counters pruned")
+	}
+}

--- a/core/state/manager.go
+++ b/core/state/manager.go
@@ -3184,6 +3184,14 @@ func (m *Manager) KVPut(key []byte, value interface{}) error {
 	return m.trie.Update(kvKey(key), encoded)
 }
 
+// KVDelete removes the value stored under the supplied key.
+func (m *Manager) KVDelete(key []byte) error {
+	if len(key) == 0 {
+		return fmt.Errorf("kv: key must not be empty")
+	}
+	return m.trie.Update(kvKey(key), nil)
+}
+
 // KVGet retrieves the value stored under the supplied key and decodes it into
 // the provided destination. The boolean return value indicates whether the key
 // existed in state.

--- a/native/common/quota.go
+++ b/native/common/quota.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"math"
 )
 
@@ -10,6 +11,12 @@ var (
 	ErrQuotaNHBCapExceeded   = errors.New("quota nhb cap exceeded")
 	ErrQuotaCounterOverflow  = errors.New("quota counter overflow")
 )
+
+// Store provides persistence for quota counters.
+type Store interface {
+	Load(module string, epoch uint64, addr []byte) (QuotaNow, bool, error)
+	Save(module string, epoch uint64, addr []byte, counters QuotaNow) error
+}
 
 // QuotaNow captures the current quota usage counters for an address.
 type QuotaNow struct {
@@ -54,5 +61,30 @@ func CheckQuota(q Quota, nowEpoch uint64, prev QuotaNow, addReq uint32, addNHB u
 		return prev, ErrQuotaNHBCapExceeded
 	}
 
+	return next, nil
+}
+
+// Apply loads the persisted counters for the provided address and updates them
+// with the supplied increments when within quota limits. The updated counters
+// are stored back to the underlying persistence layer. When the quota is
+// exceeded the original counters are returned alongside the error.
+func Apply(store Store, module string, nowEpoch uint64, addr []byte, q Quota, addReq uint32, addNHB uint64) (QuotaNow, error) {
+	if store == nil {
+		return QuotaNow{}, fmt.Errorf("quota: store unavailable")
+	}
+	if len(addr) == 0 {
+		return QuotaNow{}, fmt.Errorf("quota: address required")
+	}
+	prev, _, err := store.Load(module, nowEpoch, addr)
+	if err != nil {
+		return QuotaNow{}, err
+	}
+	next, err := CheckQuota(q, nowEpoch, prev, addReq, addNHB)
+	if err != nil {
+		return prev, err
+	}
+	if err := store.Save(module, nowEpoch, addr, next); err != nil {
+		return QuotaNow{}, err
+	}
 	return next, nil
 }

--- a/native/system/quotas/keys.go
+++ b/native/system/quotas/keys.go
@@ -1,0 +1,25 @@
+package quotas
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	quotasPrefix      = "quotas"
+	quotasIndexSuffix = "index"
+)
+
+func normaliseModule(module string) string {
+	return strings.ToLower(strings.TrimSpace(module))
+}
+
+func counterKey(module string, epoch uint64, addr []byte) []byte {
+	normalised := normaliseModule(module)
+	return []byte(fmt.Sprintf("%s/%s/%d/%x", quotasPrefix, normalised, epoch, addr))
+}
+
+func epochIndexKey(module string, epoch uint64) []byte {
+	normalised := normaliseModule(module)
+	return []byte(fmt.Sprintf("%s/%s/%d/%s", quotasPrefix, normalised, epoch, quotasIndexSuffix))
+}

--- a/native/system/quotas/store.go
+++ b/native/system/quotas/store.go
@@ -1,0 +1,95 @@
+package quotas
+
+import (
+	"fmt"
+
+	nativecommon "nhbchain/native/common"
+)
+
+type counterRecord struct {
+	ReqCount uint32
+	NHBUsed  uint64
+}
+
+type StoreState interface {
+	KVGet(key []byte, out interface{}) (bool, error)
+	KVPut(key []byte, value interface{}) error
+	KVAppend(key []byte, value []byte) error
+	KVGetList(key []byte, out interface{}) error
+	KVDelete(key []byte) error
+}
+
+type Store struct {
+	state StoreState
+}
+
+func NewStore(state StoreState) *Store {
+	return &Store{state: state}
+}
+
+func (s *Store) withState() (StoreState, error) {
+	if s == nil || s.state == nil {
+		return nil, fmt.Errorf("quota store not initialised")
+	}
+	return s.state, nil
+}
+
+func (s *Store) Load(module string, epoch uint64, addr []byte) (nativecommon.QuotaNow, bool, error) {
+	state, err := s.withState()
+	if err != nil {
+		return nativecommon.QuotaNow{}, false, err
+	}
+	if len(addr) == 0 {
+		return nativecommon.QuotaNow{}, false, fmt.Errorf("quota: address required")
+	}
+	key := counterKey(module, epoch, addr)
+	var stored counterRecord
+	ok, err := state.KVGet(key, &stored)
+	if err != nil {
+		return nativecommon.QuotaNow{}, false, fmt.Errorf("quota: load counters: %w", err)
+	}
+	if !ok {
+		return nativecommon.QuotaNow{EpochID: epoch}, false, nil
+	}
+	now := nativecommon.QuotaNow{EpochID: epoch, ReqCount: stored.ReqCount, NHBUsed: stored.NHBUsed}
+	return now, true, nil
+}
+
+func (s *Store) Save(module string, epoch uint64, addr []byte, counters nativecommon.QuotaNow) error {
+	state, err := s.withState()
+	if err != nil {
+		return err
+	}
+	if len(addr) == 0 {
+		return fmt.Errorf("quota: address required")
+	}
+	record := counterRecord{ReqCount: counters.ReqCount, NHBUsed: counters.NHBUsed}
+	if err := state.KVPut(counterKey(module, epoch, addr), record); err != nil {
+		return fmt.Errorf("quota: persist counters: %w", err)
+	}
+	if err := state.KVAppend(epochIndexKey(module, epoch), append([]byte(nil), addr...)); err != nil {
+		return fmt.Errorf("quota: update epoch index: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) PruneEpoch(module string, epoch uint64) error {
+	state, err := s.withState()
+	if err != nil {
+		return err
+	}
+	indexKey := epochIndexKey(module, epoch)
+	var addrs [][]byte
+	if err := state.KVGetList(indexKey, &addrs); err != nil {
+		return fmt.Errorf("quota: load epoch index: %w", err)
+	}
+	for _, addr := range addrs {
+		if err := state.KVDelete(counterKey(module, epoch, addr)); err != nil {
+			return fmt.Errorf("quota: prune counter: %w", err)
+		}
+	}
+	if err := state.KVDelete(indexKey); err != nil {
+		return fmt.Errorf("quota: prune index: %w", err)
+	}
+	return nil
+}

--- a/native/system/quotas/store_test.go
+++ b/native/system/quotas/store_test.go
@@ -1,0 +1,132 @@
+package quotas
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rlp"
+
+	nativecommon "nhbchain/native/common"
+)
+
+type memoryState struct {
+	data map[string][]byte
+}
+
+func newMemoryState() *memoryState {
+	return &memoryState{data: make(map[string][]byte)}
+}
+
+func (m *memoryState) KVGet(key []byte, out interface{}) (bool, error) {
+	raw, ok := m.data[string(key)]
+	if !ok || len(raw) == 0 {
+		return false, nil
+	}
+	if out == nil {
+		return true, nil
+	}
+	if err := rlp.DecodeBytes(raw, out); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (m *memoryState) KVPut(key []byte, value interface{}) error {
+	encoded, err := rlp.EncodeToBytes(value)
+	if err != nil {
+		return err
+	}
+	m.data[string(key)] = encoded
+	return nil
+}
+
+func (m *memoryState) KVAppend(key []byte, value []byte) error {
+	var existing [][]byte
+	if raw, ok := m.data[string(key)]; ok && len(raw) > 0 {
+		if err := rlp.DecodeBytes(raw, &existing); err != nil {
+			return err
+		}
+	}
+	for _, entry := range existing {
+		if string(entry) == string(value) {
+			encoded, err := rlp.EncodeToBytes(existing)
+			if err != nil {
+				return err
+			}
+			m.data[string(key)] = encoded
+			return nil
+		}
+	}
+	existing = append(existing, append([]byte(nil), value...))
+	encoded, err := rlp.EncodeToBytes(existing)
+	if err != nil {
+		return err
+	}
+	m.data[string(key)] = encoded
+	return nil
+}
+
+func (m *memoryState) KVGetList(key []byte, out interface{}) error {
+	raw, ok := m.data[string(key)]
+	if !ok || len(raw) == 0 {
+		// ensure out becomes empty slice
+		switch dest := out.(type) {
+		case *[]byte:
+			*dest = (*dest)[:0]
+		case *[][]byte:
+			*dest = (*dest)[:0]
+		default:
+			// attempt to decode empty list
+			encoded, _ := rlp.EncodeToBytes([][]byte{})
+			return rlp.DecodeBytes(encoded, out)
+		}
+		return nil
+	}
+	return rlp.DecodeBytes(raw, out)
+}
+
+func (m *memoryState) KVDelete(key []byte) error {
+	delete(m.data, string(key))
+	return nil
+}
+
+func TestQuotaStoreCountersAndPrune(t *testing.T) {
+	state := newMemoryState()
+	store := NewStore(state)
+
+	addr := make([]byte, 20)
+	addr[0] = 0xAA
+	quota := nativecommon.Quota{MaxRequestsPerMin: 2, EpochSeconds: 60}
+
+	if _, err := nativecommon.Apply(store, "escrow", 0, addr, quota, 1, 0); err != nil {
+		t.Fatalf("apply quota: %v", err)
+	}
+	next, err := nativecommon.Apply(store, "escrow", 0, addr, quota, 1, 0)
+	if err != nil {
+		t.Fatalf("apply quota second: %v", err)
+	}
+	if next.ReqCount != 2 {
+		t.Fatalf("expected request count 2, got %d", next.ReqCount)
+	}
+
+	if _, err := nativecommon.Apply(store, "escrow", 0, addr, quota, 1, 0); err == nil || !errors.Is(err, nativecommon.ErrQuotaRequestsExceeded) {
+		t.Fatalf("expected ErrQuotaRequestsExceeded, got %v", err)
+	}
+
+	rollover, err := nativecommon.Apply(store, "escrow", 1, addr, quota, 1, 0)
+	if err != nil {
+		t.Fatalf("apply quota after epoch: %v", err)
+	}
+	if rollover.EpochID != 1 || rollover.ReqCount != 1 {
+		t.Fatalf("unexpected counters after rollover: %+v", rollover)
+	}
+
+	if err := store.PruneEpoch("escrow", 0); err != nil {
+		t.Fatalf("prune epoch: %v", err)
+	}
+	if _, ok, err := store.Load("escrow", 0, addr); err != nil {
+		t.Fatalf("load after prune: %v", err)
+	} else if ok {
+		t.Fatalf("expected epoch 0 counters pruned")
+	}
+}


### PR DESCRIPTION
## Summary
- add a persistent quota store with keys under `quotas/<module>/<epoch>/<address>` and helper APIs
- wire quota enforcement into the state processor, emit QuotaExceeded events, prune stale epochs, and allow node configuration
- expose configuration plumbing through `consensusd` and add coverage for heartbeat quota enforcement

## Testing
- go test ./native/system/quotas
- go test ./core -run TestQuotaEnforcementHeartbeat -count=1

------
https://chatgpt.com/codex/tasks/task_e_68d873fb4a5c832db6081ad6d721c847