### PR TITLE
Add token bucket rate limiting to gateway routes

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -137,16 +137,20 @@ func main() {
 		if entry.ID == "" {
 			continue
 		}
+		rate := entry.RatePerSecond
+		if rate <= 0 && entry.RequestsPerMinute > 0 {
+			rate = entry.RequestsPerMinute / 60.0
+		}
 		rateLimits[entry.ID] = middleware.RateLimit{
-			RequestsPerMinute: entry.RequestsPerMinute,
-			Burst:             entry.Burst,
+			RatePerSecond: rate,
+			Burst:         entry.Burst,
 		}
 	}
 	if len(rateLimits) == 0 {
-		rateLimits["lending"] = middleware.RateLimit{RequestsPerMinute: 120, Burst: 20}
-		rateLimits["swap"] = middleware.RateLimit{RequestsPerMinute: 60, Burst: 10}
-		rateLimits["gov"] = middleware.RateLimit{RequestsPerMinute: 60, Burst: 10}
-		rateLimits["consensus"] = middleware.RateLimit{RequestsPerMinute: 240, Burst: 40}
+		rateLimits["lending"] = middleware.RateLimit{RatePerSecond: 2, Burst: 20}
+		rateLimits["swap"] = middleware.RateLimit{RatePerSecond: 1, Burst: 10}
+		rateLimits["gov"] = middleware.RateLimit{RatePerSecond: 1, Burst: 10}
+		rateLimits["consensus"] = middleware.RateLimit{RatePerSecond: 4, Burst: 40}
 	}
 
 	router := routes.New(routes.Config{

--- a/gateway/config.yaml
+++ b/gateway/config.yaml
@@ -1,0 +1,22 @@
+listen: ":8080"
+rateLimits:
+  - id: lending
+    ratePerSecond: 2
+    burst: 20
+    paths:
+      - /v1/lending
+  - id: swap
+    ratePerSecond: 1
+    burst: 10
+    paths:
+      - /v1/swap
+  - id: gov
+    ratePerSecond: 1
+    burst: 10
+    paths:
+      - /v1/gov
+  - id: consensus
+    ratePerSecond: 4
+    burst: 40
+    paths:
+      - /v1/consensus

--- a/gateway/config/config.go
+++ b/gateway/config/config.go
@@ -19,6 +19,7 @@ type ServiceConfig struct {
 type RateLimitConfig struct {
 	ID                string   `yaml:"id"`
 	RequestsPerMinute float64  `yaml:"requestsPerMinute"`
+	RatePerSecond     float64  `yaml:"ratePerSecond"`
 	Burst             int      `yaml:"burst"`
 	Paths             []string `yaml:"paths"`
 }

--- a/gateway/middleware/ratelimit_test.go
+++ b/gateway/middleware/ratelimit_test.go
@@ -1,0 +1,92 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRateLimiterBlocksAfterBurst(t *testing.T) {
+	limiter := NewRateLimiter(map[string]RateLimit{
+		"lending": {RatePerSecond: 1, Burst: 1},
+	}, nil)
+
+	handler := limiter.Middleware("lending")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/lending/accounts", nil)
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected first request to succeed, got %d", res.Code)
+	}
+
+	res = httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected second request to be rate limited, got %d", res.Code)
+	}
+}
+
+func TestRateLimiterSeparatesRoutes(t *testing.T) {
+	limiter := NewRateLimiter(map[string]RateLimit{
+		"lending": {RatePerSecond: 1, Burst: 1},
+		"swap":    {RatePerSecond: 1, Burst: 1},
+	}, nil)
+
+	lendingHandler := limiter.Middleware("lending")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	swapHandler := limiter.Middleware("swap")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/lending/positions", nil)
+	req.Header.Set("X-API-Key", "tenant-A")
+	res := httptest.NewRecorder()
+	lendingHandler.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected lending request to succeed, got %d", res.Code)
+	}
+
+	swapReq := httptest.NewRequest(http.MethodGet, "/v1/swap/quotes", nil)
+	swapReq.Header.Set("X-API-Key", "tenant-A")
+	swapRes := httptest.NewRecorder()
+	swapHandler.ServeHTTP(swapRes, swapReq)
+	if swapRes.Code != http.StatusOK {
+		t.Fatalf("expected first swap request to succeed, got %d", swapRes.Code)
+	}
+
+	swapRes = httptest.NewRecorder()
+	swapHandler.ServeHTTP(swapRes, swapReq)
+	if swapRes.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected second swap request to hit limit, got %d", swapRes.Code)
+	}
+}
+
+func TestRateLimiterPrefersAPIKeyOverIP(t *testing.T) {
+	limiter := NewRateLimiter(map[string]RateLimit{
+		"lending": {RatePerSecond: 1, Burst: 1},
+	}, nil)
+
+	handler := limiter.Middleware("lending")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	reqA := httptest.NewRequest(http.MethodGet, "/v1/lending/positions", nil)
+	reqA.Header.Set("X-API-Key", "tenant-A")
+	resA := httptest.NewRecorder()
+	handler.ServeHTTP(resA, reqA)
+	if resA.Code != http.StatusOK {
+		t.Fatalf("expected tenant A request to succeed, got %d", resA.Code)
+	}
+
+	reqB := httptest.NewRequest(http.MethodGet, "/v1/lending/positions", nil)
+	reqB.Header.Set("X-API-Key", "tenant-B")
+	resB := httptest.NewRecorder()
+	handler.ServeHTTP(resB, reqB)
+	if resB.Code != http.StatusOK {
+		t.Fatalf("expected tenant B request to succeed, got %d", resB.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- enforce per-route token bucket rate limits using rate-per-second buckets keyed by API key or IP
- extend gateway config to accept ratePerSecond values and provide reference defaults
- add middleware unit tests that cover burst handling, per-route buckets, and API key isolation

## Testing
- go test ./gateway/middleware -run RateLimiter -count=1

------
https://chatgpt.com/codex/tasks/task_e_68d87aac9e9c832d854cb12c330dc71d