### PR TITLE
Add authentication for the consensusd↔p2pd gRPC bridge

### DIFF
--- a/config-local.toml
+++ b/config-local.toml
@@ -38,3 +38,12 @@ ReadTimeout = 90
 WriteTimeout = 5
 MaxMsgBytes = 1048576
 ClientVersion = "nhbchain/node"
+
+[network_security]
+# Leave the shared secret empty for single-host development. Set SharedSecret or
+# SharedSecretEnv when deploying consensusd and p2pd on separate machines.
+SharedSecret = ""
+# ServerTLSCertFile = "./tls/p2pd.crt"
+# ServerTLSKeyFile = "./tls/p2pd.key"
+# ClientTLSCertFile = "./tls/consensus.crt"
+# ClientTLSKeyFile = "./tls/consensus.key"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -45,6 +45,20 @@ RPCIdleTimeout = 45
 RPCTLSCertFile = "/path/to/cert.pem"
 RPCTLSKeyFile = "/path/to/key.pem"
 
+[network_security]
+SharedSecret = "topsecret"
+SharedSecretFile = "./secret.txt"
+SharedSecretEnv = "NHB_TEST_SECRET"
+AuthorizationHeader = "x-test-token"
+ServerTLSCertFile = "./tls/server.crt"
+ServerTLSKeyFile = "./tls/server.key"
+ServerCAFile = "./tls/ca.pem"
+ClientCAFile = "./tls/client-ca.pem"
+ClientTLSCertFile = "./tls/client.crt"
+ClientTLSKeyFile = "./tls/client.key"
+AllowedClientCommonNames = ["consensusd"]
+ServerName = "p2pd.internal"
+
 [p2p]
 NetworkId = 187001
 MaxPeers = 42
@@ -111,6 +125,36 @@ PEX = false
 	}
 	if cfg.RPCTLSCertFile != "/path/to/cert.pem" || cfg.RPCTLSKeyFile != "/path/to/key.pem" {
 		t.Fatalf("unexpected RPC TLS paths: %s %s", cfg.RPCTLSCertFile, cfg.RPCTLSKeyFile)
+	}
+	if header := cfg.NetworkSecurity.AuthorizationHeaderName(); header != "x-test-token" {
+		t.Fatalf("unexpected auth header: %s", header)
+	}
+	if cfg.NetworkSecurity.SharedSecret != "topsecret" {
+		t.Fatalf("unexpected inline shared secret: %s", cfg.NetworkSecurity.SharedSecret)
+	}
+	if cfg.NetworkSecurity.SharedSecretFile != "./secret.txt" {
+		t.Fatalf("unexpected shared secret file: %s", cfg.NetworkSecurity.SharedSecretFile)
+	}
+	if cfg.NetworkSecurity.SharedSecretEnv != "NHB_TEST_SECRET" {
+		t.Fatalf("unexpected shared secret env: %s", cfg.NetworkSecurity.SharedSecretEnv)
+	}
+	if cfg.NetworkSecurity.ServerTLSCertFile != "./tls/server.crt" || cfg.NetworkSecurity.ServerTLSKeyFile != "./tls/server.key" {
+		t.Fatalf("unexpected server tls paths: %+v", cfg.NetworkSecurity)
+	}
+	if cfg.NetworkSecurity.ServerCAFile != "./tls/ca.pem" {
+		t.Fatalf("unexpected server CA file: %s", cfg.NetworkSecurity.ServerCAFile)
+	}
+	if cfg.NetworkSecurity.ClientCAFile != "./tls/client-ca.pem" {
+		t.Fatalf("unexpected client CA file: %s", cfg.NetworkSecurity.ClientCAFile)
+	}
+	if cfg.NetworkSecurity.ClientTLSCertFile != "./tls/client.crt" || cfg.NetworkSecurity.ClientTLSKeyFile != "./tls/client.key" {
+		t.Fatalf("unexpected client tls paths: %+v", cfg.NetworkSecurity)
+	}
+	if cfg.NetworkSecurity.ServerName != "p2pd.internal" {
+		t.Fatalf("unexpected server name: %s", cfg.NetworkSecurity.ServerName)
+	}
+	if len(cfg.NetworkSecurity.AllowedClientCommonNames) != 1 || cfg.NetworkSecurity.AllowedClientCommonNames[0] != "consensusd" {
+		t.Fatalf("unexpected allowed common names: %v", cfg.NetworkSecurity.AllowedClientCommonNames)
 	}
 	if len(cfg.Bootnodes) != 1 || cfg.Bootnodes[0] != "1.1.1.1:6001" {
 		t.Fatalf("bootnodes not parsed: %v", cfg.Bootnodes)

--- a/network/auth.go
+++ b/network/auth.go
@@ -1,0 +1,120 @@
+package network
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// Authenticator evaluates the incoming RPC context and returns an error when the
+// request should be rejected.
+type Authenticator interface {
+	Authorize(ctx context.Context) error
+}
+
+type authenticatorFunc func(context.Context) error
+
+func (f authenticatorFunc) Authorize(ctx context.Context) error {
+	if f == nil {
+		return nil
+	}
+	return f(ctx)
+}
+
+// ChainAuthenticators combines multiple authenticators, short-circuiting on the
+// first failure. When no authenticators are supplied the returned instance
+// always authorizes the request.
+func ChainAuthenticators(auths ...Authenticator) Authenticator {
+	filtered := make([]Authenticator, 0, len(auths))
+	for _, auth := range auths {
+		if auth != nil {
+			filtered = append(filtered, auth)
+		}
+	}
+	if len(filtered) == 0 {
+		return authenticatorFunc(func(context.Context) error { return nil })
+	}
+	return authenticatorFunc(func(ctx context.Context) error {
+		for _, auth := range filtered {
+			if err := auth.Authorize(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// NewTokenAuthenticator validates that the supplied metadata header carries the
+// configured shared secret. Bearer tokens ("Bearer <token>") are accepted as a
+// convenience for deployments that piggyback on HTTP-style headers.
+func NewTokenAuthenticator(header, secret string) Authenticator {
+	cleanedHeader := strings.ToLower(strings.TrimSpace(header))
+	if cleanedHeader == "" {
+		cleanedHeader = "authorization"
+	}
+	trimmedSecret := strings.TrimSpace(secret)
+	if trimmedSecret == "" {
+		return nil
+	}
+	return authenticatorFunc(func(ctx context.Context) error {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return status.Error(codes.Unauthenticated, "network: missing metadata")
+		}
+		values := md.Get(cleanedHeader)
+		for _, value := range values {
+			token := strings.TrimSpace(value)
+			if token == trimmedSecret {
+				return nil
+			}
+			if strings.HasPrefix(strings.ToLower(token), "bearer ") {
+				if strings.TrimSpace(token[len("bearer "):]) == trimmedSecret {
+					return nil
+				}
+			}
+		}
+		return status.Error(codes.Unauthenticated, "network: invalid or missing shared secret")
+	})
+}
+
+// NewTLSAuthorizer ensures the peer negotiated TLS and, when a non-empty allow
+// list is provided, that at least one presented client certificate matches the
+// configured common names.
+func NewTLSAuthorizer(allowed []string) Authenticator {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, cn := range allowed {
+		trimmed := strings.TrimSpace(cn)
+		if trimmed == "" {
+			continue
+		}
+		allowedSet[strings.ToLower(trimmed)] = struct{}{}
+	}
+	return authenticatorFunc(func(ctx context.Context) error {
+		p, ok := peer.FromContext(ctx)
+		if !ok {
+			return status.Error(codes.Unauthenticated, "network: missing peer info")
+		}
+		info, ok := p.AuthInfo.(credentials.TLSInfo)
+		if !ok {
+			return status.Error(codes.Unauthenticated, "network: connection is not using TLS")
+		}
+		if len(info.State.PeerCertificates) == 0 {
+			return status.Error(codes.Unauthenticated, "network: no client certificate presented")
+		}
+		if len(allowedSet) == 0 {
+			return nil
+		}
+		for _, cert := range info.State.PeerCertificates {
+			cn := strings.ToLower(strings.TrimSpace(cert.Subject.CommonName))
+			if _, ok := allowedSet[cn]; ok {
+				return nil
+			}
+		}
+		return status.Error(codes.PermissionDenied, "network: client certificate not authorised")
+	})
+}

--- a/network/credentials.go
+++ b/network/credentials.go
@@ -1,0 +1,37 @@
+package network
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc/credentials"
+)
+
+type staticTokenCredentials struct {
+	header string
+	token  string
+}
+
+// NewStaticTokenCredentials returns a grpc.PerRPCCredentials implementation
+// that injects the configured shared-secret header on every request.
+func NewStaticTokenCredentials(header, token string) credentials.PerRPCCredentials {
+	normalizedHeader := strings.ToLower(strings.TrimSpace(header))
+	if normalizedHeader == "" {
+		normalizedHeader = "authorization"
+	}
+	return staticTokenCredentials{
+		header: normalizedHeader,
+		token:  strings.TrimSpace(token),
+	}
+}
+
+func (c staticTokenCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	if c.token == "" {
+		return map[string]string{}, nil
+	}
+	return map[string]string{c.header: c.token}, nil
+}
+
+func (c staticTokenCredentials) RequireTransportSecurity() bool {
+	return false
+}

--- a/tests/system/network_security_test.go
+++ b/tests/system/network_security_test.go
@@ -1,0 +1,98 @@
+package system
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	"nhbchain/network"
+	networkv1 "nhbchain/proto/network/v1"
+)
+
+func TestNetworkServiceSharedSecretAuth(t *testing.T) {
+	relay := network.NewRelay()
+	secret := "shared-secret"
+	header := "x-nhb-network-token"
+
+	server := grpc.NewServer(grpc.Creds(insecure.NewCredentials()))
+	networkv1.RegisterNetworkServiceServer(server, network.NewService(relay, network.NewTokenAuthenticator(header, secret)))
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() {
+		server.Stop()
+		_ = lis.Close()
+	})
+
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	addr := lis.Addr().String()
+
+	// Unauthenticated gossip stream should fail.
+	unauthCtx, cancelUnauth := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancelUnauth)
+	unauthClient, err := network.Dial(unauthCtx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial unauth: %v", err)
+	}
+	if err := unauthClient.Run(unauthCtx, nil, nil); status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected unauthenticated stream error, got %v", err)
+	}
+	_ = unauthClient.Close()
+
+	// Unauthenticated unary calls should also be rejected.
+	conn, err := grpc.DialContext(unauthCtx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial unauth conn: %v", err)
+	}
+	_, err = networkv1.NewNetworkServiceClient(conn).DialPeer(unauthCtx, &networkv1.DialPeerRequest{Target: "example"})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected unauthenticated dial, got %v", err)
+	}
+	_ = conn.Close()
+
+	// Authenticated stream should remain connected until the context is cancelled.
+	authCtx, cancelAuth := context.WithCancel(context.Background())
+	defer cancelAuth()
+	authClient, err := network.Dial(authCtx, addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(network.NewStaticTokenCredentials(header, secret)),
+	)
+	if err != nil {
+		t.Fatalf("dial auth: %v", err)
+	}
+	streamDone := make(chan error, 1)
+	go func() {
+		streamDone <- authClient.Run(authCtx, nil, nil)
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancelAuth()
+	if err := <-streamDone; err != nil && status.Code(err) != codes.Canceled {
+		t.Fatalf("expected stream cancellation, got %v", err)
+	}
+	_ = authClient.Close()
+
+	// Authenticated unary calls should reach the service (even if the relay has no backing server).
+	authConn, err := grpc.DialContext(context.Background(), addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(network.NewStaticTokenCredentials(header, secret)),
+	)
+	if err != nil {
+		t.Fatalf("dial auth conn: %v", err)
+	}
+	defer authConn.Close()
+	_, err = networkv1.NewNetworkServiceClient(authConn).BanPeer(context.Background(), &networkv1.BanPeerRequest{NodeId: "peer"})
+	if status.Code(err) == codes.Unauthenticated {
+		t.Fatalf("authenticated request should not be rejected: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- extend p2pd to load TLS or shared-secret settings, default the network RPC listener to 127.0.0.1, and pass the resulting credentials into grpc.Creds
- add token and mTLS authenticators to network.Service and require authorization for Gossip, DialPeer, and BanPeer requests
- update consensusd to reuse the new network_security config when dialing p2pd and document the new options alongside an integration test that proves unauthenticated calls fail while authenticated traffic succeeds

## Testing
- go test ./config -run TestLoadParsesP2PSettings -v
- go test ./tests/system -run TestNetworkServiceSharedSecretAuth -v

------
https://chatgpt.com/codex/tasks/task_e_68d88709d39c832da223af23decfac22