### PR TITLE
docs: add operator runbooks for pauses and quotas

### DIFF
--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -1,0 +1,96 @@
+# Runtime Configuration Guardrails
+
+Operations teams configure NHB consensus nodes through `config.toml` and the
+nested `[global.*]` runtime overrides. The binary performs a series of invariant
+checks before it opens the state database. Invalid settings terminate the boot
+sequence so you can correct the issue before a validator starts gossiping bad
+state.【F:config/validate.go†L9-L21】【F:cmd/consensusd/main.go†L65-L83】
+
+## Boot-time validation failures
+
+`consensusd` validates the governance, slashing, mempool, and block limit knobs
+before it touches the chain database:
+
+- **Governance:** quorum must be greater than or equal to the pass threshold and
+the voting period must be at least one hour.【F:config/validate.go†L9-L13】
+- **Slashing:** the minimum evaluation window must be non-zero and less than or
+  equal to the maximum window.【F:config/validate.go†L14-L16】
+- **Mempool:** the global byte cap must be positive.【F:config/validate.go†L17-L18】
+- **Blocks:** each block must allow at least one transaction.【F:config/validate.go†L19-L20】
+
+### Reproducing and fixing a validation error
+
+1. Copy the shipping config and append invalid overrides that violate the
+   invariants.
+
+   ```bash
+   cp config.toml /tmp/invalid-config.toml
+   cat <<'EOCFG' >> /tmp/invalid-config.toml
+   [global.governance]
+   QuorumBPS = 4000
+   PassThresholdBPS = 5000
+   VotingPeriodSecs = 1800
+
+   [global.slashing]
+   MinWindowSecs = 120
+   MaxWindowSecs = 60
+
+   [global.mempool]
+   MaxBytes = 0
+
+   [global.blocks]
+   MaxTxs = 0
+   EOCFG
+   ```
+
+2. Start `consensusd` with the broken file to see the boot failure. The process
+   aborts before opening the database and prints the first invariant violation.
+
+   ```bash
+   go run ./cmd/consensusd --config /tmp/invalid-config.toml --genesis ./config/genesis.json
+   ```
+
+   Example output:
+
+   ```
+   2024/04/03 12:00:00 invalid configuration err="governance: quorum_bps < pass_threshold_bps"
+   exit status 1
+   ```
+
+3. Repair the overrides and retry. The commands below restore the quorum,
+   voting-period, and resource limits before re-running the node.
+
+   ```bash
+   sed -i 's/QuorumBPS = 4000/QuorumBPS = 6000/' /tmp/invalid-config.toml
+   sed -i 's/VotingPeriodSecs = 1800/VotingPeriodSecs = 604800/' /tmp/invalid-config.toml
+   sed -i 's/MaxWindowSecs = 60/MaxWindowSecs = 600/' /tmp/invalid-config.toml
+   sed -i 's/MaxBytes = 0/MaxBytes = 33554432/' /tmp/invalid-config.toml
+   sed -i 's/MaxTxs = 0/MaxTxs = 5000/' /tmp/invalid-config.toml
+   go run ./cmd/consensusd --config /tmp/invalid-config.toml --genesis ./config/genesis.json
+   ```
+
+   When the invariants pass, the node continues initialisation and begins wiring
+   the consensus, governance, and swap modules.【F:cmd/consensusd/main.go†L83-L229】
+
+## Pauses, quotas, and emergency levers
+
+The runtime exposes a pair of safety nets that operators can use when a module
+misbehaves or traffic exceeds contracted levels:
+
+- **Module pauses (kill switches):** `config.Pauses` tracks per-module kill
+  switches for lending, swap, escrow, trade, loyalty, and POTSO. Setting a flag
+  to `true` pauses new state transitions for that module until governance
+  re-enables it.【F:config/types.go†L23-L39】【F:core/node.go†L328-L347】
+- **Per-address quotas:** `config.Quotas` defines the request and NHB spend
+  ceilings applied to each module. The consensus node loads the configured
+  values at boot and enforces them during transaction admission.【F:config/types.go†L41-L59】【F:cmd/consensusd/main.go†L220-L227】【F:core/state_transition.go†L186-L233】
+
+Module pauses are governed via the `gov.v1.Msg/SetPauses` RPC, so include the
+entire pause map when you submit a toggle to avoid unintentionally resuming a
+module that should stay halted.【F:services/governd/server/server.go†L158-L170】
+Per-address quota counters live in the parameter store and emit `QuotaExceeded`
+block events when a client breaches either ceiling.【F:native/system/quotas/store.go†L18-L74】【F:core/state_transition.go†L203-L233】
+
+See [Pause and quota runbook](../runbooks/pause-and-quotas.md) for operational
+recipes, including copy-paste commands that dump the live pause state, submit a
+pause transaction, inspect quota usage, and stage a safe cap increase.

--- a/docs/runbooks/pause-and-quotas.md
+++ b/docs/runbooks/pause-and-quotas.md
@@ -1,0 +1,91 @@
+# Pause and Quota Operations Runbook
+
+This runbook covers the operator-facing kill switches (`system/pauses`) and per
+address quotas enforced by the runtime. Use these procedures when you need to
+freeze a module, confirm that the kill switch landed, inspect live quota usage,
+or raise caps after coordinating with governance.
+
+## Inspect current pause state
+
+1. Query the live parameter store snapshot through the helper script. It loads
+the latest block root, decodes `system/pauses`, and prints the module map.【F:examples/docs/ops/read_pauses/main.go†L7-L42】
+
+   ```bash
+   go run ./examples/docs/ops/read_pauses \
+     --db ./nhb-data \
+     --consensus localhost:9090
+   ```
+
+2. Record the output in the incident channel so responders know which modules
+   are paused. When the store does not contain an override, all modules are
+   active.
+
+## Pause or resume a module
+
+1. Confirm the desired state using the previous step. `SetPauses` overwrites the
+   entire map, so starting from an up-to-date snapshot prevents accidental
+   unpauses.【F:services/governd/server/server.go†L158-L170】
+2. Submit the governance transaction through the helper CLI. It reads the
+   current map, toggles the selected module, and broadcasts
+   `gov.v1.MsgSetPauses` to `governd`. Capture the transaction hash in the
+   incident log.【F:examples/docs/ops/pause_toggle/main.go†L13-L97】
+
+   ```bash
+   go run ./examples/docs/ops/pause_toggle \
+     --db ./nhb-data \
+     --consensus localhost:9090 \
+     --governance localhost:50061 \
+     --authority nhb1operatorauthority0000000000000000000000 \
+     --module swap \
+     --state pause
+   ```
+
+3. Re-run the inspection command to verify the pause state propagated. To resume
+   a module replace `--state pause` with `--state resume`.
+
+## Inspect quota usage for an address
+
+1. Determine the module, target address, and quota epoch window. The helper
+   script normalises the module name, derives the current epoch from the block
+   timestamp, and loads the counters stored under `quotas/<module>/<epoch>/<addr>`.【F:examples/docs/ops/quota_dump/main.go†L7-L63】【F:native/system/quotas/store.go†L18-L74】
+
+   ```bash
+   go run ./examples/docs/ops/quota_dump \
+     --db ./nhb-data \
+     --consensus localhost:9090 \
+     --module swap \
+     --address nhb1customeraddress000000000000000000000 \
+     --epoch-seconds 3600
+   ```
+
+2. Share the `requests used` and `nhb used` figures with the requester. If the
+   script reports no counters, the address has not consumed quota in the current
+   epoch.
+
+## Raise module caps safely
+
+1. Stage a config overlay that increases the target module’s quota. The example
+   below raises the swap request ceiling to 30/min while keeping the NHB cap
+   disabled. Keep the overlay under version control alongside the change ticket.【F:config/types.go†L41-L59】【F:cmd/consensusd/main.go†L220-L227】
+
+   ```bash
+   cp config.toml /tmp/quotas-override.toml
+   cat <<'EOCFG' >> /tmp/quotas-override.toml
+   [global.quotas.swap]
+   MaxRequestsPerMin = 30
+   MaxNHBPerEpoch = 0
+   EpochSeconds = 60
+   EOCFG
+   ```
+
+2. Validate the override locally before deploying. `consensusd` will abort if
+   any invariants are violated. Use `Ctrl+C` once you see the “initialised and
+   running” banner.【F:cmd/consensusd/main.go†L220-L235】
+
+   ```bash
+   go run ./cmd/consensusd --config /tmp/quotas-override.toml --genesis ./config/genesis.json
+   ```
+
+3. Roll the change through staging, post the diff and test logs in the change
+   channel, and coordinate the production restart. After restart, re-run the
+   quota inspection command to confirm the new cap is in effect.

--- a/examples/docs/ops/internal/stateutil/stateutil.go
+++ b/examples/docs/ops/internal/stateutil/stateutil.go
@@ -1,0 +1,89 @@
+package stateutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	consclient "nhbchain/consensus/client"
+	"nhbchain/core/state"
+	"nhbchain/storage"
+	"nhbchain/storage/trie"
+)
+
+// Snapshot captures a read-only view of the latest application state along with
+// metadata describing the block it was sourced from.
+type Snapshot struct {
+	Manager   *state.Manager
+	Height    uint64
+	Timestamp time.Time
+
+	db     *storage.LevelDB
+	client *consclient.Client
+}
+
+// Load connects to the consensus gRPC endpoint, fetches the latest block, and
+// opens the application state trie from the provided data directory.
+func Load(ctx context.Context, dbPath, consensusEndpoint string) (*Snapshot, error) {
+	if dbPath == "" {
+		return nil, fmt.Errorf("data directory is required")
+	}
+	if consensusEndpoint == "" {
+		consensusEndpoint = "localhost:9090"
+	}
+
+	client, err := consclient.Dial(ctx, consensusEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("dial consensus: %w", err)
+	}
+
+	height, err := client.GetHeight(ctx)
+	if err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("get height: %w", err)
+	}
+	block, err := client.GetBlockByHeight(ctx, height)
+	if err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("get block %d: %w", height, err)
+	}
+	if block == nil || block.Header == nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("block %d missing header", height)
+	}
+
+	db, err := storage.NewLevelDB(dbPath)
+	if err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("open leveldb: %w", err)
+	}
+
+	trie, err := trie.NewTrie(db, block.Header.StateRoot)
+	if err != nil {
+		db.Close()
+		_ = client.Close()
+		return nil, fmt.Errorf("open state trie: %w", err)
+	}
+
+	snapshot := &Snapshot{
+		Manager:   state.NewManager(trie),
+		Height:    height,
+		Timestamp: time.Unix(block.Header.Timestamp, 0).UTC(),
+		db:        db,
+		client:    client,
+	}
+	return snapshot, nil
+}
+
+// Close releases the underlying consensus and database handles.
+func (s *Snapshot) Close() {
+	if s == nil {
+		return
+	}
+	if s.db != nil {
+		s.db.Close()
+	}
+	if s.client != nil {
+		_ = s.client.Close()
+	}
+}

--- a/examples/docs/ops/pause_toggle/main.go
+++ b/examples/docs/ops/pause_toggle/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"nhbchain/config"
+	"nhbchain/examples/docs/ops/internal/stateutil"
+	govv1 "nhbchain/proto/gov/v1"
+	govsdk "nhbchain/sdk/gov"
+)
+
+func main() {
+	dbPath := flag.String("db", "./nhb-data", "path to the consensus data directory")
+	consensusEndpoint := flag.String("consensus", "localhost:9090", "consensus gRPC endpoint")
+	govEndpoint := flag.String("governance", "localhost:50061", "governd gRPC endpoint")
+	authority := flag.String("authority", "", "governance authority address")
+	module := flag.String("module", "", "module to toggle (lending|swap|escrow|trade|loyalty|potso)")
+	state := flag.String("state", "pause", "target state: pause or resume")
+	flag.Parse()
+
+	if strings.TrimSpace(*authority) == "" {
+		log.Fatal("--authority is required")
+	}
+	if strings.TrimSpace(*module) == "" {
+		log.Fatal("--module is required")
+	}
+
+	desiredPause, err := parseState(*state)
+	if err != nil {
+		log.Fatalf("invalid state: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	snapshot, err := stateutil.Load(ctx, *dbPath, *consensusEndpoint)
+	cancel()
+	if err != nil {
+		log.Fatalf("load state snapshot: %v", err)
+	}
+	defer snapshot.Close()
+
+	pauses, err := currentPauses(snapshot.Manager)
+	if err != nil {
+		log.Fatalf("load pause configuration: %v", err)
+	}
+
+	if err := setModulePause(&pauses, *module, desiredPause); err != nil {
+		log.Fatal(err)
+	}
+
+	payload := &govv1.Pauses{
+		Lending: pauses.Lending,
+		Swap:    pauses.Swap,
+		Escrow:  pauses.Escrow,
+		Trade:   pauses.Trade,
+		Loyalty: pauses.Loyalty,
+		Potso:   pauses.POTSO,
+	}
+
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	client, err := govsdk.Dial(dialCtx, *govEndpoint)
+	dialCancel()
+	if err != nil {
+		log.Fatalf("dial governance service: %v", err)
+	}
+	defer client.Close()
+
+	sendCtx, sendCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer sendCancel()
+
+	msg, err := govsdk.NewMsgSetPauses(strings.TrimSpace(*authority), payload)
+	if err != nil {
+		log.Fatalf("build pause message: %v", err)
+	}
+
+	txHash, err := client.SetPauses(sendCtx, msg)
+	if err != nil {
+		log.Fatalf("broadcast pause transaction: %v", err)
+	}
+
+	fmt.Printf("updated %s pause=%t via tx %s\n", strings.ToLower(strings.TrimSpace(*module)), desiredPause, txHash)
+}
+
+func parseState(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "pause", "paused", "on":
+		return true, nil
+	case "resume", "unpause", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("unknown state %q", value)
+	}
+}
+
+func currentPauses(manager interface {
+	ParamStoreGet(name string) ([]byte, bool, error)
+}) (config.Pauses, error) {
+	var pauses config.Pauses
+	raw, ok, err := manager.ParamStoreGet("system/pauses")
+	if err != nil {
+		return pauses, err
+	}
+	if !ok || len(bytes.TrimSpace(raw)) == 0 {
+		return pauses, nil
+	}
+	if err := json.Unmarshal(raw, &pauses); err != nil {
+		return config.Pauses{}, fmt.Errorf("decode pause payload: %w", err)
+	}
+	return pauses, nil
+}
+
+func setModulePause(pauses *config.Pauses, module string, paused bool) error {
+	switch strings.ToLower(strings.TrimSpace(module)) {
+	case "lending":
+		pauses.Lending = paused
+	case "swap":
+		pauses.Swap = paused
+	case "escrow":
+		pauses.Escrow = paused
+	case "trade":
+		pauses.Trade = paused
+	case "loyalty":
+		pauses.Loyalty = paused
+	case "potso":
+		pauses.POTSO = paused
+	default:
+		return fmt.Errorf("unknown module %q", module)
+	}
+	return nil
+}

--- a/examples/docs/ops/quota_dump/main.go
+++ b/examples/docs/ops/quota_dump/main.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	"strings"
+	"time"
+
+	"nhbchain/crypto"
+	"nhbchain/examples/docs/ops/internal/stateutil"
+	nativecommon "nhbchain/native/common"
+	systemquotas "nhbchain/native/system/quotas"
+)
+
+func main() {
+	dbPath := flag.String("db", "./nhb-data", "path to the consensus data directory")
+	consensusEndpoint := flag.String("consensus", "localhost:9090", "consensus gRPC endpoint")
+	module := flag.String("module", "", "module name (lending|swap|escrow|trade|loyalty|potso)")
+	address := flag.String("address", "", "bech32 account address to inspect")
+	epoch := flag.Uint64("epoch", 0, "explicit quota epoch (defaults to current epoch)")
+	epochSeconds := flag.Uint64("epoch-seconds", 60, "epoch window size in seconds for the module")
+	flag.Parse()
+
+	if strings.TrimSpace(*module) == "" {
+		log.Fatal("--module is required")
+	}
+	if strings.TrimSpace(*address) == "" {
+		log.Fatal("--address is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	snapshot, err := stateutil.Load(ctx, *dbPath, *consensusEndpoint)
+	if err != nil {
+		log.Fatalf("load state snapshot: %v", err)
+	}
+	defer snapshot.Close()
+
+	seconds := *epochSeconds
+	if seconds == 0 {
+		seconds = 60
+	}
+
+	effectiveEpoch := *epoch
+	if effectiveEpoch == 0 {
+		unix := snapshot.Timestamp.Unix()
+		if unix < 0 {
+			unix = 0
+		}
+		effectiveEpoch = uint64(unix) / uint64(seconds)
+	}
+
+	acct, err := crypto.DecodeAddress(*address)
+	if err != nil {
+		log.Fatalf("decode address: %v", err)
+	}
+
+	store := systemquotas.NewStore(snapshot.Manager)
+	counters, ok, err := store.Load(*module, effectiveEpoch, acct.Bytes())
+	if err != nil {
+		log.Fatalf("load quota counters: %v", err)
+	}
+
+	normalized := strings.ToLower(strings.TrimSpace(*module))
+	fmt.Printf("quota snapshot at height %d (%s)\n", snapshot.Height, snapshot.Timestamp.Format(time.RFC3339))
+	fmt.Printf("module: %s\n", normalized)
+	fmt.Printf("epoch:  %d (window %d seconds)\n", effectiveEpoch, seconds)
+	fmt.Printf("address: %s\n", acct.String())
+
+	if !ok {
+		fmt.Println("no counters recorded for this address in the selected epoch")
+		return
+	}
+
+	fmt.Printf("requests used: %d\n", counters.ReqCount)
+	fmt.Printf("nhb used:      %d\n", counters.NHBUsed)
+
+	if counters.ReqCount == math.MaxUint32 {
+		fmt.Println("warning: request counter saturated (uint32 max)")
+	}
+	if counters.NHBUsed == math.MaxUint64 {
+		fmt.Println("warning: nhb counter saturated (uint64 max)")
+	}
+
+	fmt.Printf("raw counters: %+v\n", nativecommon.QuotaNow{ReqCount: counters.ReqCount, NHBUsed: counters.NHBUsed, EpochID: counters.EpochID})
+}

--- a/examples/docs/ops/read_pauses/main.go
+++ b/examples/docs/ops/read_pauses/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"nhbchain/config"
+	"nhbchain/examples/docs/ops/internal/stateutil"
+)
+
+func main() {
+	dbPath := flag.String("db", "./nhb-data", "path to the consensus data directory")
+	consensusEndpoint := flag.String("consensus", "localhost:9090", "consensus gRPC endpoint")
+	flag.Parse()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	snapshot, err := stateutil.Load(ctx, *dbPath, *consensusEndpoint)
+	if err != nil {
+		log.Fatalf("load state snapshot: %v", err)
+	}
+	defer snapshot.Close()
+
+	fmt.Printf("state height %d (%s)\n", snapshot.Height, snapshot.Timestamp.Format(time.RFC3339))
+
+	raw, ok, err := snapshot.Manager.ParamStoreGet("system/pauses")
+	if err != nil {
+		log.Fatalf("read pause configuration: %v", err)
+	}
+	if !ok || len(bytes.TrimSpace(raw)) == 0 {
+		fmt.Println("no pause overrides set (all modules active)")
+		return
+	}
+
+	var pauses config.Pauses
+	if err := json.Unmarshal(raw, &pauses); err != nil {
+		log.Fatalf("decode pause payload: %v", err)
+	}
+
+	fmt.Println("module pause status:")
+	fmt.Printf("- lending: %t\n", pauses.Lending)
+	fmt.Printf("- swap:    %t\n", pauses.Swap)
+	fmt.Printf("- escrow:  %t\n", pauses.Escrow)
+	fmt.Printf("- trade:   %t\n", pauses.Trade)
+	fmt.Printf("- loyalty: %t\n", pauses.Loyalty)
+	fmt.Printf("- potso:   %t\n", pauses.POTSO)
+}


### PR DESCRIPTION
## Summary
- add documentation for configuration invariants and operator guardrails
- provide a pause and quota runbook with copy-paste workflows
- add helper CLIs for inspecting and toggling pauses and quotas

## Testing
- go run ./tools/docs/verify.go > /tmp/docs.log

------
https://chatgpt.com/codex/tasks/task_e_68d881023b5c832d85aee2e701d88dcf