### PR TITLE
HARDEN-5: enforce paymaster reserves and caps

### DIFF
--- a/core/events/loyalty.go
+++ b/core/events/loyalty.go
@@ -35,16 +35,20 @@ func (LoyaltyProgramCreated) EventType() string { return TypeLoyaltyProgramCreat
 // LoyaltyProgramUpdated captures the mutable configuration of an existing
 // loyalty program after an update operation.
 type LoyaltyProgramUpdated struct {
-	ID           [32]byte
-	Active       bool
-	AccrualBps   uint32
-	MinSpendWei  *big.Int
-	CapPerTx     *big.Int
-	DailyCapUser *big.Int
-	StartTime    uint64
-	EndTime      uint64
-	Pool         [20]byte
-	TokenSymbol  string
+	ID                 [32]byte
+	Active             bool
+	AccrualBps         uint32
+	MinSpendWei        *big.Int
+	CapPerTx           *big.Int
+	DailyCapUser       *big.Int
+	DailyCapProgram    *big.Int
+	EpochCapProgram    *big.Int
+	EpochLengthSeconds uint64
+	IssuanceCapUser    *big.Int
+	StartTime          uint64
+	EndTime            uint64
+	Pool               [20]byte
+	TokenSymbol        string
 }
 
 // EventType implements the Event interface.

--- a/core/state/manager.go
+++ b/core/state/manager.go
@@ -47,67 +47,70 @@ type TokenMetadata struct {
 }
 
 var (
-	tokenPrefix                = []byte("token:")
-	tokenListKey               = ethcrypto.Keccak256([]byte("token-list"))
-	balancePrefix              = []byte("balance:")
-	rolePrefix                 = []byte("role:")
-	loyaltyGlobalKeyBytes      = ethcrypto.Keccak256([]byte("loyalty:global"))
-	loyaltyDailyPrefix         = []byte("loyalty-meter:base-daily:")
-	loyaltyTotalPrefix         = []byte("loyalty-meter:base-total:")
-	loyaltyProgramDailyPrefix  = []byte("loyalty-meter:program-daily:")
-	loyaltyBusinessPrefix      = []byte("loyalty/business/")
-	loyaltyBusinessOwnerPrefix = []byte("loyalty/business-owner/")
-	loyaltyMerchantIndexPrefix = []byte("loyalty/merchant-index/")
-	loyaltyBusinessCounterKey  = []byte("loyalty/business/counter")
-	loyaltyOwnerPaymasterPref  = []byte("loyalty/owner-paymaster/")
-	escrowRecordPrefix         = []byte("escrow/record/")
-	escrowVaultPrefix          = []byte("escrow/vault/")
-	escrowModuleSeedPrefix     = "module/escrow/vault/"
-	escrowRealmPrefix          = []byte("escrow/realm/")
-	escrowFrozenPolicyPrefix   = []byte("escrow/frozen/")
-	creatorContentPrefix       = []byte("creator/content/")
-	creatorStakePrefix         = []byte("creator/stake/")
-	creatorLedgerPrefix        = []byte("creator/ledger/")
-	claimableRecordPrefix      = []byte("claimable/record/")
-	claimableNoncePrefix       = []byte("claimable/nonce/")
-	tradeRecordPrefix          = []byte("trade/record/")
-	tradeEscrowIndexPrefix     = []byte("trade/index/escrow/")
-	identityAliasPrefix        = []byte("identity/alias/")
-	identityReversePrefix      = []byte("identity/reverse/")
-	mintInvoicePrefix          = []byte("mint/invoice/")
-	swapOrderPrefix            = []byte("swap/order/")
-	potsoHeartbeatPrefix       = []byte("potso/heartbeat/")
-	potsoMeterPrefix           = []byte("potso/meter/")
-	potsoDayIndexPrefix        = []byte("potso/day-index/")
-	potsoStakeTotalPrefix      = []byte("potso/stake/")
-	potsoStakeNoncePrefix      = []byte("potso/stake/nonce/")
-	potsoStakeLocksPrefix      = []byte("potso/stake/locks/")
-	potsoStakeLockIndexPrefix  = []byte("potso/stake/locks/index/")
-	potsoStakeQueuePrefix      = []byte("potso/stake/unbondq/")
-	potsoStakeModuleSeedPrefix = "module/potso/stake/vault"
-	potsoStakeOwnerIndexKey    = []byte("potso/stake/owners")
-	potsoRewardLastProcessed   = []byte("potso/rewards/lastProcessed")
-	potsoRewardMetaKeyFormat   = "potso/rewards/epoch/%d/meta"
-	potsoRewardWinnersFormat   = "potso/rewards/epoch/%d/winners"
-	potsoRewardPayoutFormat    = "potso/rewards/epoch/%d/payout/%x"
-	potsoRewardClaimFormat     = "potso/rewards/epoch/%d/claim/%x"
-	potsoRewardHistoryFormat   = "potso/rewards/history/%x"
-	potsoMetricsMeterPrefix    = []byte("potso/metrics/meter/")
-	potsoMetricsIndexPrefix    = []byte("potso/metrics/index/")
-	potsoMetricsSnapshotPrefix = []byte("potso/metrics/snapshot/")
-	governanceProposalPrefix   = []byte("gov/proposals/")
-	governanceVotePrefix       = []byte("gov/votes/")
-	governanceVoteIndexPrefix  = []byte("gov/vote-index/")
-	governanceSequenceKey      = []byte("gov/seq")
-	governanceAuditPrefix      = []byte("gov/audit/")
-	governanceAuditSequenceKey = []byte("gov/audit-seq")
-	governanceEscrowPrefix     = []byte("gov/escrow/")
-	paramsNamespacePrefix      = []byte("params/")
-	snapshotPotsoPrefix        = []byte("snapshots/potso/")
-	lendingMarketPrefix        = []byte("lending/market/")
-	lendingFeeAccrualPrefix    = []byte("lending/fees/")
-	lendingUserPrefix          = []byte("lending/user/")
-	lendingPoolIndexKey        = []byte("lending/pools/index")
+	tokenPrefix                    = []byte("token:")
+	tokenListKey                   = ethcrypto.Keccak256([]byte("token-list"))
+	balancePrefix                  = []byte("balance:")
+	rolePrefix                     = []byte("role:")
+	loyaltyGlobalKeyBytes          = ethcrypto.Keccak256([]byte("loyalty:global"))
+	loyaltyDailyPrefix             = []byte("loyalty-meter:base-daily:")
+	loyaltyTotalPrefix             = []byte("loyalty-meter:base-total:")
+	loyaltyProgramDailyPrefix      = []byte("loyalty-meter:program-daily:")
+	loyaltyProgramDailyTotalPrefix = []byte("loyalty-meter:program-daily-total:")
+	loyaltyProgramEpochPrefix      = []byte("loyalty-meter:program-epoch:")
+	loyaltyProgramIssuancePrefix   = []byte("loyalty-meter:program-issuance:")
+	loyaltyBusinessPrefix          = []byte("loyalty/business/")
+	loyaltyBusinessOwnerPrefix     = []byte("loyalty/business-owner/")
+	loyaltyMerchantIndexPrefix     = []byte("loyalty/merchant-index/")
+	loyaltyBusinessCounterKey      = []byte("loyalty/business/counter")
+	loyaltyOwnerPaymasterPref      = []byte("loyalty/owner-paymaster/")
+	escrowRecordPrefix             = []byte("escrow/record/")
+	escrowVaultPrefix              = []byte("escrow/vault/")
+	escrowModuleSeedPrefix         = "module/escrow/vault/"
+	escrowRealmPrefix              = []byte("escrow/realm/")
+	escrowFrozenPolicyPrefix       = []byte("escrow/frozen/")
+	creatorContentPrefix           = []byte("creator/content/")
+	creatorStakePrefix             = []byte("creator/stake/")
+	creatorLedgerPrefix            = []byte("creator/ledger/")
+	claimableRecordPrefix          = []byte("claimable/record/")
+	claimableNoncePrefix           = []byte("claimable/nonce/")
+	tradeRecordPrefix              = []byte("trade/record/")
+	tradeEscrowIndexPrefix         = []byte("trade/index/escrow/")
+	identityAliasPrefix            = []byte("identity/alias/")
+	identityReversePrefix          = []byte("identity/reverse/")
+	mintInvoicePrefix              = []byte("mint/invoice/")
+	swapOrderPrefix                = []byte("swap/order/")
+	potsoHeartbeatPrefix           = []byte("potso/heartbeat/")
+	potsoMeterPrefix               = []byte("potso/meter/")
+	potsoDayIndexPrefix            = []byte("potso/day-index/")
+	potsoStakeTotalPrefix          = []byte("potso/stake/")
+	potsoStakeNoncePrefix          = []byte("potso/stake/nonce/")
+	potsoStakeLocksPrefix          = []byte("potso/stake/locks/")
+	potsoStakeLockIndexPrefix      = []byte("potso/stake/locks/index/")
+	potsoStakeQueuePrefix          = []byte("potso/stake/unbondq/")
+	potsoStakeModuleSeedPrefix     = "module/potso/stake/vault"
+	potsoStakeOwnerIndexKey        = []byte("potso/stake/owners")
+	potsoRewardLastProcessed       = []byte("potso/rewards/lastProcessed")
+	potsoRewardMetaKeyFormat       = "potso/rewards/epoch/%d/meta"
+	potsoRewardWinnersFormat       = "potso/rewards/epoch/%d/winners"
+	potsoRewardPayoutFormat        = "potso/rewards/epoch/%d/payout/%x"
+	potsoRewardClaimFormat         = "potso/rewards/epoch/%d/claim/%x"
+	potsoRewardHistoryFormat       = "potso/rewards/history/%x"
+	potsoMetricsMeterPrefix        = []byte("potso/metrics/meter/")
+	potsoMetricsIndexPrefix        = []byte("potso/metrics/index/")
+	potsoMetricsSnapshotPrefix     = []byte("potso/metrics/snapshot/")
+	governanceProposalPrefix       = []byte("gov/proposals/")
+	governanceVotePrefix           = []byte("gov/votes/")
+	governanceVoteIndexPrefix      = []byte("gov/vote-index/")
+	governanceSequenceKey          = []byte("gov/seq")
+	governanceAuditPrefix          = []byte("gov/audit/")
+	governanceAuditSequenceKey     = []byte("gov/audit-seq")
+	governanceEscrowPrefix         = []byte("gov/escrow/")
+	paramsNamespacePrefix          = []byte("params/")
+	snapshotPotsoPrefix            = []byte("snapshots/potso/")
+	lendingMarketPrefix            = []byte("lending/market/")
+	lendingFeeAccrualPrefix        = []byte("lending/fees/")
+	lendingUserPrefix              = []byte("lending/user/")
+	lendingPoolIndexKey            = []byte("lending/pools/index")
 )
 
 // GovernanceProposalKey constructs the storage key for the proposal metadata
@@ -692,6 +695,35 @@ func LoyaltyProgramDailyMeterKey(id loyalty.ProgramID, addr []byte, day string) 
 	copy(buf[len(loyaltyProgramDailyPrefix)+len(id)+1:], trimmed)
 	buf[len(loyaltyProgramDailyPrefix)+len(id)+1+len(trimmed)] = ':'
 	copy(buf[len(loyaltyProgramDailyPrefix)+len(id)+1+len(trimmed)+1:], addr)
+	return ethcrypto.Keccak256(buf)
+}
+
+func LoyaltyProgramDailyTotalKey(id loyalty.ProgramID, day string) []byte {
+	trimmed := strings.TrimSpace(day)
+	buf := make([]byte, len(loyaltyProgramDailyTotalPrefix)+len(id)+1+len(trimmed))
+	copy(buf, loyaltyProgramDailyTotalPrefix)
+	copy(buf[len(loyaltyProgramDailyTotalPrefix):], id[:])
+	buf[len(loyaltyProgramDailyTotalPrefix)+len(id)] = ':'
+	copy(buf[len(loyaltyProgramDailyTotalPrefix)+len(id)+1:], trimmed)
+	return ethcrypto.Keccak256(buf)
+}
+
+func LoyaltyProgramEpochKey(id loyalty.ProgramID, epoch uint64) []byte {
+	epochStr := strconv.FormatUint(epoch, 10)
+	buf := make([]byte, len(loyaltyProgramEpochPrefix)+len(id)+1+len(epochStr))
+	copy(buf, loyaltyProgramEpochPrefix)
+	copy(buf[len(loyaltyProgramEpochPrefix):], id[:])
+	buf[len(loyaltyProgramEpochPrefix)+len(id)] = ':'
+	copy(buf[len(loyaltyProgramEpochPrefix)+len(id)+1:], epochStr)
+	return ethcrypto.Keccak256(buf)
+}
+
+func LoyaltyProgramIssuanceKey(id loyalty.ProgramID, addr []byte) []byte {
+	buf := make([]byte, len(loyaltyProgramIssuancePrefix)+len(id)+1+len(addr))
+	copy(buf, loyaltyProgramIssuancePrefix)
+	copy(buf[len(loyaltyProgramIssuancePrefix):], id[:])
+	buf[len(loyaltyProgramIssuancePrefix)+len(id)] = ':'
+	copy(buf[len(loyaltyProgramIssuancePrefix)+len(id)+1:], addr)
 	return ethcrypto.Keccak256(buf)
 }
 
@@ -2345,21 +2377,21 @@ func (s *storedEscrow) toEscrow() (*escrow.Escrow, error) {
 }
 
 type storedTrade struct {
-        ID          [32]byte
-        OfferID     string
-        Buyer       [20]byte
-        Seller      [20]byte
-        QuoteToken  string
-        QuoteAmount *big.Int
-        EscrowQuote [32]byte
-        BaseToken   string
-        BaseAmount  *big.Int
-        EscrowBase  [32]byte
-        Deadline    *big.Int
-        CreatedAt   *big.Int
-        FundedAt    *big.Int
-        SlippageBps uint32
-        Status      uint8
+	ID          [32]byte
+	OfferID     string
+	Buyer       [20]byte
+	Seller      [20]byte
+	QuoteToken  string
+	QuoteAmount *big.Int
+	EscrowQuote [32]byte
+	BaseToken   string
+	BaseAmount  *big.Int
+	EscrowBase  [32]byte
+	Deadline    *big.Int
+	CreatedAt   *big.Int
+	FundedAt    *big.Int
+	SlippageBps uint32
+	Status      uint8
 }
 
 func newStoredTrade(t *escrow.Trade) *storedTrade {
@@ -2374,39 +2406,39 @@ func newStoredTrade(t *escrow.Trade) *storedTrade {
 	if t.BaseAmount != nil {
 		base = new(big.Int).Set(t.BaseAmount)
 	}
-        return &storedTrade{
-                ID:          t.ID,
-                OfferID:     t.OfferID,
-                Buyer:       t.Buyer,
-                Seller:      t.Seller,
-                QuoteToken:  t.QuoteToken,
-                QuoteAmount: quote,
-                EscrowQuote: t.EscrowQuote,
-                BaseToken:   t.BaseToken,
-                BaseAmount:  base,
-                EscrowBase:  t.EscrowBase,
-                Deadline:    big.NewInt(t.Deadline),
-                CreatedAt:   big.NewInt(t.CreatedAt),
-                FundedAt: func() *big.Int {
-                        if t.FundedAt == 0 {
-                                return nil
-                        }
-                        return big.NewInt(t.FundedAt)
-                }(),
-                SlippageBps: t.SlippageBps,
-                Status:      uint8(t.Status),
-        }
+	return &storedTrade{
+		ID:          t.ID,
+		OfferID:     t.OfferID,
+		Buyer:       t.Buyer,
+		Seller:      t.Seller,
+		QuoteToken:  t.QuoteToken,
+		QuoteAmount: quote,
+		EscrowQuote: t.EscrowQuote,
+		BaseToken:   t.BaseToken,
+		BaseAmount:  base,
+		EscrowBase:  t.EscrowBase,
+		Deadline:    big.NewInt(t.Deadline),
+		CreatedAt:   big.NewInt(t.CreatedAt),
+		FundedAt: func() *big.Int {
+			if t.FundedAt == 0 {
+				return nil
+			}
+			return big.NewInt(t.FundedAt)
+		}(),
+		SlippageBps: t.SlippageBps,
+		Status:      uint8(t.Status),
+	}
 }
 
 func (s *storedTrade) toTrade() (*escrow.Trade, error) {
 	if s == nil {
 		return nil, fmt.Errorf("trade: nil storage record")
 	}
-        out := &escrow.Trade{
-                ID:         s.ID,
-                OfferID:    s.OfferID,
-                Buyer:      s.Buyer,
-                Seller:     s.Seller,
+	out := &escrow.Trade{
+		ID:         s.ID,
+		OfferID:    s.OfferID,
+		Buyer:      s.Buyer,
+		Seller:     s.Seller,
 		QuoteToken: s.QuoteToken,
 		QuoteAmount: func() *big.Int {
 			if s.QuoteAmount == nil {
@@ -2422,19 +2454,19 @@ func (s *storedTrade) toTrade() (*escrow.Trade, error) {
 			}
 			return new(big.Int).Set(s.BaseAmount)
 		}(),
-                EscrowBase: s.EscrowBase,
-                SlippageBps: s.SlippageBps,
-                Status:     escrow.TradeStatus(s.Status),
-        }
-        if s.Deadline != nil {
-                out.Deadline = s.Deadline.Int64()
-        }
-        if s.CreatedAt != nil {
-                out.CreatedAt = s.CreatedAt.Int64()
-        }
-        if s.FundedAt != nil {
-                out.FundedAt = s.FundedAt.Int64()
-        }
+		EscrowBase:  s.EscrowBase,
+		SlippageBps: s.SlippageBps,
+		Status:      escrow.TradeStatus(s.Status),
+	}
+	if s.Deadline != nil {
+		out.Deadline = s.Deadline.Int64()
+	}
+	if s.CreatedAt != nil {
+		out.CreatedAt = s.CreatedAt.Int64()
+	}
+	if s.FundedAt != nil {
+		out.FundedAt = s.FundedAt.Int64()
+	}
 	if !out.Status.Valid() {
 		return nil, fmt.Errorf("trade: invalid status in storage")
 	}
@@ -2706,6 +2738,48 @@ func (m *Manager) LoyaltyProgramDailyAccrued(id loyalty.ProgramID, addr []byte, 
 	return m.loadBigInt(LoyaltyProgramDailyMeterKey(id, addr, day))
 }
 
+// SetLoyaltyProgramDailyTotalAccrued stores the accrued rewards for the provided program and day across all users.
+func (m *Manager) SetLoyaltyProgramDailyTotalAccrued(id loyalty.ProgramID, day string, amount *big.Int) error {
+	if strings.TrimSpace(day) == "" {
+		return fmt.Errorf("day must not be empty")
+	}
+	return m.writeBigInt(LoyaltyProgramDailyTotalKey(id, day), amount)
+}
+
+// LoyaltyProgramDailyTotalAccrued returns the daily accrued rewards for the provided program across all users.
+func (m *Manager) LoyaltyProgramDailyTotalAccrued(id loyalty.ProgramID, day string) (*big.Int, error) {
+	if strings.TrimSpace(day) == "" {
+		return nil, fmt.Errorf("day must not be empty")
+	}
+	return m.loadBigInt(LoyaltyProgramDailyTotalKey(id, day))
+}
+
+// SetLoyaltyProgramEpochAccrued stores the accrued rewards for the provided program and epoch.
+func (m *Manager) SetLoyaltyProgramEpochAccrued(id loyalty.ProgramID, epoch uint64, amount *big.Int) error {
+	return m.writeBigInt(LoyaltyProgramEpochKey(id, epoch), amount)
+}
+
+// LoyaltyProgramEpochAccrued returns the accrued rewards for the provided program and epoch.
+func (m *Manager) LoyaltyProgramEpochAccrued(id loyalty.ProgramID, epoch uint64) (*big.Int, error) {
+	return m.loadBigInt(LoyaltyProgramEpochKey(id, epoch))
+}
+
+// SetLoyaltyProgramIssuanceAccrued stores the lifetime accrued rewards for the provided program and address.
+func (m *Manager) SetLoyaltyProgramIssuanceAccrued(id loyalty.ProgramID, addr []byte, amount *big.Int) error {
+	if len(addr) == 0 {
+		return fmt.Errorf("address must not be empty")
+	}
+	return m.writeBigInt(LoyaltyProgramIssuanceKey(id, addr), amount)
+}
+
+// LoyaltyProgramIssuanceAccrued returns the lifetime accrued rewards for the provided program and address.
+func (m *Manager) LoyaltyProgramIssuanceAccrued(id loyalty.ProgramID, addr []byte) (*big.Int, error) {
+	if len(addr) == 0 {
+		return nil, fmt.Errorf("address must not be empty")
+	}
+	return m.loadBigInt(LoyaltyProgramIssuanceKey(id, addr))
+}
+
 // SetRole associates an address with the specified role. Duplicate assignments
 // are ignored while the stored list remains sorted for determinism.
 func (m *Manager) SetRole(role string, addr []byte) error {
@@ -2935,44 +3009,44 @@ func (m *Manager) EscrowCredit(id [32]byte, token string, amt *big.Int) error {
 
 // EscrowDebit decreases the tracked escrow balance for the supplied token.
 func (m *Manager) EscrowDebit(id [32]byte, token string, amt *big.Int) error {
-        if amt == nil {
-                amt = big.NewInt(0)
-        }
-        if amt.Sign() < 0 {
-                return fmt.Errorf("escrow: negative debit")
-        }
-        normalized, err := escrow.NormalizeToken(token)
-        if err != nil {
-                return err
-        }
-        key := escrowVaultKey(id, normalized)
-        balance, err := m.loadBigInt(key)
-        if err != nil {
-                return err
-        }
-        if balance.Cmp(amt) < 0 {
-                return fmt.Errorf("escrow: insufficient balance")
-        }
-        if amt.Sign() == 0 {
-                return nil
-        }
-        updated := new(big.Int).Sub(balance, amt)
-        return m.writeBigInt(key, updated)
+	if amt == nil {
+		amt = big.NewInt(0)
+	}
+	if amt.Sign() < 0 {
+		return fmt.Errorf("escrow: negative debit")
+	}
+	normalized, err := escrow.NormalizeToken(token)
+	if err != nil {
+		return err
+	}
+	key := escrowVaultKey(id, normalized)
+	balance, err := m.loadBigInt(key)
+	if err != nil {
+		return err
+	}
+	if balance.Cmp(amt) < 0 {
+		return fmt.Errorf("escrow: insufficient balance")
+	}
+	if amt.Sign() == 0 {
+		return nil
+	}
+	updated := new(big.Int).Sub(balance, amt)
+	return m.writeBigInt(key, updated)
 }
 
 // EscrowBalance returns the tracked vault balance for the specified escrow
 // identifier and token symbol.
 func (m *Manager) EscrowBalance(id [32]byte, token string) (*big.Int, error) {
-        normalized, err := escrow.NormalizeToken(token)
-        if err != nil {
-                return nil, err
-        }
-        key := escrowVaultKey(id, normalized)
-        balance, err := m.loadBigInt(key)
-        if err != nil {
-                return nil, err
-        }
-        return balance, nil
+	normalized, err := escrow.NormalizeToken(token)
+	if err != nil {
+		return nil, err
+	}
+	key := escrowVaultKey(id, normalized)
+	balance, err := m.loadBigInt(key)
+	if err != nil {
+		return nil, err
+	}
+	return balance, nil
 }
 
 // TradePut persists the provided trade definition after validation.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -3049,6 +3049,36 @@ func (sp *StateProcessor) SetLoyaltyProgramDailyAccrued(programID loyalty.Progra
 	return manager.SetLoyaltyProgramDailyAccrued(programID, addr, day, amount)
 }
 
+func (sp *StateProcessor) LoyaltyProgramDailyTotalAccrued(programID loyalty.ProgramID, day string) (*big.Int, error) {
+	manager := nhbstate.NewManager(sp.Trie)
+	return manager.LoyaltyProgramDailyTotalAccrued(programID, day)
+}
+
+func (sp *StateProcessor) SetLoyaltyProgramDailyTotalAccrued(programID loyalty.ProgramID, day string, amount *big.Int) error {
+	manager := nhbstate.NewManager(sp.Trie)
+	return manager.SetLoyaltyProgramDailyTotalAccrued(programID, day, amount)
+}
+
+func (sp *StateProcessor) LoyaltyProgramEpochAccrued(programID loyalty.ProgramID, epoch uint64) (*big.Int, error) {
+	manager := nhbstate.NewManager(sp.Trie)
+	return manager.LoyaltyProgramEpochAccrued(programID, epoch)
+}
+
+func (sp *StateProcessor) SetLoyaltyProgramEpochAccrued(programID loyalty.ProgramID, epoch uint64, amount *big.Int) error {
+	manager := nhbstate.NewManager(sp.Trie)
+	return manager.SetLoyaltyProgramEpochAccrued(programID, epoch, amount)
+}
+
+func (sp *StateProcessor) LoyaltyProgramIssuanceAccrued(programID loyalty.ProgramID, addr []byte) (*big.Int, error) {
+	manager := nhbstate.NewManager(sp.Trie)
+	return manager.LoyaltyProgramIssuanceAccrued(programID, addr)
+}
+
+func (sp *StateProcessor) SetLoyaltyProgramIssuanceAccrued(programID loyalty.ProgramID, addr []byte, amount *big.Int) error {
+	manager := nhbstate.NewManager(sp.Trie)
+	return manager.SetLoyaltyProgramIssuanceAccrued(programID, addr, amount)
+}
+
 func (sp *StateProcessor) MintToken(symbol string, addr []byte, amount *big.Int) error {
 	if len(addr) != 20 {
 		return fmt.Errorf("mint: address must be 20 bytes")

--- a/docs/loyalty/paymaster.md
+++ b/docs/loyalty/paymaster.md
@@ -1,0 +1,58 @@
+# Loyalty Paymaster Health & Throttling
+
+The loyalty engine requires businesses to pre-fund a paymaster pool in ZapNHB (ZNHB).
+This document describes the runtime safeguards that protect reward execution when paymaster
+funding approaches exhaustion.
+
+## Reserve enforcement
+
+* Each business can configure a **`paymaster_reserve_min`** threshold. When a reward would drop
+  the paymaster below this minimum the engine throttles the accrual and returns the status
+  `"throttled — low reserve"`. The transaction itself continues to settle; only the reward is
+  skipped.
+* Early-warning events (`loyalty.program.paymaster_warning`) fire when the projected balance after
+  paying a reward falls to **80% headroom** above the configured reserve. The event attributes include
+  the projected balance and reserve target to simplify alerting.
+* The engine continues to enforce spend token `NHB` and reward token `ZNHB` exclusively. Future
+  multi-asset support is intentionally disabled until downstream accounting and compliance flows are
+  extended.
+
+## Reward caps
+
+Program reward configuration now supports additional throttles:
+
+| Field | Description |
+|-------|-------------|
+| `DailyCapProgram` | Maximum total ZNHB a program can issue per UTC day across all recipients. |
+| `EpochCapProgram` / `EpochLengthSeconds` | Maximum ZNHB per custom epoch window. Epoch accounting stops at the configured cap until the epoch rolls over. |
+| `IssuanceCapUser` | Lifetime issuance ceiling per address for the program. |
+
+All caps apply after per-transaction and per-user daily limits. When a cap blocks a reward the
+engine emits `loyalty.program.skipped` with reason `daily_program_cap_reached`, `epoch_cap_reached`,
+`issuance_cap_reached`, or `throttled — low reserve` depending on the guard that triggered.
+
+## Observability
+
+The following events surface paymaster health to off-chain monitors:
+
+* `loyalty.program.paymaster_warning` – emitted when a payout would leave the paymaster within 20%
+  of its configured reserve minimum (80% of the safety buffer consumed). Attributes include
+  `balance`, `reserveMin`, and standard program metadata.
+* `loyalty.program.skipped` – existing event now reports the human-readable reason string described
+  above plus contextual metadata (`available`, `reserveMin`, etc.) when throttling is activated.
+
+The new meters exposed via RPC/state (`loyalty.programDailyTotalAccrued`,
+`loyalty.programEpochAccrued`, and `loyalty.programIssuanceAccrued`) allow operators to reconcile
+cap usage and build dashboards.
+
+## Developer notes
+
+* Reserve enforcement and caps are designed to be **non-fatal** – they never revert the underlying
+  settlement. Businesses should subscribe to the warning/skip events or poll the meters to
+  proactively top up paymasters.
+* All new fields accept zero values to disable the guard. Governance tooling must provide
+  non-zero `EpochLengthSeconds` when `EpochCapProgram` is configured; otherwise program updates are
+  rejected.
+* Multi-token spend/reward combinations remain out of scope for this release. Any attempt to
+  configure non-`NHB`/`ZNHB` symbols continues to raise `token_not_supported` or
+  `reward_token_not_supported` events.

--- a/native/loyalty/engine_program.go
+++ b/native/loyalty/engine_program.go
@@ -11,8 +11,12 @@ import (
 )
 
 const (
-	eventProgramAccrued = "loyalty.program.accrued"
-	eventProgramSkipped = "loyalty.program.skipped"
+	eventProgramAccrued       = "loyalty.program.accrued"
+	eventProgramSkipped       = "loyalty.program.skipped"
+	eventProgramPaymasterWarn = "loyalty.program.paymaster_warning"
+
+	resultAccrued             = "accrued"
+	resultThrottledLowReserve = "throttled — low reserve"
 )
 
 // ProgramRewardState describes the additional state access required to process
@@ -24,6 +28,12 @@ type ProgramRewardState interface {
 	LoyaltyBusinessByMerchant(merchant [20]byte) (*Business, bool, error)
 	LoyaltyProgramDailyAccrued(programID ProgramID, addr []byte, day string) (*big.Int, error)
 	SetLoyaltyProgramDailyAccrued(programID ProgramID, addr []byte, day string, amount *big.Int) error
+	LoyaltyProgramDailyTotalAccrued(programID ProgramID, day string) (*big.Int, error)
+	SetLoyaltyProgramDailyTotalAccrued(programID ProgramID, day string, amount *big.Int) error
+	LoyaltyProgramEpochAccrued(programID ProgramID, epoch uint64) (*big.Int, error)
+	SetLoyaltyProgramEpochAccrued(programID ProgramID, epoch uint64, amount *big.Int) error
+	LoyaltyProgramIssuanceAccrued(programID ProgramID, addr []byte) (*big.Int, error)
+	SetLoyaltyProgramIssuanceAccrued(programID ProgramID, addr []byte, amount *big.Int) error
 }
 
 // ProgramRewardContext extends the base reward context with optional hints used
@@ -91,95 +101,100 @@ func (ctx *ProgramRewardContext) programEventAttributes(program *Program, busine
 
 // ApplyProgramReward evaluates and applies a loyalty program reward when a
 // matching program and funded paymaster are available.
-func (e *Engine) ApplyProgramReward(st ProgramRewardState, ctx *ProgramRewardContext) {
+func (e *Engine) ApplyProgramReward(st ProgramRewardState, ctx *ProgramRewardContext) string {
 	if st == nil || ctx == nil || ctx.BaseRewardContext == nil {
-		return
+		return ""
 	}
 	baseCtx := ctx.BaseRewardContext
 	if baseCtx.FromAccount == nil {
 		emitProgramSkip(st, ctx, nil, nil, "missing_from_account", nil)
-		return
+		return "missing_from_account"
 	}
 	amount := baseCtx.amountValue()
 	if amount.Sign() <= 0 {
 		emitProgramSkip(st, ctx, nil, nil, "amount_not_positive", nil)
-		return
+		return "amount_not_positive"
 	}
 	fromAddr := baseCtx.From
 	if len(fromAddr) != 20 {
 		emitProgramSkip(st, ctx, nil, nil, "invalid_from_address", map[string]string{"length": strconv.Itoa(len(fromAddr))})
-		return
+		return "invalid_from_address"
 	}
 	timestamp := uint64(baseCtx.Timestamp.UTC().Unix())
 
 	resolution, reason, extra := resolveProgram(st, ctx, timestamp)
 	if reason != "" {
 		emitProgramSkip(st, ctx, resolution.program, resolution.business, reason, extra)
-		return
+		return reason
 	}
 	program := resolution.program
 	business := resolution.business
 	if program == nil || business == nil {
 		emitProgramSkip(st, ctx, program, business, "program_not_found", nil)
-		return
+		return "program_not_found"
 	}
 	if !programActiveForTimestamp(program, timestamp) {
 		emitProgramSkip(st, ctx, program, business, "program_inactive", nil)
-		return
+		return "program_inactive"
 	}
 
 	if token := strings.ToUpper(strings.TrimSpace(baseCtx.Token)); token != "NHB" {
 		emitProgramSkip(st, ctx, program, business, "token_not_supported", map[string]string{"token": baseCtx.Token})
-		return
+		return "token_not_supported"
 	}
 	if token := strings.ToUpper(strings.TrimSpace(program.TokenSymbol)); token != "ZNHB" {
 		emitProgramSkip(st, ctx, program, business, "reward_token_not_supported", map[string]string{"token": program.TokenSymbol})
-		return
+		return "reward_token_not_supported"
 	}
 	if program.MinSpendWei != nil && amount.Cmp(program.MinSpendWei) < 0 {
 		emitProgramSkip(st, ctx, program, business, "below_min_spend", map[string]string{"minSpend": program.MinSpendWei.String()})
-		return
+		return "below_min_spend"
 	}
 	if program.StartTime != 0 && timestamp < program.StartTime {
 		emitProgramSkip(st, ctx, program, business, "not_started", map[string]string{"startTime": strconv.FormatUint(program.StartTime, 10)})
-		return
+		return "not_started"
 	}
 	if program.EndTime != 0 && timestamp > program.EndTime {
 		emitProgramSkip(st, ctx, program, business, "program_ended", map[string]string{"endTime": strconv.FormatUint(program.EndTime, 10)})
-		return
+		return "program_ended"
 	}
 	if program.AccrualBps == 0 {
 		emitProgramSkip(st, ctx, program, business, "no_reward_rate", nil)
-		return
+		return "no_reward_rate"
 	}
 
 	reward := new(big.Int).Mul(amount, new(big.Int).SetUint64(uint64(program.AccrualBps)))
 	reward = reward.Quo(reward, big.NewInt(10_000))
 	if reward.Sign() <= 0 {
 		emitProgramSkip(st, ctx, program, business, "reward_zero", nil)
-		return
+		return "reward_zero"
 	}
 	if program.CapPerTx != nil && program.CapPerTx.Sign() > 0 && reward.Cmp(program.CapPerTx) > 0 {
 		reward = new(big.Int).Set(program.CapPerTx)
 	}
 
 	dayKey := ctx.dayKey()
-	var accruedToday *big.Int
+	var (
+		accruedToday      *big.Int
+		programDailyTotal *big.Int
+		programEpochTotal *big.Int
+		issuanceTotal     *big.Int
+	)
 	if program.DailyCapUser != nil && program.DailyCapUser.Sign() > 0 {
 		if dayKey == "" {
 			emitProgramSkip(st, ctx, program, business, "missing_day_key", nil)
-			return
+			return "missing_day_key"
 		}
 		var err error
 		accruedToday, err = st.LoyaltyProgramDailyAccrued(program.ID, fromAddr, dayKey)
 		if err != nil {
 			emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
-			return
+			return "meter_error"
 		}
 		remaining := new(big.Int).Sub(program.DailyCapUser, accruedToday)
 		if remaining.Sign() <= 0 {
 			emitProgramSkip(st, ctx, program, business, "daily_cap_reached", map[string]string{"dailyCap": program.DailyCapUser.String()})
-			return
+			return "daily_cap_reached"
 		}
 		if reward.Cmp(remaining) > 0 {
 			reward = remaining
@@ -187,30 +202,112 @@ func (e *Engine) ApplyProgramReward(st ProgramRewardState, ctx *ProgramRewardCon
 	}
 	if reward.Sign() <= 0 {
 		emitProgramSkip(st, ctx, program, business, "reward_zero", nil)
-		return
+		return "reward_zero"
+	}
+
+	if program.DailyCapProgram != nil && program.DailyCapProgram.Sign() > 0 {
+		if dayKey == "" {
+			emitProgramSkip(st, ctx, program, business, "missing_day_key", nil)
+			return "missing_day_key"
+		}
+		var err error
+		programDailyTotal, err = st.LoyaltyProgramDailyTotalAccrued(program.ID, dayKey)
+		if err != nil {
+			emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
+			return "meter_error"
+		}
+		remaining := new(big.Int).Sub(program.DailyCapProgram, programDailyTotal)
+		if remaining.Sign() <= 0 {
+			emitProgramSkip(st, ctx, program, business, "daily_program_cap_reached", map[string]string{"dailyCap": program.DailyCapProgram.String()})
+			return "daily_program_cap_reached"
+		}
+		if reward.Cmp(remaining) > 0 {
+			reward = remaining
+		}
+	}
+
+	var epochKey uint64
+	if program.EpochCapProgram != nil && program.EpochCapProgram.Sign() > 0 {
+		if program.EpochLengthSeconds == 0 {
+			emitProgramSkip(st, ctx, program, business, "epoch_not_configured", nil)
+			return "epoch_not_configured"
+		}
+		epochKey = timestamp / program.EpochLengthSeconds
+		var err error
+		programEpochTotal, err = st.LoyaltyProgramEpochAccrued(program.ID, epochKey)
+		if err != nil {
+			emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
+			return "meter_error"
+		}
+		remaining := new(big.Int).Sub(program.EpochCapProgram, programEpochTotal)
+		if remaining.Sign() <= 0 {
+			emitProgramSkip(st, ctx, program, business, "epoch_cap_reached", map[string]string{"epochCap": program.EpochCapProgram.String(), "epoch": strconv.FormatUint(epochKey, 10)})
+			return "epoch_cap_reached"
+		}
+		if reward.Cmp(remaining) > 0 {
+			reward = remaining
+		}
+	}
+
+	if reward.Sign() <= 0 {
+		emitProgramSkip(st, ctx, program, business, "reward_zero", nil)
+		return "reward_zero"
+	}
+
+	if program.IssuanceCapUser != nil && program.IssuanceCapUser.Sign() > 0 {
+		var err error
+		issuanceTotal, err = st.LoyaltyProgramIssuanceAccrued(program.ID, fromAddr)
+		if err != nil {
+			emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
+			return "meter_error"
+		}
+		remaining := new(big.Int).Sub(program.IssuanceCapUser, issuanceTotal)
+		if remaining.Sign() <= 0 {
+			emitProgramSkip(st, ctx, program, business, "issuance_cap_reached", map[string]string{"issuanceCap": program.IssuanceCapUser.String()})
+			return "issuance_cap_reached"
+		}
+		if reward.Cmp(remaining) > 0 {
+			reward = remaining
+		}
 	}
 
 	if isZeroAddress(business.Paymaster) {
 		emitProgramSkip(st, ctx, program, business, "paymaster_missing", nil)
-		return
+		return "paymaster_missing"
 	}
 	paymasterAcc, err := st.GetAccount(business.Paymaster[:])
 	if err != nil {
 		emitProgramSkip(st, ctx, program, business, "paymaster_error", map[string]string{"error": err.Error()})
-		return
+		return "paymaster_error"
 	}
 	if paymasterAcc.BalanceZNHB == nil {
 		paymasterAcc.BalanceZNHB = big.NewInt(0)
 	}
+
+	if business.PaymasterReserveMin != nil && business.PaymasterReserveMin.Sign() > 0 {
+		projected := new(big.Int).Sub(paymasterAcc.BalanceZNHB, reward)
+		warnThreshold := new(big.Int).Mul(business.PaymasterReserveMin, big.NewInt(120))
+		warnThreshold = warnThreshold.Quo(warnThreshold, big.NewInt(100))
+		if projected.Cmp(warnThreshold) <= 0 {
+			emitPaymasterWarning(st, ctx, program, business, projected, business.PaymasterReserveMin)
+		}
+		if projected.Cmp(business.PaymasterReserveMin) < 0 {
+			emitProgramSkip(st, ctx, program, business, resultThrottledLowReserve, map[string]string{
+				"available":  paymasterAcc.BalanceZNHB.String(),
+				"reserveMin": business.PaymasterReserveMin.String(),
+			})
+			return resultThrottledLowReserve
+		}
+	}
 	if paymasterAcc.BalanceZNHB.Cmp(reward) < 0 {
 		emitProgramSkip(st, ctx, program, business, "paymaster_insufficient", map[string]string{"available": paymasterAcc.BalanceZNHB.String()})
-		return
+		return "paymaster_insufficient"
 	}
 
 	paymasterAcc.BalanceZNHB = new(big.Int).Sub(paymasterAcc.BalanceZNHB, reward)
 	if err := st.PutAccount(business.Paymaster[:], paymasterAcc); err != nil {
 		emitProgramSkip(st, ctx, program, business, "paymaster_persist_error", map[string]string{"error": err.Error()})
-		return
+		return "paymaster_persist_error"
 	}
 
 	if baseCtx.FromAccount.BalanceZNHB == nil {
@@ -224,17 +321,60 @@ func (e *Engine) ApplyProgramReward(st ProgramRewardState, ctx *ProgramRewardCon
 			accruedToday, err = st.LoyaltyProgramDailyAccrued(program.ID, fromAddr, dayKey)
 			if err != nil {
 				emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
-				return
+				return "meter_error"
 			}
 		}
 		newDaily := new(big.Int).Add(accruedToday, reward)
 		if err := st.SetLoyaltyProgramDailyAccrued(program.ID, fromAddr, dayKey, newDaily); err != nil {
 			emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
-			return
+			return "meter_error"
+		}
+		if program.DailyCapProgram != nil && program.DailyCapProgram.Sign() > 0 {
+			if programDailyTotal == nil {
+				var err error
+				programDailyTotal, err = st.LoyaltyProgramDailyTotalAccrued(program.ID, dayKey)
+				if err != nil {
+					emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
+					return "meter_error"
+				}
+			}
+			if err := st.SetLoyaltyProgramDailyTotalAccrued(program.ID, dayKey, new(big.Int).Add(programDailyTotal, reward)); err != nil {
+				emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
+				return "meter_error"
+			}
+		}
+	}
+	if program.EpochCapProgram != nil && program.EpochCapProgram.Sign() > 0 {
+		if programEpochTotal == nil {
+			var err error
+			programEpochTotal, err = st.LoyaltyProgramEpochAccrued(program.ID, epochKey)
+			if err != nil {
+				emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
+				return "meter_error"
+			}
+		}
+		if err := st.SetLoyaltyProgramEpochAccrued(program.ID, epochKey, new(big.Int).Add(programEpochTotal, reward)); err != nil {
+			emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
+			return "meter_error"
+		}
+	}
+	if program.IssuanceCapUser != nil && program.IssuanceCapUser.Sign() > 0 {
+		if issuanceTotal == nil {
+			var err error
+			issuanceTotal, err = st.LoyaltyProgramIssuanceAccrued(program.ID, fromAddr)
+			if err != nil {
+				emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
+				return "meter_error"
+			}
+		}
+		if err := st.SetLoyaltyProgramIssuanceAccrued(program.ID, fromAddr, new(big.Int).Add(issuanceTotal, reward)); err != nil {
+			emitProgramSkip(st, ctx, program, business, "meter_error", map[string]string{"error": err.Error()})
+			return "meter_error"
 		}
 	}
 
 	emitProgramAccrued(st, ctx, program, business, reward)
+	return resultAccrued
 }
 
 type programResolution struct {
@@ -366,4 +506,18 @@ func emitProgramAccrued(st ProgramRewardState, ctx *ProgramRewardContext, progra
 	attrs := ctx.programEventAttributes(program, business)
 	attrs["reward"] = reward.String()
 	st.AppendEvent(&types.Event{Type: eventProgramAccrued, Attributes: attrs})
+}
+
+func emitPaymasterWarning(st ProgramRewardState, ctx *ProgramRewardContext, program *Program, business *Business, balance, reserve *big.Int) {
+	if st == nil || ctx == nil {
+		return
+	}
+	attrs := ctx.programEventAttributes(program, business)
+	if balance != nil {
+		attrs["balance"] = balance.String()
+	}
+	if reserve != nil {
+		attrs["reserveMin"] = reserve.String()
+	}
+	st.AppendEvent(&types.Event{Type: eventProgramPaymasterWarn, Attributes: attrs})
 }

--- a/native/loyalty/engine_program_test.go
+++ b/native/loyalty/engine_program_test.go
@@ -11,19 +11,25 @@ import (
 
 type mockProgramState struct {
 	*mockState
-	programs      map[[32]byte]*Program
-	ownerPrograms map[[20]byte][]ProgramID
-	businesses    map[[20]byte]*Business
-	programDaily  map[[32]byte]map[string]map[string]*big.Int
+	programs           map[[32]byte]*Program
+	ownerPrograms      map[[20]byte][]ProgramID
+	businesses         map[[20]byte]*Business
+	programDaily       map[[32]byte]map[string]map[string]*big.Int
+	programDailyTotals map[[32]byte]map[string]*big.Int
+	programEpochTotals map[[32]byte]map[uint64]*big.Int
+	programIssuance    map[[32]byte]map[string]*big.Int
 }
 
 func newMockProgramState(cfg *GlobalConfig) *mockProgramState {
 	return &mockProgramState{
-		mockState:     newMockState(cfg),
-		programs:      make(map[[32]byte]*Program),
-		ownerPrograms: make(map[[20]byte][]ProgramID),
-		businesses:    make(map[[20]byte]*Business),
-		programDaily:  make(map[[32]byte]map[string]map[string]*big.Int),
+		mockState:          newMockState(cfg),
+		programs:           make(map[[32]byte]*Program),
+		ownerPrograms:      make(map[[20]byte][]ProgramID),
+		businesses:         make(map[[20]byte]*Business),
+		programDaily:       make(map[[32]byte]map[string]map[string]*big.Int),
+		programDailyTotals: make(map[[32]byte]map[string]*big.Int),
+		programEpochTotals: make(map[[32]byte]map[uint64]*big.Int),
+		programIssuance:    make(map[[32]byte]map[string]*big.Int),
 	}
 }
 
@@ -35,6 +41,9 @@ func cloneProgram(p *Program) *Program {
 	clone.MinSpendWei = cloneBigInt(p.MinSpendWei)
 	clone.CapPerTx = cloneBigInt(p.CapPerTx)
 	clone.DailyCapUser = cloneBigInt(p.DailyCapUser)
+	clone.DailyCapProgram = cloneBigInt(p.DailyCapProgram)
+	clone.EpochCapProgram = cloneBigInt(p.EpochCapProgram)
+	clone.IssuanceCapUser = cloneBigInt(p.IssuanceCapUser)
 	return &clone
 }
 
@@ -55,11 +64,12 @@ func (m *mockProgramState) addBusinessMapping(merchant [20]byte, business *Busin
 		return
 	}
 	m.businesses[merchant] = &Business{
-		ID:        business.ID,
-		Owner:     business.Owner,
-		Name:      business.Name,
-		Paymaster: business.Paymaster,
-		Merchants: append([][20]byte(nil), business.Merchants...),
+		ID:                  business.ID,
+		Owner:               business.Owner,
+		Name:                business.Name,
+		Paymaster:           business.Paymaster,
+		Merchants:           append([][20]byte(nil), business.Merchants...),
+		PaymasterReserveMin: cloneBigInt(business.PaymasterReserveMin),
 	}
 }
 
@@ -80,11 +90,12 @@ func (m *mockProgramState) LoyaltyProgramsByOwner(owner [20]byte) ([]ProgramID, 
 func (m *mockProgramState) LoyaltyBusinessByMerchant(merchant [20]byte) (*Business, bool, error) {
 	if business, ok := m.businesses[merchant]; ok {
 		return &Business{
-			ID:        business.ID,
-			Owner:     business.Owner,
-			Name:      business.Name,
-			Paymaster: business.Paymaster,
-			Merchants: append([][20]byte(nil), business.Merchants...),
+			ID:                  business.ID,
+			Owner:               business.Owner,
+			Name:                business.Name,
+			Paymaster:           business.Paymaster,
+			Merchants:           append([][20]byte(nil), business.Merchants...),
+			PaymasterReserveMin: cloneBigInt(business.PaymasterReserveMin),
 		}, true, nil
 	}
 	return nil, false, nil
@@ -115,6 +126,63 @@ func (m *mockProgramState) SetLoyaltyProgramDailyAccrued(programID ProgramID, ad
 		m.programDaily[programKey][day] = make(map[string]*big.Int)
 	}
 	m.programDaily[programKey][day][string(addr)] = new(big.Int).Set(amount)
+	return nil
+}
+
+func (m *mockProgramState) LoyaltyProgramDailyTotalAccrued(programID ProgramID, day string) (*big.Int, error) {
+	totals, ok := m.programDailyTotals[programID]
+	if !ok {
+		return big.NewInt(0), nil
+	}
+	if amt, exists := totals[day]; exists {
+		return new(big.Int).Set(amt), nil
+	}
+	return big.NewInt(0), nil
+}
+
+func (m *mockProgramState) SetLoyaltyProgramDailyTotalAccrued(programID ProgramID, day string, amount *big.Int) error {
+	if _, ok := m.programDailyTotals[programID]; !ok {
+		m.programDailyTotals[programID] = make(map[string]*big.Int)
+	}
+	m.programDailyTotals[programID][day] = new(big.Int).Set(amount)
+	return nil
+}
+
+func (m *mockProgramState) LoyaltyProgramEpochAccrued(programID ProgramID, epoch uint64) (*big.Int, error) {
+	totals, ok := m.programEpochTotals[programID]
+	if !ok {
+		return big.NewInt(0), nil
+	}
+	if amt, exists := totals[epoch]; exists {
+		return new(big.Int).Set(amt), nil
+	}
+	return big.NewInt(0), nil
+}
+
+func (m *mockProgramState) SetLoyaltyProgramEpochAccrued(programID ProgramID, epoch uint64, amount *big.Int) error {
+	if _, ok := m.programEpochTotals[programID]; !ok {
+		m.programEpochTotals[programID] = make(map[uint64]*big.Int)
+	}
+	m.programEpochTotals[programID][epoch] = new(big.Int).Set(amount)
+	return nil
+}
+
+func (m *mockProgramState) LoyaltyProgramIssuanceAccrued(programID ProgramID, addr []byte) (*big.Int, error) {
+	totals, ok := m.programIssuance[programID]
+	if !ok {
+		return big.NewInt(0), nil
+	}
+	if amt, exists := totals[string(addr)]; exists {
+		return new(big.Int).Set(amt), nil
+	}
+	return big.NewInt(0), nil
+}
+
+func (m *mockProgramState) SetLoyaltyProgramIssuanceAccrued(programID ProgramID, addr []byte, amount *big.Int) error {
+	if _, ok := m.programIssuance[programID]; !ok {
+		m.programIssuance[programID] = make(map[string]*big.Int)
+	}
+	m.programIssuance[programID][string(addr)] = new(big.Int).Set(amount)
 	return nil
 }
 
@@ -165,7 +233,9 @@ func TestApplyProgramRewardHappyPath(t *testing.T) {
 	}
 
 	engine := NewEngine()
-	engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx})
+	if result := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx}); result != resultAccrued {
+		t.Fatalf("expected result %q, got %q", resultAccrued, result)
+	}
 
 	if got := ctx.FromAccount.BalanceZNHB.String(); got != "50" {
 		t.Fatalf("expected reward 50, got %s", got)
@@ -231,7 +301,9 @@ func TestApplyProgramRewardProgramPaused(t *testing.T) {
 	}
 
 	engine := NewEngine()
-	engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: baseCtx, ProgramHint: &programID})
+	if result := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: baseCtx, ProgramHint: &programID}); result != "program_inactive" {
+		t.Fatalf("expected program_inactive result, got %q", result)
+	}
 
 	if baseCtx.FromAccount.BalanceZNHB.Sign() != 0 {
 		t.Fatalf("expected no reward for paused program")
@@ -287,7 +359,9 @@ func TestApplyProgramRewardInsufficientPaymaster(t *testing.T) {
 	}
 
 	engine := NewEngine()
-	engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx})
+	if result := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx}); result != "paymaster_insufficient" {
+		t.Fatalf("expected paymaster_insufficient result, got %q", result)
+	}
 
 	if ctx.FromAccount.BalanceZNHB.Sign() != 0 {
 		t.Fatalf("expected no reward, got %s", ctx.FromAccount.BalanceZNHB.String())
@@ -344,7 +418,9 @@ func TestApplyProgramRewardPaymasterRotation(t *testing.T) {
 	}
 
 	engine := NewEngine()
-	engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx, ProgramHint: &programID})
+	if result := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx, ProgramHint: &programID}); result != resultAccrued {
+		t.Fatalf("expected result %q, got %q", resultAccrued, result)
+	}
 
 	paymasterAcc, _ := state.GetAccount(oldPaymaster[:])
 	if paymasterAcc.BalanceZNHB.String() != "950" {
@@ -367,7 +443,9 @@ func TestApplyProgramRewardPaymasterRotation(t *testing.T) {
 		Timestamp:   ctx.Timestamp.Add(24 * time.Hour),
 		FromAccount: fromAccount,
 	}
-	engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx2, ProgramHint: &programID})
+	if result := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx2, ProgramHint: &programID}); result != resultAccrued {
+		t.Fatalf("expected result %q, got %q", resultAccrued, result)
+	}
 
 	newPaymasterAcc, _ := state.GetAccount(newPaymaster[:])
 	if newPaymasterAcc.BalanceZNHB.String() != "950" {
@@ -382,5 +460,358 @@ func TestApplyProgramRewardPaymasterRotation(t *testing.T) {
 	}
 	if got := state.events[len(state.events)-1].Attributes["paymaster"]; got != hex.EncodeToString(newPaymaster[:]) {
 		t.Fatalf("expected paymaster attribute %s, got %s", hex.EncodeToString(newPaymaster[:]), got)
+	}
+}
+
+func TestApplyProgramRewardThrottledLowReserve(t *testing.T) {
+	treasury := []byte("treasury")
+	cfg := newConfig(0, 0, 0, 0, treasury)
+	state := newMockProgramState(cfg)
+
+	var from [20]byte
+	from[0] = 0x11
+	var merchant [20]byte
+	merchant[0] = 0x12
+	var paymaster [20]byte
+	paymaster[0] = 0x13
+	var programID ProgramID
+	programID[0] = 0x21
+
+	state.addAccount(paymaster[:], &types.Account{BalanceZNHB: big.NewInt(1200), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	program := &Program{
+		ID:          programID,
+		Owner:       merchant,
+		TokenSymbol: "ZNHB",
+		AccrualBps:  2500,
+		Active:      true,
+	}
+	state.addProgram(program)
+	state.addBusinessMapping(merchant, &Business{Paymaster: paymaster, PaymasterReserveMin: big.NewInt(1000)})
+
+	fromAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}
+	ctx := &BaseRewardContext{
+		From:        toBytes(from),
+		To:          toBytes(merchant),
+		Token:       "NHB",
+		Amount:      big.NewInt(1000),
+		Timestamp:   time.Date(2024, 1, 10, 10, 0, 0, 0, time.UTC),
+		FromAccount: fromAccount,
+	}
+
+	if reserve := state.businesses[merchant].PaymasterReserveMin; reserve == nil || reserve.String() != "1000" {
+		t.Fatalf("expected reserve min 1000, got %v", reserve)
+	}
+
+	engine := NewEngine()
+	result := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx})
+	if result != resultThrottledLowReserve {
+		t.Fatalf("expected throttled result, got %q; events=%v", result, state.events)
+	}
+	if fromAccount.BalanceZNHB.Sign() != 0 {
+		t.Fatalf("expected no reward accrual, got %s", fromAccount.BalanceZNHB.String())
+	}
+	paymasterAcc, _ := state.GetAccount(paymaster[:])
+	if paymasterAcc.BalanceZNHB.Cmp(big.NewInt(1200)) != 0 {
+		t.Fatalf("expected paymaster balance unchanged, got %s", paymasterAcc.BalanceZNHB.String())
+	}
+	if len(state.events) != 2 {
+		t.Fatalf("expected warning and skip events, got %d", len(state.events))
+	}
+	if state.events[0].Type != eventProgramPaymasterWarn {
+		t.Fatalf("expected paymaster warning event, got %s", state.events[0].Type)
+	}
+	if state.events[0].Attributes["balance"] != "950" {
+		t.Fatalf("expected warning balance 950, got %s", state.events[0].Attributes["balance"])
+	}
+	if state.events[1].Attributes["reason"] != resultThrottledLowReserve {
+		t.Fatalf("expected throttled reason, got %s", state.events[1].Attributes["reason"])
+	}
+}
+
+func TestApplyProgramRewardDailyProgramCap(t *testing.T) {
+	treasury := []byte("treasury")
+	cfg := newConfig(0, 0, 0, 0, treasury)
+	state := newMockProgramState(cfg)
+
+	var from [20]byte
+	from[5] = 0x21
+	var merchant [20]byte
+	merchant[5] = 0x22
+	var paymaster [20]byte
+	paymaster[5] = 0x23
+	var programID ProgramID
+	programID[5] = 0x24
+
+	state.addAccount(paymaster[:], &types.Account{BalanceZNHB: big.NewInt(10_000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	program := &Program{
+		ID:              programID,
+		Owner:           merchant,
+		TokenSymbol:     "ZNHB",
+		AccrualBps:      1000,
+		DailyCapProgram: big.NewInt(150),
+		Active:          true,
+	}
+	state.addProgram(program)
+	state.addBusinessMapping(merchant, &Business{Paymaster: paymaster})
+
+	fromAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}
+	ctx := &BaseRewardContext{
+		From:        toBytes(from),
+		To:          toBytes(merchant),
+		Token:       "NHB",
+		Amount:      big.NewInt(1000),
+		Timestamp:   time.Date(2024, 1, 11, 8, 0, 0, 0, time.UTC),
+		FromAccount: fromAccount,
+	}
+
+	engine := NewEngine()
+	if res := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx}); res != resultAccrued {
+		t.Fatalf("first accrual expected %q, got %q", resultAccrued, res)
+	}
+	if fromAccount.BalanceZNHB.String() != "100" {
+		t.Fatalf("expected first reward 100, got %s", fromAccount.BalanceZNHB.String())
+	}
+
+	ctx2 := &BaseRewardContext{
+		From:        toBytes(from),
+		To:          toBytes(merchant),
+		Token:       "NHB",
+		Amount:      big.NewInt(1000),
+		Timestamp:   time.Date(2024, 1, 11, 9, 0, 0, 0, time.UTC),
+		FromAccount: fromAccount,
+	}
+	if res := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx2}); res != resultAccrued {
+		t.Fatalf("second accrual expected %q, got %q", resultAccrued, res)
+	}
+	if fromAccount.BalanceZNHB.String() != "150" {
+		t.Fatalf("expected cumulative reward 150, got %s", fromAccount.BalanceZNHB.String())
+	}
+	total, err := state.LoyaltyProgramDailyTotalAccrued(programID, "2024-01-11")
+	if err != nil {
+		t.Fatalf("daily total error: %v", err)
+	}
+	if total.String() != "150" {
+		t.Fatalf("expected program daily total 150, got %s", total.String())
+	}
+}
+
+func TestApplyProgramRewardEpochCap(t *testing.T) {
+	treasury := []byte("treasury")
+	cfg := newConfig(0, 0, 0, 0, treasury)
+	state := newMockProgramState(cfg)
+
+	var from [20]byte
+	from[9] = 0x31
+	var merchant [20]byte
+	merchant[9] = 0x32
+	var paymaster [20]byte
+	paymaster[9] = 0x33
+	var programID ProgramID
+	programID[9] = 0x34
+
+	state.addAccount(paymaster[:], &types.Account{BalanceZNHB: big.NewInt(10_000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	program := &Program{
+		ID:                 programID,
+		Owner:              merchant,
+		TokenSymbol:        "ZNHB",
+		AccrualBps:         1000,
+		EpochCapProgram:    big.NewInt(180),
+		EpochLengthSeconds: 1000,
+		Active:             true,
+	}
+	state.addProgram(program)
+	state.addBusinessMapping(merchant, &Business{Paymaster: paymaster})
+
+	fromAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}
+	timestamp := time.Unix(1_000, 0).UTC()
+	ctx := &BaseRewardContext{
+		From:        toBytes(from),
+		To:          toBytes(merchant),
+		Token:       "NHB",
+		Amount:      big.NewInt(1000),
+		Timestamp:   timestamp,
+		FromAccount: fromAccount,
+	}
+
+	engine := NewEngine()
+	if res := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx}); res != resultAccrued {
+		t.Fatalf("first accrual expected %q, got %q", resultAccrued, res)
+	}
+
+	ctx2 := &BaseRewardContext{
+		From:        toBytes(from),
+		To:          toBytes(merchant),
+		Token:       "NHB",
+		Amount:      big.NewInt(1000),
+		Timestamp:   timestamp.Add(10 * time.Second),
+		FromAccount: fromAccount,
+	}
+	if res := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx2}); res != resultAccrued {
+		t.Fatalf("second accrual expected %q, got %q", resultAccrued, res)
+	}
+	if fromAccount.BalanceZNHB.String() != "180" {
+		t.Fatalf("expected cumulative epoch reward 180, got %s", fromAccount.BalanceZNHB.String())
+	}
+
+	ctx3 := &BaseRewardContext{
+		From:        toBytes(from),
+		To:          toBytes(merchant),
+		Token:       "NHB",
+		Amount:      big.NewInt(1000),
+		Timestamp:   timestamp.Add(20 * time.Second),
+		FromAccount: fromAccount,
+	}
+	if res := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx3}); res != "epoch_cap_reached" {
+		t.Fatalf("expected epoch cap reached result, got %q", res)
+	}
+	epochKey := uint64(timestamp.UTC().Unix()) / program.EpochLengthSeconds
+	total, err := state.LoyaltyProgramEpochAccrued(programID, epochKey)
+	if err != nil {
+		t.Fatalf("epoch meter error: %v", err)
+	}
+	if total.String() != "180" {
+		t.Fatalf("expected epoch total 180, got %s", total.String())
+	}
+}
+
+func TestApplyProgramRewardIssuanceCap(t *testing.T) {
+	treasury := []byte("treasury")
+	cfg := newConfig(0, 0, 0, 0, treasury)
+	state := newMockProgramState(cfg)
+
+	var from [20]byte
+	from[10] = 0x41
+	var merchant [20]byte
+	merchant[10] = 0x42
+	var paymaster [20]byte
+	paymaster[10] = 0x43
+	var programID ProgramID
+	programID[10] = 0x44
+
+	state.addAccount(paymaster[:], &types.Account{BalanceZNHB: big.NewInt(10_000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	program := &Program{
+		ID:              programID,
+		Owner:           merchant,
+		TokenSymbol:     "ZNHB",
+		AccrualBps:      1200,
+		IssuanceCapUser: big.NewInt(150),
+		Active:          true,
+	}
+	state.addProgram(program)
+	state.addBusinessMapping(merchant, &Business{Paymaster: paymaster})
+
+	fromAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}
+	timestamp := time.Date(2024, 1, 12, 12, 0, 0, 0, time.UTC)
+	ctx := &BaseRewardContext{
+		From:        toBytes(from),
+		To:          toBytes(merchant),
+		Token:       "NHB",
+		Amount:      big.NewInt(1000),
+		Timestamp:   timestamp,
+		FromAccount: fromAccount,
+	}
+
+	engine := NewEngine()
+	if res := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx}); res != resultAccrued {
+		t.Fatalf("expected first accrual %q, got %q", resultAccrued, res)
+	}
+	if fromAccount.BalanceZNHB.String() != "120" {
+		t.Fatalf("expected first reward 120, got %s", fromAccount.BalanceZNHB.String())
+	}
+
+	ctx2 := &BaseRewardContext{
+		From:        toBytes(from),
+		To:          toBytes(merchant),
+		Token:       "NHB",
+		Amount:      big.NewInt(1000),
+		Timestamp:   timestamp.Add(time.Hour),
+		FromAccount: fromAccount,
+	}
+	if res := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx2}); res != resultAccrued {
+		t.Fatalf("expected second accrual %q, got %q", resultAccrued, res)
+	}
+	if fromAccount.BalanceZNHB.String() != "150" {
+		t.Fatalf("expected capped total 150, got %s", fromAccount.BalanceZNHB.String())
+	}
+
+	ctx3 := &BaseRewardContext{
+		From:        toBytes(from),
+		To:          toBytes(merchant),
+		Token:       "NHB",
+		Amount:      big.NewInt(1000),
+		Timestamp:   timestamp.Add(2 * time.Hour),
+		FromAccount: fromAccount,
+	}
+	if res := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx3}); res != "issuance_cap_reached" {
+		t.Fatalf("expected issuance cap reached, got %q", res)
+	}
+	issuance, err := state.LoyaltyProgramIssuanceAccrued(programID, toBytes(from))
+	if err != nil {
+		t.Fatalf("issuance meter error: %v", err)
+	}
+	if issuance.String() != "150" {
+		t.Fatalf("expected issuance total 150, got %s", issuance.String())
+	}
+}
+
+func TestApplyProgramRewardPaymasterWarning(t *testing.T) {
+	treasury := []byte("treasury")
+	cfg := newConfig(0, 0, 0, 0, treasury)
+	state := newMockProgramState(cfg)
+
+	var from [20]byte
+	from[15] = 0x51
+	var merchant [20]byte
+	merchant[15] = 0x52
+	var paymaster [20]byte
+	paymaster[15] = 0x53
+	var programID ProgramID
+	programID[15] = 0x54
+
+	state.addAccount(paymaster[:], &types.Account{BalanceZNHB: big.NewInt(1_500), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	program := &Program{
+		ID:          programID,
+		Owner:       merchant,
+		TokenSymbol: "ZNHB",
+		AccrualBps:  4000,
+		Active:      true,
+	}
+	state.addProgram(program)
+	state.addBusinessMapping(merchant, &Business{Paymaster: paymaster, PaymasterReserveMin: big.NewInt(1000)})
+
+	fromAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}
+	ctx := &BaseRewardContext{
+		From:        toBytes(from),
+		To:          toBytes(merchant),
+		Token:       "NHB",
+		Amount:      big.NewInt(1000),
+		Timestamp:   time.Date(2024, 1, 13, 15, 0, 0, 0, time.UTC),
+		FromAccount: fromAccount,
+	}
+
+	engine := NewEngine()
+	if res := engine.ApplyProgramReward(state, &ProgramRewardContext{BaseRewardContext: ctx}); res != resultAccrued {
+		t.Fatalf("expected accrued result, got %q", res)
+	}
+	if len(state.events) < 2 {
+		t.Fatalf("expected warning and accrued events, got %d", len(state.events))
+	}
+	if state.events[0].Type != eventProgramPaymasterWarn {
+		t.Fatalf("expected first event warning, got %s", state.events[0].Type)
+	}
+	if state.events[0].Attributes["balance"] != "1100" {
+		t.Fatalf("expected warning balance 1100, got %s", state.events[0].Attributes["balance"])
+	}
+	if state.events[1].Type != eventProgramAccrued {
+		t.Fatalf("expected accrued event second, got %s", state.events[1].Type)
+	}
+	paymasterAcc, _ := state.GetAccount(paymaster[:])
+	if paymasterAcc.BalanceZNHB.String() != "1100" {
+		t.Fatalf("expected paymaster balance 1100, got %s", paymasterAcc.BalanceZNHB.String())
 	}
 }

--- a/native/loyalty/loyalty.go
+++ b/native/loyalty/loyalty.go
@@ -32,6 +32,6 @@ func (e *Engine) OnTransactionSuccess(st BaseRewardState, ctx *BaseRewardContext
 
 	if programState, ok := st.(ProgramRewardState); ok {
 		programCtx := &ProgramRewardContext{BaseRewardContext: ctx}
-		e.ApplyProgramReward(programState, programCtx)
+		_ = e.ApplyProgramReward(programState, programCtx)
 	}
 }

--- a/native/loyalty/types.go
+++ b/native/loyalty/types.go
@@ -9,17 +9,21 @@ type ProgramID [32]byte
 
 // Program captures the on-chain configuration for a merchant loyalty program.
 type Program struct {
-	ID           ProgramID
-	Owner        [20]byte
-	Pool         [20]byte
-	TokenSymbol  string
-	AccrualBps   uint32
-	MinSpendWei  *big.Int
-	CapPerTx     *big.Int
-	DailyCapUser *big.Int
-	StartTime    uint64
-	EndTime      uint64
-	Active       bool
+	ID                 ProgramID
+	Owner              [20]byte
+	Pool               [20]byte
+	TokenSymbol        string
+	AccrualBps         uint32
+	MinSpendWei        *big.Int
+	CapPerTx           *big.Int
+	DailyCapUser       *big.Int
+	DailyCapProgram    *big.Int
+	EpochCapProgram    *big.Int
+	EpochLengthSeconds uint64
+	IssuanceCapUser    *big.Int
+	StartTime          uint64
+	EndTime            uint64
+	Active             bool
 }
 
 // BusinessID uniquely identifies a registered business entity.
@@ -27,9 +31,10 @@ type BusinessID [32]byte
 
 // Business captures the on-chain configuration for a registered business.
 type Business struct {
-	ID        BusinessID
-	Owner     [20]byte
-	Name      string
-	Paymaster [20]byte
-	Merchants [][20]byte
+	ID                  BusinessID
+	Owner               [20]byte
+	Name                string
+	Paymaster           [20]byte
+	Merchants           [][20]byte
+	PaymasterReserveMin *big.Int
 }

--- a/tests/loyalty/paymaster_test.go
+++ b/tests/loyalty/paymaster_test.go
@@ -1,0 +1,79 @@
+package loyalty_test
+
+import (
+	"math/big"
+	"testing"
+
+	"nhbchain/core"
+	nhbstate "nhbchain/core/state"
+	"nhbchain/native/loyalty"
+	"nhbchain/storage"
+	statetrie "nhbchain/storage/trie"
+)
+
+func newStateProcessor(t *testing.T) *core.StateProcessor {
+	t.Helper()
+	db := storage.NewMemDB()
+	t.Cleanup(db.Close)
+	trie, err := statetrie.NewTrie(db, nil)
+	if err != nil {
+		t.Fatalf("new trie: %v", err)
+	}
+	sp, err := core.NewStateProcessor(trie)
+	if err != nil {
+		t.Fatalf("state processor: %v", err)
+	}
+	return sp
+}
+
+func TestProgramMetersRoundTrip(t *testing.T) {
+	sp := newStateProcessor(t)
+
+	var programID loyalty.ProgramID
+	programID[0] = 0xAB
+	day := "2024-01-20"
+	epoch := uint64(42)
+	addr := []byte("user-addr")
+
+	if err := sp.SetLoyaltyProgramDailyTotalAccrued(programID, day, big.NewInt(125)); err != nil {
+		t.Fatalf("set daily total: %v", err)
+	}
+	daily, err := sp.LoyaltyProgramDailyTotalAccrued(programID, day)
+	if err != nil {
+		t.Fatalf("get daily total: %v", err)
+	}
+	if daily.String() != "125" {
+		t.Fatalf("expected daily total 125, got %s", daily.String())
+	}
+
+	if err := sp.SetLoyaltyProgramEpochAccrued(programID, epoch, big.NewInt(900)); err != nil {
+		t.Fatalf("set epoch: %v", err)
+	}
+	epochTotal, err := sp.LoyaltyProgramEpochAccrued(programID, epoch)
+	if err != nil {
+		t.Fatalf("get epoch: %v", err)
+	}
+	if epochTotal.String() != "900" {
+		t.Fatalf("expected epoch total 900, got %s", epochTotal.String())
+	}
+
+	if err := sp.SetLoyaltyProgramIssuanceAccrued(programID, addr, big.NewInt(321)); err != nil {
+		t.Fatalf("set issuance: %v", err)
+	}
+	issuance, err := sp.LoyaltyProgramIssuanceAccrued(programID, addr)
+	if err != nil {
+		t.Fatalf("get issuance: %v", err)
+	}
+	if issuance.String() != "321" {
+		t.Fatalf("expected issuance total 321, got %s", issuance.String())
+	}
+
+	manager := nhbstate.NewManager(sp.Trie)
+	missingDay, err := manager.LoyaltyProgramDailyTotalAccrued(programID, "2024-01-21")
+	if err != nil {
+		t.Fatalf("zero daily total: %v", err)
+	}
+	if missingDay.Sign() != 0 {
+		t.Fatalf("expected zero for missing day, got %s", missingDay.String())
+	}
+}


### PR DESCRIPTION
## Summary
- enforce paymaster reserve minimums with throttling, projected balance warnings, and status reporting
- add program-level daily/epoch caps plus lifetime issuance limits with supporting state meters
- document paymaster health behavior and cover new flows with unit and integration tests

## Testing
- go test ./native/loyalty
- go test ./tests/loyalty

------
https://chatgpt.com/codex/tasks/task_e_68d8a438c22c832dbd676d97bbbed6ca