### PR TITLE
harden: enforce governance invariants

### DIFF
--- a/cmd/consensusd/main.go
+++ b/cmd/consensusd/main.go
@@ -127,6 +127,7 @@ func main() {
 		panic(fmt.Sprintf("Failed to create node: %v", err))
 	}
 
+	node.SetGlobalConfig(cfg.Global)
 	node.SetMempoolLimit(cfg.Mempool.MaxTransactions)
 
 	govPolicy, err := cfg.Governance.Policy()

--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -89,6 +89,7 @@ func main() {
 		panic(fmt.Sprintf("Failed to create node: %v", err))
 	}
 
+	node.SetGlobalConfig(cfg.Global)
 	node.SetMempoolLimit(cfg.Mempool.MaxTransactions)
 
 	govPolicy, err := cfg.Governance.Policy()

--- a/docs/gov/policy-invariants.md
+++ b/docs/gov/policy-invariants.md
@@ -1,0 +1,45 @@
+# Governance Policy Invariants
+
+The runtime enforces a set of invariants before accepting governance policy
+updates. These bounds guarantee that proposals cannot install values that would
+halt core services or render future upgrades impossible.
+
+## Quorum and Approval Thresholds
+
+* **Quorum** must always be greater than or equal to the approval threshold.
+  Proposals that drop quorum below the approval threshold are rejected during
+  preflight, preventing a configuration where no outcome can ever pass.
+* **Approval threshold** is clamped to non-trivial values (`>= 5,000` basis
+  points). The client and chain both reject payloads that fall outside this
+  range.
+
+## Voting Periods
+
+The minimum voting period is defined in software (default `3,600` seconds). Any
+attempt to shorten the period below this floor is rejected. The same checks are
+run by the client preflight helpers and the chain when applying a proposal.
+
+## Slashing Windows
+
+Slashing policy proposals must keep the evaluation window bounded within the
+runtime limits. The minimum window must be greater than zero and may not exceed
+its configured maximum. Evidence TTL values must also remain within their
+published limits to avoid unbounded liability.
+
+## Treasury Directives
+
+Treasury directives require at least one transfer and the source vault must be
+present on the allow list before execution. This prevents empty directives and
+ensures proposals cannot route funds from unauthorised vaults.
+
+## Dual Enforcement
+
+All invariants are checked twice:
+
+1. **Client preflight:** payloads are simulated against the current runtime
+   configuration before the transaction is broadcast.
+2. **Chain execution:** the same simulation runs when the proposal is queued or
+   executed. Any violation aborts the proposal and the change is not applied.
+
+This dual enforcement ensures misconfigured payloads are rejected before they
+can brick the network, even if a client bypasses the service-side checks.

--- a/tests/gov/invariants_test.go
+++ b/tests/gov/invariants_test.go
@@ -1,0 +1,79 @@
+package gov_test
+
+import (
+	"errors"
+	"testing"
+
+	"nhbchain/config"
+	govcfg "nhbchain/native/gov"
+)
+
+func testBaseline() govcfg.Baseline {
+	return govcfg.Baseline{
+		Governance: govcfg.GovernanceBaseline{
+			QuorumBPS:        6000,
+			PassThresholdBPS: 5000,
+			VotingPeriodSecs: config.MinVotingPeriodSeconds,
+		},
+		Slashing: govcfg.SlashingBaseline{
+			MinWindowSecs: 60,
+			MaxWindowSecs: 600,
+		},
+		Mempool: govcfg.MempoolBaseline{MaxBytes: 1},
+		Blocks:  govcfg.BlocksBaseline{MaxTxs: 1},
+	}
+}
+
+func TestPreflightBaselineApplyRejectsInvalidPolicies(t *testing.T) {
+	baseline := testBaseline()
+
+	invalidQuorum := govcfg.PolicyDelta{Governance: &govcfg.GovernanceDelta{QuorumBPS: uint32Ptr(4000)}}
+	if err := govcfg.PreflightBaselineApply(baseline, invalidQuorum); !errors.Is(err, govcfg.ErrInvalidPolicyInvariants) {
+		t.Fatalf("expected quorum invariant error, got %v", err)
+	}
+
+	zeroPeriod := uint64(0)
+	invalidPeriod := govcfg.PolicyDelta{Governance: &govcfg.GovernanceDelta{VotingPeriodSecs: &zeroPeriod}}
+	if err := govcfg.PreflightBaselineApply(baseline, invalidPeriod); !errors.Is(err, govcfg.ErrInvalidPolicyInvariants) {
+		t.Fatalf("expected voting period invariant error, got %v", err)
+	}
+
+	zeroWindow := uint64(0)
+	invalidWindow := govcfg.PolicyDelta{Slashing: &govcfg.SlashingDelta{MinWindowSecs: &zeroWindow}}
+	if err := govcfg.PreflightBaselineApply(baseline, invalidWindow); !errors.Is(err, govcfg.ErrInvalidPolicyInvariants) {
+		t.Fatalf("expected slashing min invariant error, got %v", err)
+	}
+
+	minWindow := uint64(700)
+	invalidRange := govcfg.PolicyDelta{Slashing: &govcfg.SlashingDelta{MinWindowSecs: &minWindow}}
+	maxWindow := uint64(650)
+	invalidRange.Slashing.MaxWindowSecs = &maxWindow
+	if err := govcfg.PreflightBaselineApply(baseline, invalidRange); !errors.Is(err, govcfg.ErrInvalidPolicyInvariants) {
+		t.Fatalf("expected slashing range invariant error, got %v", err)
+	}
+}
+
+func TestPreflightBaselineApplyAllowsValidPolicy(t *testing.T) {
+	baseline := testBaseline()
+	quorum := uint32(6500)
+	threshold := uint32(5200)
+	voting := config.MinVotingPeriodSeconds + 3600
+	minWindow := uint64(120)
+	maxWindow := uint64(3600)
+	delta := govcfg.PolicyDelta{
+		Governance: &govcfg.GovernanceDelta{
+			QuorumBPS:        &quorum,
+			PassThresholdBPS: &threshold,
+			VotingPeriodSecs: &voting,
+		},
+		Slashing: &govcfg.SlashingDelta{
+			MinWindowSecs: &minWindow,
+			MaxWindowSecs: &maxWindow,
+		},
+	}
+	if err := govcfg.PreflightBaselineApply(baseline, delta); err != nil {
+		t.Fatalf("expected valid policy delta, got %v", err)
+	}
+}
+
+func uint32Ptr(v uint32) *uint32 { return &v }


### PR DESCRIPTION
## Summary
- retain the validated global configuration on the node and feed it into governance policy preflight checks
- document the policy invariants enforced by governance preflight
- add regression tests covering quorum, voting period, and slashing window invariants

## Testing
- `go test ./native/gov -run TestPreflight -count=1 -v`
- `go test ./tests/gov -v`


------
https://chatgpt.com/codex/tasks/task_e_68d89c0dc220832db6d31669cd504bcb