### PR TITLE
Harden creator share accounting and anti-griefing

### DIFF
--- a/core/state/manager.go
+++ b/core/state/manager.go
@@ -3295,6 +3295,7 @@ type storedCreatorContent struct {
 	Creator     [20]byte
 	URI         string
 	Metadata    string
+	Hash        string
 	PublishedAt int64
 	TotalTips   *big.Int
 	TotalStake  *big.Int
@@ -3309,6 +3310,7 @@ func newStoredCreatorContent(content *creator.Content) *storedCreatorContent {
 		Creator:     content.Creator,
 		URI:         strings.TrimSpace(content.URI),
 		Metadata:    strings.TrimSpace(content.Metadata),
+		Hash:        strings.TrimSpace(content.Hash),
 		PublishedAt: content.PublishedAt,
 		TotalTips:   big.NewInt(0),
 		TotalStake:  big.NewInt(0),
@@ -3331,6 +3333,7 @@ func (s *storedCreatorContent) toContent() *creator.Content {
 		Creator:     s.Creator,
 		URI:         strings.TrimSpace(s.URI),
 		Metadata:    strings.TrimSpace(s.Metadata),
+		Hash:        strings.TrimSpace(s.Hash),
 		PublishedAt: s.PublishedAt,
 		TotalTips:   big.NewInt(0),
 		TotalStake:  big.NewInt(0),
@@ -3401,6 +3404,9 @@ type storedCreatorLedger struct {
 	TotalStakingYield   *big.Int
 	PendingDistribution *big.Int
 	LastPayout          int64
+	TotalAssets         *big.Int
+	TotalShares         *big.Int
+	IndexRay            *big.Int
 }
 
 func newStoredCreatorLedger(ledger *creator.PayoutLedger) *storedCreatorLedger {
@@ -3413,6 +3419,9 @@ func newStoredCreatorLedger(ledger *creator.PayoutLedger) *storedCreatorLedger {
 		TotalStakingYield:   big.NewInt(0),
 		PendingDistribution: big.NewInt(0),
 		LastPayout:          ledger.LastPayout,
+		TotalAssets:         big.NewInt(0),
+		TotalShares:         big.NewInt(0),
+		IndexRay:            big.NewInt(0),
 	}
 	if ledger.TotalTips != nil {
 		stored.TotalTips = new(big.Int).Set(ledger.TotalTips)
@@ -3422,6 +3431,15 @@ func newStoredCreatorLedger(ledger *creator.PayoutLedger) *storedCreatorLedger {
 	}
 	if ledger.PendingDistribution != nil {
 		stored.PendingDistribution = new(big.Int).Set(ledger.PendingDistribution)
+	}
+	if ledger.TotalAssets != nil {
+		stored.TotalAssets = new(big.Int).Set(ledger.TotalAssets)
+	}
+	if ledger.TotalShares != nil {
+		stored.TotalShares = new(big.Int).Set(ledger.TotalShares)
+	}
+	if ledger.IndexRay != nil {
+		stored.IndexRay = new(big.Int).Set(ledger.IndexRay)
 	}
 	return stored
 }
@@ -3436,6 +3454,9 @@ func (s *storedCreatorLedger) toLedger() *creator.PayoutLedger {
 		TotalStakingYield:   big.NewInt(0),
 		PendingDistribution: big.NewInt(0),
 		LastPayout:          s.LastPayout,
+		TotalAssets:         big.NewInt(0),
+		TotalShares:         big.NewInt(0),
+		IndexRay:            big.NewInt(0),
 	}
 	if s.TotalTips != nil {
 		ledger.TotalTips = new(big.Int).Set(s.TotalTips)
@@ -3445,6 +3466,15 @@ func (s *storedCreatorLedger) toLedger() *creator.PayoutLedger {
 	}
 	if s.PendingDistribution != nil {
 		ledger.PendingDistribution = new(big.Int).Set(s.PendingDistribution)
+	}
+	if s.TotalAssets != nil {
+		ledger.TotalAssets = new(big.Int).Set(s.TotalAssets)
+	}
+	if s.TotalShares != nil {
+		ledger.TotalShares = new(big.Int).Set(s.TotalShares)
+	}
+	if s.IndexRay != nil {
+		ledger.IndexRay = new(big.Int).Set(s.IndexRay)
 	}
 	return ledger
 }

--- a/docs/creator/economics.md
+++ b/docs/creator/economics.md
@@ -1,0 +1,55 @@
+# Creator Economy Share Accounting
+
+The creator engine mints proportional staking shares using an ERC4626-style
+index. The engine tracks three aggregate values per creator:
+
+* **`totalAssets`** – the amount of NHB staked behind the creator.
+* **`totalShares`** – the outstanding fan shares, including any bootstrap
+  liquidity held by the protocol.
+* **`indexRay`** – a high-precision (1e27) price index equal to
+  `totalAssets * 1e27 / totalShares`.
+
+## Minting
+
+When a fan stakes `deposit` NHB the engine calculates the number of shares to
+mint as:
+
+```
+mintShares = floor(deposit * totalShares / totalAssets)
+```
+
+If this is the first deposit (`totalShares == 0`) the engine performs a
+bootstrap by minting `MIN_LIQUIDITY` shares to the zero address and allocating
+`deposit - MIN_LIQUIDITY` shares to the fan. The current constants are
+`MIN_LIQUIDITY = 1` share and `MIN_DEPOSIT = 1_000` NHB. Deposits smaller than
+`MIN_DEPOSIT` are rejected, and any deposit that would round down to zero shares
+is rejected with `deposit too small for share precision`.
+
+After minting, the ledger updates `totalAssets`, `totalShares`, and recomputes
+`indexRay`.
+
+## Redemption
+
+Unstaking burns a share amount and returns assets according to:
+
+```
+redeemAssets = floor(shares * totalAssets / totalShares)
+```
+
+If the redemption would drain the pool the residual assets (including the
+bootstrap share) are returned to the redeemer and the ledger resets its
+aggregates to zero.
+
+The engine enforces that a fan cannot withdraw more than their pro-rata share of
+assets. Property tests cover dilution scenarios to ensure no actor can exit with
+more than their proportional stake.
+
+## Metadata and Anti-Grief Controls
+
+* Content URIs must use an allow-listed scheme (`https`, `ipfs`, `ar`, or `nhb`),
+  be UTF-8, and not exceed length limits. Metadata is trimmed, validated as
+  UTF-8, and hashed with BLAKE3 (stored on the content record).
+* Staking per fan is capped per epoch (`1h`) by `fanStakeEpochCap`.
+* Tips per creator are rate limited using a fixed 1-second window and
+  `tipRateBurst` allowance.
+* Zero-value stakes or tips are rejected early to prevent spam.

--- a/native/creator/math.go
+++ b/native/creator/math.go
@@ -1,0 +1,67 @@
+package creator
+
+import "math/big"
+
+var (
+	oneRay       = new(big.Int).Exp(big.NewInt(10), big.NewInt(27), nil)
+	minLiquidity = big.NewInt(1)
+	minDeposit   = big.NewInt(1_000)
+)
+
+func calculateMintShares(deposit, totalShares, totalAssets *big.Int) (userShares, bootstrapShares *big.Int, err error) {
+	if deposit == nil || deposit.Sign() <= 0 {
+		return nil, nil, errInvalidAmount
+	}
+	if totalShares == nil || totalShares.Sign() == 0 || totalAssets == nil || totalAssets.Sign() == 0 {
+		if deposit.Cmp(minDeposit) < 0 {
+			return nil, nil, errDepositTooSmall
+		}
+		if deposit.Cmp(minLiquidity) <= 0 {
+			return nil, nil, errDepositTooSmall
+		}
+		minted := new(big.Int).Sub(deposit, minLiquidity)
+		return minted, new(big.Int).Set(minLiquidity), nil
+	}
+	minted := new(big.Int).Mul(deposit, totalShares)
+	minted = minted.Div(minted, totalAssets)
+	if minted.Sign() == 0 {
+		if deposit.Cmp(minDeposit) < 0 {
+			return nil, nil, errDepositTooSmall
+		}
+		return nil, nil, errZeroShareMint
+	}
+	return minted, nil, nil
+}
+
+func calculateRedeemAssets(shares, totalShares, totalAssets *big.Int) (*big.Int, error) {
+	if shares == nil || shares.Sign() <= 0 {
+		return nil, errInvalidAmount
+	}
+	if totalShares == nil || totalShares.Sign() == 0 {
+		return nil, errSharesDepleted
+	}
+	if totalAssets == nil || totalAssets.Sign() == 0 {
+		return big.NewInt(0), nil
+	}
+	if shares.Cmp(totalShares) > 0 {
+		return nil, errInsufficientShares
+	}
+	assets := new(big.Int).Mul(shares, totalAssets)
+	assets = assets.Div(assets, totalShares)
+	if assets.Sign() == 0 {
+		return nil, errRedeemTooSmall
+	}
+	return assets, nil
+}
+
+func computeIndex(totalAssets, totalShares *big.Int) *big.Int {
+	if totalShares == nil || totalShares.Sign() == 0 {
+		return new(big.Int).Set(oneRay)
+	}
+	if totalAssets == nil || totalAssets.Sign() == 0 {
+		return big.NewInt(0)
+	}
+	index := new(big.Int).Mul(totalAssets, oneRay)
+	index = index.Div(index, totalShares)
+	return index
+}

--- a/native/creator/types.go
+++ b/native/creator/types.go
@@ -8,6 +8,7 @@ type Content struct {
 	Creator     [20]byte `json:"creator"`
 	URI         string   `json:"uri"`
 	Metadata    string   `json:"metadata"`
+	Hash        string   `json:"hash"`
 	PublishedAt int64    `json:"publishedAt"`
 	TotalTips   *big.Int `json:"totalTips"`
 	TotalStake  *big.Int `json:"totalStake"`
@@ -39,6 +40,9 @@ type PayoutLedger struct {
 	TotalStakingYield   *big.Int `json:"totalStakingYield"`
 	PendingDistribution *big.Int `json:"pendingDistribution"`
 	LastPayout          int64    `json:"lastPayout"`
+	TotalAssets         *big.Int `json:"totalAssets"`
+	TotalShares         *big.Int `json:"totalShares"`
+	IndexRay            *big.Int `json:"indexRay"`
 }
 
 // Clone returns a deep copy of the payout ledger.
@@ -55,6 +59,15 @@ func (p *PayoutLedger) Clone() *PayoutLedger {
 	}
 	if p.PendingDistribution != nil {
 		clone.PendingDistribution = new(big.Int).Set(p.PendingDistribution)
+	}
+	if p.TotalAssets != nil {
+		clone.TotalAssets = new(big.Int).Set(p.TotalAssets)
+	}
+	if p.TotalShares != nil {
+		clone.TotalShares = new(big.Int).Set(p.TotalShares)
+	}
+	if p.IndexRay != nil {
+		clone.IndexRay = new(big.Int).Set(p.IndexRay)
 	}
 	return &clone
 }

--- a/tests/creator/griefing_test.go
+++ b/tests/creator/griefing_test.go
@@ -1,0 +1,97 @@
+package creator_test
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strings"
+	"testing"
+
+	"lukechampine.com/blake3"
+	"nhbchain/native/creator"
+)
+
+func TestStakeCapPerEpoch(t *testing.T) {
+	state := newTestState()
+	engine := creator.NewEngine()
+	engine.SetState(state)
+	payoutVault := addr(0xC1)
+	rewards := addr(0xC2)
+	engine.SetPayoutVault(payoutVault)
+	engine.SetRewardsTreasury(rewards)
+	state.setAccountBig(addr(0x10), big.NewInt(2_000_000_000_000))
+	state.setAccount(payoutVault, 0)
+	state.setAccount(rewards, 0)
+
+	fan := addr(0x10)
+	creatorAddr := addr(0x11)
+	engine.SetNowFunc(func() int64 { return 1000 })
+
+	cap := big.NewInt(1_000_000_000_000)
+	nearCap := new(big.Int).Sub(cap, big.NewInt(5_000))
+	if _, _, err := engine.StakeCreator(fan, creatorAddr, nearCap); err != nil {
+		t.Fatalf("expected first stake within cap, got %v", err)
+	}
+	exceed := big.NewInt(10_000)
+	if _, _, err := engine.StakeCreator(fan, creatorAddr, exceed); err == nil || !strings.Contains(err.Error(), "per-epoch stake cap exceeded") {
+		t.Fatalf("expected stake cap error, got %v", err)
+	}
+}
+
+func TestTipRateLimitBlocksBurst(t *testing.T) {
+	state := newTestState()
+	engine := creator.NewEngine()
+	engine.SetState(state)
+	payoutVault := addr(0xD1)
+	rewards := addr(0xD2)
+	engine.SetPayoutVault(payoutVault)
+	engine.SetRewardsTreasury(rewards)
+	state.setAccount(payoutVault, 0)
+	state.setAccount(rewards, 0)
+
+	creatorAddr := addr(0x20)
+	fan := addr(0x21)
+	state.setAccount(fan, 10_000)
+
+	current := int64(5000)
+	engine.SetNowFunc(func() int64 { return current })
+
+	content, err := engine.PublishContent(creatorAddr, "tip-test", "https://example.com/video", "hello world")
+	if err != nil {
+		t.Fatalf("publish failed: %v", err)
+	}
+	amount := big.NewInt(100)
+	for i := 0; i < 5; i++ {
+		if _, err := engine.TipContent(fan, content.ID, amount); err != nil {
+			t.Fatalf("tip %d failed: %v", i, err)
+		}
+	}
+	if _, err := engine.TipContent(fan, content.ID, amount); err == nil || !strings.Contains(err.Error(), "tip rate limit exceeded") {
+		t.Fatalf("expected tip rate limit, got %v", err)
+	}
+}
+
+func TestPublishContentValidationAndHash(t *testing.T) {
+	state := newTestState()
+	engine := creator.NewEngine()
+	engine.SetState(state)
+
+	creatorAddr := addr(0x30)
+
+	if _, err := engine.PublishContent(creatorAddr, "invalid", "ftp://example.com", "bad"); err == nil {
+		t.Fatalf("expected invalid URI error")
+	}
+	badMetadata := string([]byte{0xff, 0xfe})
+	if _, err := engine.PublishContent(creatorAddr, "invalid-meta", "https://example.com", badMetadata); err == nil {
+		t.Fatalf("expected invalid metadata error")
+	}
+
+	content, err := engine.PublishContent(creatorAddr, "valid", "https://example.com/resource", "lorem ipsum")
+	if err != nil {
+		t.Fatalf("publish valid failed: %v", err)
+	}
+	expected := blake3.Sum256([]byte("lorem ipsum"))
+	expectedHex := hex.EncodeToString(expected[:])
+	if !strings.EqualFold(content.Hash, expectedHex) {
+		t.Fatalf("unexpected content hash: got %s want %s", content.Hash, expectedHex)
+	}
+}

--- a/tests/creator/shares_test.go
+++ b/tests/creator/shares_test.go
@@ -1,0 +1,83 @@
+package creator_test
+
+import (
+	"math/big"
+	"testing"
+
+	"nhbchain/native/creator"
+)
+
+func TestStakeRejectsTinyDeposit(t *testing.T) {
+	state := newTestState()
+	engine := creator.NewEngine()
+	engine.SetState(state)
+	vault := addr(0xAA)
+	rewards := addr(0xBB)
+	engine.SetPayoutVault(vault)
+	engine.SetRewardsTreasury(rewards)
+	state.setAccount(vault, 0)
+	state.setAccount(rewards, 0)
+
+	fan := addr(0x01)
+	creatorAddr := addr(0x02)
+	state.setAccount(fan, 10_000)
+
+	if _, _, err := engine.StakeCreator(fan, creatorAddr, big.NewInt(1)); err == nil {
+		t.Fatalf("expected minimum deposit error")
+	}
+}
+
+func FuzzShareRedemptionProRata(f *testing.F) {
+	f.Add(int64(5_000), int64(7_500))
+	f.Add(int64(20_000), int64(15_000))
+	f.Fuzz(func(t *testing.T, a int64, b int64) {
+		depositA := big.NewInt(1_000 + absInt64(a)%90_000)
+		depositB := big.NewInt(1_000 + absInt64(b)%90_000)
+
+		state := newTestState()
+		engine := creator.NewEngine()
+		engine.SetState(state)
+		payoutVault := addr(0xA1)
+		rewards := addr(0xB1)
+		engine.SetPayoutVault(payoutVault)
+		engine.SetRewardsTreasury(rewards)
+
+		fanA := addr(0x11)
+		fanB := addr(0x12)
+		creatorAddr := addr(0x20)
+
+		state.setAccountBig(fanA, big.NewInt(500_000_000))
+		state.setAccountBig(fanB, big.NewInt(500_000_000))
+		state.setAccount(payoutVault, 0)
+		state.setAccount(rewards, 0)
+
+		stakeA, _, err := engine.StakeCreator(fanA, creatorAddr, depositA)
+		if err != nil {
+			t.Fatalf("stake A failed: %v", err)
+		}
+		if stakeA.Shares.Sign() == 0 {
+			t.Fatalf("expected shares for stake A")
+		}
+		if _, _, err := engine.StakeCreator(fanB, creatorAddr, depositB); err != nil {
+			t.Fatalf("stake B failed: %v", err)
+		}
+
+		balanceBefore := state.account(fanA).BalanceNHB
+		redeemed := new(big.Int).Set(stakeA.Shares)
+		if _, err := engine.UnstakeCreator(fanA, creatorAddr, redeemed); err != nil {
+			t.Fatalf("unstake A failed: %v", err)
+		}
+		balanceAfter := state.account(fanA).BalanceNHB
+		withdrawn := new(big.Int).Sub(balanceAfter, balanceBefore)
+		if withdrawn.Cmp(depositA) > 0 {
+			t.Fatalf("fan A withdrew more than deposit: got %s want <= %s", withdrawn, depositA)
+		}
+	})
+}
+
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/tests/creator/state_test.go
+++ b/tests/creator/state_test.go
@@ -1,0 +1,173 @@
+package creator_test
+
+import (
+	"math/big"
+
+	"nhbchain/core/types"
+	"nhbchain/native/creator"
+)
+
+type testState struct {
+	contents map[string]*creator.Content
+	stakes   map[string]*creator.Stake
+	ledgers  map[string]*creator.PayoutLedger
+	accounts map[string]*types.Account
+}
+
+func newTestState() *testState {
+	return &testState{
+		contents: make(map[string]*creator.Content),
+		stakes:   make(map[string]*creator.Stake),
+		ledgers:  make(map[string]*creator.PayoutLedger),
+		accounts: make(map[string]*types.Account),
+	}
+}
+
+func (s *testState) CreatorContentGet(id string) (*creator.Content, bool, error) {
+	if content, ok := s.contents[id]; ok {
+		clone := *content
+		clone.Hash = content.Hash
+		if content.TotalTips != nil {
+			clone.TotalTips = new(big.Int).Set(content.TotalTips)
+		}
+		if content.TotalStake != nil {
+			clone.TotalStake = new(big.Int).Set(content.TotalStake)
+		}
+		return &clone, true, nil
+	}
+	return nil, false, nil
+}
+
+func (s *testState) CreatorContentPut(content *creator.Content) error {
+	if content == nil {
+		return nil
+	}
+	clone := *content
+	clone.Hash = content.Hash
+	if content.TotalTips != nil {
+		clone.TotalTips = new(big.Int).Set(content.TotalTips)
+	}
+	if content.TotalStake != nil {
+		clone.TotalStake = new(big.Int).Set(content.TotalStake)
+	}
+	s.contents[content.ID] = &clone
+	return nil
+}
+
+func stakeKey(creatorAddr [20]byte, fan [20]byte) string {
+	key := make([]byte, 0, 40)
+	key = append(key, creatorAddr[:]...)
+	key = append(key, fan[:]...)
+	return string(key)
+}
+
+func (s *testState) CreatorStakeGet(creatorAddr [20]byte, fan [20]byte) (*creator.Stake, bool, error) {
+	if stake, ok := s.stakes[stakeKey(creatorAddr, fan)]; ok {
+		clone := *stake
+		if stake.Amount != nil {
+			clone.Amount = new(big.Int).Set(stake.Amount)
+		}
+		if stake.Shares != nil {
+			clone.Shares = new(big.Int).Set(stake.Shares)
+		}
+		return &clone, true, nil
+	}
+	return nil, false, nil
+}
+
+func (s *testState) CreatorStakePut(stake *creator.Stake) error {
+	if stake == nil {
+		return nil
+	}
+	clone := *stake
+	if stake.Amount != nil {
+		clone.Amount = new(big.Int).Set(stake.Amount)
+	}
+	if stake.Shares != nil {
+		clone.Shares = new(big.Int).Set(stake.Shares)
+	}
+	s.stakes[stakeKey(stake.Creator, stake.Fan)] = &clone
+	return nil
+}
+
+func (s *testState) CreatorStakeDelete(creatorAddr [20]byte, fan [20]byte) error {
+	delete(s.stakes, stakeKey(creatorAddr, fan))
+	return nil
+}
+
+func (s *testState) CreatorPayoutLedgerGet(creatorAddr [20]byte) (*creator.PayoutLedger, bool, error) {
+	if ledger, ok := s.ledgers[string(creatorAddr[:])]; ok {
+		return ledger.Clone(), true, nil
+	}
+	return nil, false, nil
+}
+
+func (s *testState) CreatorPayoutLedgerPut(ledger *creator.PayoutLedger) error {
+	if ledger == nil {
+		return nil
+	}
+	s.ledgers[string(ledger.Creator[:])] = ledger.Clone()
+	return nil
+}
+
+func (s *testState) GetAccount(addr []byte) (*types.Account, error) {
+	if acc, ok := s.accounts[string(addr)]; ok {
+		return cloneAccount(acc), nil
+	}
+	return nil, nil
+}
+
+func (s *testState) PutAccount(addr []byte, account *types.Account) error {
+	if account == nil {
+		delete(s.accounts, string(addr))
+		return nil
+	}
+	s.accounts[string(addr)] = cloneAccount(account)
+	return nil
+}
+
+func (s *testState) setAccount(addr [20]byte, amount int64) {
+	s.accounts[string(addr[:])] = &types.Account{
+		BalanceNHB:  big.NewInt(amount),
+		BalanceZNHB: big.NewInt(0),
+		Stake:       big.NewInt(0),
+	}
+}
+
+func (s *testState) setAccountBig(addr [20]byte, amount *big.Int) {
+	s.accounts[string(addr[:])] = &types.Account{
+		BalanceNHB:  new(big.Int).Set(amount),
+		BalanceZNHB: big.NewInt(0),
+		Stake:       big.NewInt(0),
+	}
+}
+
+func (s *testState) account(addr [20]byte) *types.Account {
+	if acc, ok := s.accounts[string(addr[:])]; ok {
+		return cloneAccount(acc)
+	}
+	return &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}
+}
+
+func cloneAccount(acc *types.Account) *types.Account {
+	if acc == nil {
+		return nil
+	}
+	clone := *acc
+	if acc.BalanceNHB != nil {
+		clone.BalanceNHB = new(big.Int).Set(acc.BalanceNHB)
+	}
+	if acc.BalanceZNHB != nil {
+		clone.BalanceZNHB = new(big.Int).Set(acc.BalanceZNHB)
+	}
+	if acc.Stake != nil {
+		clone.Stake = new(big.Int).Set(acc.Stake)
+	}
+	return &clone
+}
+
+func addr(last byte) [20]byte {
+	var out [20]byte
+	out[19] = last
+	return out
+}


### PR DESCRIPTION
## Summary
- implement proportional ERC4626-style share minting and redemption with running index tracking
- validate creator content metadata, store BLAKE3 hashes, and enforce staking/tipping rate limits
- document the new economics model and add fuzz/property tests covering share math and anti-griefing flows

## Testing
- go test ./native/creator ./tests/creator

------
https://chatgpt.com/codex/tasks/task_e_68d88e2223b8832dbcb0f8b41b664f79