### PR TITLE
Add system tests for pause and quota invariants

### DIFF
--- a/tests/config/invariants_test.go
+++ b/tests/config/invariants_test.go
@@ -45,6 +45,91 @@ func TestValidateConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "voting period too small",
+			cfg: config.Global{
+				Governance: config.Governance{
+					QuorumBPS:        6000,
+					PassThresholdBPS: 5000,
+					VotingPeriodSecs: config.MinVotingPeriodSeconds - 1,
+				},
+				Slashing: config.Slashing{
+					MinWindowSecs: 1,
+					MaxWindowSecs: 10,
+				},
+				Mempool: config.Mempool{MaxBytes: 1},
+				Blocks:  config.Blocks{MaxTxs: 1},
+			},
+			wantErr: true,
+		},
+		{
+			name: "slashing min window zero",
+			cfg: config.Global{
+				Governance: config.Governance{
+					QuorumBPS:        6000,
+					PassThresholdBPS: 5000,
+					VotingPeriodSecs: config.MinVotingPeriodSeconds,
+				},
+				Slashing: config.Slashing{
+					MinWindowSecs: 0,
+					MaxWindowSecs: 10,
+				},
+				Mempool: config.Mempool{MaxBytes: 1},
+				Blocks:  config.Blocks{MaxTxs: 1},
+			},
+			wantErr: true,
+		},
+		{
+			name: "slashing min greater than max",
+			cfg: config.Global{
+				Governance: config.Governance{
+					QuorumBPS:        6000,
+					PassThresholdBPS: 5000,
+					VotingPeriodSecs: config.MinVotingPeriodSeconds,
+				},
+				Slashing: config.Slashing{
+					MinWindowSecs: 11,
+					MaxWindowSecs: 10,
+				},
+				Mempool: config.Mempool{MaxBytes: 1},
+				Blocks:  config.Blocks{MaxTxs: 1},
+			},
+			wantErr: true,
+		},
+		{
+			name: "mempool max bytes non-positive",
+			cfg: config.Global{
+				Governance: config.Governance{
+					QuorumBPS:        6000,
+					PassThresholdBPS: 5000,
+					VotingPeriodSecs: config.MinVotingPeriodSeconds,
+				},
+				Slashing: config.Slashing{
+					MinWindowSecs: 1,
+					MaxWindowSecs: 10,
+				},
+				Mempool: config.Mempool{MaxBytes: 0},
+				Blocks:  config.Blocks{MaxTxs: 1},
+			},
+			wantErr: true,
+		},
+		{
+			name: "blocks max txs non-positive",
+			cfg: config.Global{
+				Governance: config.Governance{
+					QuorumBPS:        6000,
+					PassThresholdBPS: 5000,
+					VotingPeriodSecs: config.MinVotingPeriodSeconds,
+				},
+				Slashing: config.Slashing{
+					MinWindowSecs: 1,
+					MaxWindowSecs: 10,
+				},
+				Mempool: config.Mempool{MaxBytes: 1},
+				Blocks:  config.Blocks{MaxTxs: 0},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/tests/system/pause_test.go
+++ b/tests/system/pause_test.go
@@ -1,0 +1,173 @@
+package system
+
+import (
+	"math/big"
+	"testing"
+
+	"nhbchain/core"
+	nhbstate "nhbchain/core/state"
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	nativecommon "nhbchain/native/common"
+	"nhbchain/native/lending"
+	"nhbchain/rpc/modules"
+	"nhbchain/storage"
+)
+
+func TestLendingSupplyFailsWhenPaused(t *testing.T) {
+	db := storage.NewMemDB()
+	t.Cleanup(db.Close)
+
+	validatorKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate validator key: %v", err)
+	}
+
+	node, err := core.NewNode(db, validatorKey, "", true)
+	if err != nil {
+		t.Fatalf("new node: %v", err)
+	}
+
+	node.SetLendingRiskParameters(lending.RiskParameters{MaxLTV: 7500, LiquidationThreshold: 8000, LiquidationBonus: 500, DeveloperFeeCapBps: 100})
+	node.SetLendingDeveloperFee(0, crypto.Address{})
+
+	userKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate user key: %v", err)
+	}
+	userAddr := userKey.PubKey().Address()
+
+	if err := seedPausedLendingState(node, userAddr); err != nil {
+		t.Fatalf("seed lending state: %v", err)
+	}
+
+	before := snapshotLendingState(t, node, userAddr)
+
+	node.SetModulePaused("lending", true)
+
+	module := modules.NewLendingModule(node)
+	var user [20]byte
+	copy(user[:], userAddr.Bytes())
+	amount := big.NewInt(100)
+
+	txHash, moduleErr := module.SupplyNHB("default", user, amount)
+	if moduleErr == nil {
+		t.Fatalf("expected error when module paused, got tx hash %q", txHash)
+	}
+	if moduleErr.Message != nativecommon.ErrModulePaused.Error() {
+		t.Fatalf("expected ErrModulePaused, got %v", moduleErr.Message)
+	}
+	if txHash != "" {
+		t.Fatalf("expected empty tx hash on failure, got %q", txHash)
+	}
+
+	after := snapshotLendingState(t, node, userAddr)
+	if after != before {
+		t.Fatalf("state mutated while paused\n before: %+v\n after:  %+v", before, after)
+	}
+}
+
+type lendingSnapshot struct {
+	userBalanceNHB     string
+	userBalanceZNHB    string
+	moduleBalanceNHB   string
+	collateralBalance  string
+	marketSupplied     string
+	marketSupplyShares string
+	marketBorrowed     string
+	userAccountExists  bool
+	userSupplyShares   string
+}
+
+func snapshotLendingState(t *testing.T, node *core.Node, addr crypto.Address) lendingSnapshot {
+	t.Helper()
+	var snap lendingSnapshot
+	err := node.WithState(func(manager *nhbstate.Manager) error {
+		account, err := manager.GetAccount(addr.Bytes())
+		if err != nil {
+			return err
+		}
+		snap.userBalanceNHB = account.BalanceNHB.String()
+		if account.BalanceZNHB != nil {
+			snap.userBalanceZNHB = account.BalanceZNHB.String()
+		}
+
+		moduleAccount, err := manager.GetAccount(node.LendingModuleAddress().Bytes())
+		if err != nil {
+			return err
+		}
+		snap.moduleBalanceNHB = moduleAccount.BalanceNHB.String()
+
+		collateralAccount, err := manager.GetAccount(node.LendingCollateralAddress().Bytes())
+		if err != nil {
+			return err
+		}
+		snap.collateralBalance = collateralAccount.BalanceZNHB.String()
+
+		market, ok, err := manager.LendingGetMarket("default")
+		if err != nil {
+			return err
+		}
+		if ok && market != nil {
+			if market.TotalNHBSupplied != nil {
+				snap.marketSupplied = market.TotalNHBSupplied.String()
+			}
+			if market.TotalSupplyShares != nil {
+				snap.marketSupplyShares = market.TotalSupplyShares.String()
+			}
+			if market.TotalNHBBorrowed != nil {
+				snap.marketBorrowed = market.TotalNHBBorrowed.String()
+			}
+		}
+
+		var userKey [20]byte
+		copy(userKey[:], addr.Bytes())
+		userAccount, exists, err := manager.LendingGetUserAccount("default", userKey)
+		if err != nil {
+			return err
+		}
+		snap.userAccountExists = exists
+		if exists && userAccount != nil && userAccount.SupplyShares != nil {
+			snap.userSupplyShares = userAccount.SupplyShares.String()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot lending state: %v", err)
+	}
+	return snap
+}
+
+func seedPausedLendingState(node *core.Node, userAddr crypto.Address) error {
+	return node.WithState(func(manager *nhbstate.Manager) error {
+		userAccount := &types.Account{BalanceNHB: big.NewInt(1000), BalanceZNHB: big.NewInt(0)}
+		if err := manager.PutAccount(userAddr.Bytes(), userAccount); err != nil {
+			return err
+		}
+
+		moduleAddr := node.LendingModuleAddress()
+		moduleAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0)}
+		if err := manager.PutAccount(moduleAddr.Bytes(), moduleAccount); err != nil {
+			return err
+		}
+
+		collateralAddr := node.LendingCollateralAddress()
+		collateralAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0)}
+		if err := manager.PutAccount(collateralAddr.Bytes(), collateralAccount); err != nil {
+			return err
+		}
+
+		market := &lending.Market{
+			PoolID:            "default",
+			DeveloperOwner:    userAddr,
+			DeveloperFeeBps:   0,
+			TotalNHBSupplied:  big.NewInt(0),
+			TotalSupplyShares: big.NewInt(0),
+			TotalNHBBorrowed:  big.NewInt(0),
+		}
+		if err := manager.LendingPutMarket("default", market); err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/tests/system/quota_test.go
+++ b/tests/system/quota_test.go
@@ -1,0 +1,104 @@
+package system
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"nhbchain/core"
+	nhbstate "nhbchain/core/state"
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	nativecommon "nhbchain/native/common"
+	"nhbchain/storage"
+	statetrie "nhbchain/storage/trie"
+)
+
+func TestQuotaRequestLimitResetsNextEpoch(t *testing.T) {
+	db := storage.NewMemDB()
+	t.Cleanup(db.Close)
+
+	trie, err := statetrie.NewTrie(db, nil)
+	if err != nil {
+		t.Fatalf("new trie: %v", err)
+	}
+
+	sp, err := core.NewStateProcessor(trie)
+	if err != nil {
+		t.Fatalf("state processor: %v", err)
+	}
+
+	sp.SetQuotaConfig(map[string]nativecommon.Quota{
+		"potso": {MaxRequestsPerMin: 2, EpochSeconds: 60},
+	})
+
+	priv, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	addr := priv.PubKey().Address()
+
+	manager := nhbstate.NewManager(sp.Trie)
+	account := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0)}
+	if err := manager.PutAccount(addr.Bytes(), account); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	start := time.Unix(1_700_000_000, 0).UTC()
+
+	sp.BeginBlock(1, start)
+
+	nextNonce := uint64(0)
+	makeTx := func(nonce uint64, payload types.HeartbeatPayload) *types.Transaction {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		tx := &types.Transaction{
+			ChainID:  types.NHBChainID(),
+			Type:     types.TxTypeHeartbeat,
+			Nonce:    nonce,
+			GasLimit: 1,
+			GasPrice: big.NewInt(0),
+			Data:     data,
+		}
+		if err := tx.Sign(priv.PrivateKey); err != nil {
+			t.Fatalf("sign tx: %v", err)
+		}
+		return tx
+	}
+
+	for i := 0; i < 2; i++ {
+		payload := types.HeartbeatPayload{DeviceID: "dev", Timestamp: start.Add(time.Duration(i+1) * time.Minute).Unix()}
+		tx := makeTx(nextNonce, payload)
+		if err := sp.ApplyTransaction(tx); err != nil {
+			t.Fatalf("heartbeat %d: %v", i+1, err)
+		}
+		nextNonce++
+	}
+
+	denyPayload := types.HeartbeatPayload{DeviceID: "dev", Timestamp: start.Add(3 * time.Minute).Unix()}
+	denyTx := makeTx(nextNonce, denyPayload)
+	if err := sp.ApplyTransaction(denyTx); err == nil || !errors.Is(err, nativecommon.ErrQuotaRequestsExceeded) {
+		t.Fatalf("expected quota error, got %v", err)
+	}
+
+	sp.EndBlock()
+	if err := sp.ProcessBlockLifecycle(1, start.Unix()); err != nil {
+		t.Fatalf("process block 1: %v", err)
+	}
+
+	sp.BeginBlock(2, start.Add(time.Minute))
+	allowPayload := types.HeartbeatPayload{DeviceID: "dev", Timestamp: start.Add(4 * time.Minute).Unix()}
+	allowTx := makeTx(nextNonce, allowPayload)
+	if err := sp.ApplyTransaction(allowTx); err != nil {
+		t.Fatalf("heartbeat after epoch rollover: %v", err)
+	}
+	nextNonce++
+	sp.EndBlock()
+	if err := sp.ProcessBlockLifecycle(2, start.Add(time.Minute).Unix()); err != nil {
+		t.Fatalf("process block 2: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- extend config validation tests to cover voting period, slashing window, mempool, and blocks invariants
- add system test verifying lending supply rejects when the module pause flag is set
- add system test ensuring quota counters block the N+1st request and reset after the epoch advances

## Testing
- go test ./...
- go test -coverpkg=nhbchain/config ./tests/config
- go test -race ./... *(fails: existing race in integrations/webhooks)*

------
https://chatgpt.com/codex/tasks/task_e_68d87cc1b8f0832d8147ee9f25bb2c5e