### PR TITLE
feat(potso): harden heartbeat emissions and telemetry

### DIFF
--- a/docs/potso/operations.md
+++ b/docs/potso/operations.md
@@ -1,0 +1,61 @@
+# POTSO Operations Guide
+
+This note captures the runtime invariants and telemetry surfaced by the POTSO
+heartbeat pipeline. It supplements the [abuse controls](abuse-controls.md) and
+is aimed at validators and SREs operating public endpoints.
+
+## Emission safety
+
+Reward epochs can only be enabled when both of the following hold:
+
+- `EpochLengthBlocks > 0`
+- `EmissionPerEpoch > 0`
+
+Configurations that attempt to enable epochs with zero emission are rejected at
+validation time. This guarantees that once the module is "enabled" an emission
+budget exists, eliminating the accidental "enabled but zero emissions" state.
+
+When emissions are disabled (for example, during maintenance) the node records
+any meter growth as a wash-engagement signal. These events appear on the metric
+`potso_heartbeat_wash_total` labelled by epoch and participant address.
+
+## Heartbeat abuse counters
+
+To surface basic anti-abuse signals the node publishes the following Prometheus
+series:
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `potso_heartbeat_total` | `epoch`, `address` | Count of accepted heartbeats per address for the epoch. |
+| `potso_heartbeat_rate_limited_total` | `epoch`, `address` | Heartbeats rejected because the per-address quota was exceeded. |
+| `potso_heartbeat_unique_peers` | `epoch` | Number of distinct addresses that submitted heartbeats in the epoch. |
+| `potso_heartbeat_avg_session_seconds` | `epoch` | Average session length derived from uptime deltas inside the epoch. |
+| `potso_heartbeat_wash_total` | `epoch`, `address` | Meter increases recorded while emissions were disabled. |
+
+Use these counters to alert on suspicious behaviour (e.g. high rate-limited
+counts for a single address) and to track organic participation growth.
+
+## Per-address rate limit
+
+A rate limit of **1440 heartbeats per epoch** is enforced for every address by
+default. This corresponds to one heartbeat per minute across a 24 hour epoch and
+prevents automated wash engagement. The limit can be tuned by governance via the
+engine parameters if future epochs deviate significantly from 24 hours.
+
+Rate-limited submissions return a descriptive error to clients and increment
+`potso_heartbeat_rate_limited_total`. Accepted heartbeats continue to enforce
+the existing 60-second interval gate to guard against short-term replay spam.
+
+## Dashboards
+
+Ensure the new metrics are scraped by your Prometheus deployment. Suggested
+panels include:
+
+- **Heartbeat rate limiting**: plot `sum by (address) (increase(potso_heartbeat_rate_limited_total[5m]))` to surface abusers.
+- **Unique peers per epoch**: graph `potso_heartbeat_unique_peers` to monitor
+  validator participation.
+- **Average session length**: track `potso_heartbeat_avg_session_seconds` to
+  catch clients that drift from the expected cadence.
+
+Combined with the existing emissions telemetry, these signals enable quick
+triage when abuse or misconfiguration occurs.

--- a/native/potso/engine.go
+++ b/native/potso/engine.go
@@ -1,0 +1,150 @@
+package potso
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+
+	"nhbchain/observability/metrics"
+)
+
+// ErrHeartbeatRateLimited indicates that an address has exceeded the per-epoch
+// heartbeat allowance and must wait until the next epoch to resume.
+var ErrHeartbeatRateLimited = errors.New("potso: heartbeat rate limit exceeded")
+
+// Engine tracks runtime metrics and abuse signals for POTSO heartbeats.
+type Engine struct {
+	mu              sync.Mutex
+	params          EngineParams
+	currentEpoch    uint64
+	heartbeats      map[[20]byte]uint64
+	totalHeartbeats uint64
+	totalUptime     uint64
+	uniquePeers     map[[20]byte]struct{}
+	telemetry       *metrics.PotsoMetrics
+}
+
+// NewEngine constructs a heartbeat engine with the supplied parameters.
+func NewEngine(params EngineParams) (*Engine, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+	return &Engine{
+		params:       params,
+		currentEpoch: math.MaxUint64,
+		heartbeats:   make(map[[20]byte]uint64),
+		uniquePeers:  make(map[[20]byte]struct{}),
+		telemetry:    metrics.Potso(),
+	}, nil
+}
+
+// SetParams replaces the runtime parameters after validation.
+func (e *Engine) SetParams(params EngineParams) error {
+	if e == nil {
+		return fmt.Errorf("potso: engine not initialised")
+	}
+	if err := params.Validate(); err != nil {
+		return err
+	}
+	e.mu.Lock()
+	e.params = params
+	e.mu.Unlock()
+	return nil
+}
+
+// Reset clears the cached per-epoch state. Useful when reward configuration
+// changes or during tests.
+func (e *Engine) Reset() {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	e.currentEpoch = math.MaxUint64
+	e.heartbeats = make(map[[20]byte]uint64)
+	e.uniquePeers = make(map[[20]byte]struct{})
+	e.totalHeartbeats = 0
+	e.totalUptime = 0
+	e.mu.Unlock()
+}
+
+// Precheck validates whether the address may submit another heartbeat within
+// the epoch. No state is mutated if the heartbeat is rejected.
+func (e *Engine) Precheck(addr [20]byte, epoch uint64) error {
+	if e == nil {
+		return nil
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.ensureEpoch(epoch)
+	if e.params.MaxHeartbeatsPerEpoch > 0 {
+		if count := e.heartbeats[addr]; count >= e.params.MaxHeartbeatsPerEpoch {
+			e.recordRateLimited(addr, epoch)
+			return ErrHeartbeatRateLimited
+		}
+	}
+	return nil
+}
+
+// Commit records an accepted heartbeat, updating metrics and abuse counters.
+func (e *Engine) Commit(addr [20]byte, epoch, delta uint64) {
+	if e == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.ensureEpoch(epoch)
+	e.heartbeats[addr]++
+	e.totalHeartbeats++
+	e.totalUptime += delta
+	if _, exists := e.uniquePeers[addr]; !exists {
+		e.uniquePeers[addr] = struct{}{}
+		if e.telemetry != nil {
+			e.telemetry.SetHeartbeatUniquePeers(epoch, float64(len(e.uniquePeers)))
+		}
+	}
+	if e.telemetry != nil {
+		e.telemetry.IncHeartbeat(addrString(addr), epoch)
+		avg := 0.0
+		if e.totalHeartbeats > 0 {
+			avg = float64(e.totalUptime) / float64(e.totalHeartbeats)
+		}
+		e.telemetry.SetHeartbeatAvgSession(epoch, avg)
+	}
+}
+
+// ObserveWashEngagement marks that an address accrued meter progress while
+// emissions are disabled.
+func (e *Engine) ObserveWashEngagement(addr [20]byte, epoch uint64) {
+	if e == nil {
+		return
+	}
+	if e.telemetry != nil {
+		e.telemetry.IncHeartbeatWash(addrString(addr), epoch)
+	}
+}
+
+func (e *Engine) ensureEpoch(epoch uint64) {
+	if e.currentEpoch == epoch {
+		return
+	}
+	e.currentEpoch = epoch
+	e.heartbeats = make(map[[20]byte]uint64)
+	e.uniquePeers = make(map[[20]byte]struct{})
+	e.totalHeartbeats = 0
+	e.totalUptime = 0
+	if e.telemetry != nil {
+		e.telemetry.InitHeartbeatEpoch(epoch)
+	}
+}
+
+func (e *Engine) recordRateLimited(addr [20]byte, epoch uint64) {
+	if e.telemetry == nil {
+		return
+	}
+	e.telemetry.IncHeartbeatRateLimited(addrString(addr), epoch)
+}
+
+func addrString(addr [20]byte) string {
+	return fmt.Sprintf("0x%x", addr)
+}

--- a/native/potso/params.go
+++ b/native/potso/params.go
@@ -1,0 +1,25 @@
+package potso
+
+import "fmt"
+
+// EngineParams controls runtime limits applied to POTSO heartbeat processing.
+type EngineParams struct {
+	// MaxHeartbeatsPerEpoch bounds how many heartbeats a single address may
+	// submit within the same epoch. Exceeding the limit results in
+	// heartbeats being rejected to prevent wash engagement farming.
+	MaxHeartbeatsPerEpoch uint64
+}
+
+// DefaultEngineParams returns conservative defaults suitable for production
+// networks. The limit assumes a one minute cadence and a 24 hour epoch.
+func DefaultEngineParams() EngineParams {
+	return EngineParams{MaxHeartbeatsPerEpoch: 1440}
+}
+
+// Validate ensures the supplied parameters fall within safe operating ranges.
+func (p EngineParams) Validate() error {
+	if p.MaxHeartbeatsPerEpoch == 0 {
+		return fmt.Errorf("max heartbeats per epoch must be positive")
+	}
+	return nil
+}

--- a/native/potso/rewards.go
+++ b/native/potso/rewards.go
@@ -159,6 +159,11 @@ func (c RewardConfig) Validate() error {
 	if c.EmissionPerEpoch != nil && c.EmissionPerEpoch.Sign() < 0 {
 		return errors.New("emission per epoch cannot be negative")
 	}
+	if c.EpochLengthBlocks > 0 {
+		if c.EmissionPerEpoch == nil || c.EmissionPerEpoch.Sign() <= 0 {
+			return errors.New("emission per epoch must be positive when epoch length is set")
+		}
+	}
 	if c.MaxUserShareBps > RewardBpsDenominator {
 		return fmt.Errorf("max user share must be <= %d", RewardBpsDenominator)
 	}

--- a/tests/potso/emission_invariant_test.go
+++ b/tests/potso/emission_invariant_test.go
@@ -1,0 +1,146 @@
+package potso_test
+
+import (
+	"encoding/hex"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"nhbchain/core"
+	"nhbchain/crypto"
+	"nhbchain/native/potso"
+	"nhbchain/observability/metrics"
+	"nhbchain/storage"
+)
+
+func TestPotsoRewardConfigRejectsZeroEmission(t *testing.T) {
+	db := storage.NewMemDB()
+	key, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	node, err := core.NewNode(db, key, "", true)
+	if err != nil {
+		t.Fatalf("new node: %v", err)
+	}
+	cfg := potso.RewardConfig{
+		EpochLengthBlocks:  10,
+		EmissionPerEpoch:   big.NewInt(0),
+		TreasuryAddress:    bech32Addr(t, key),
+		MinPayoutWei:       big.NewInt(0),
+		MaxWinnersPerEpoch: 0,
+	}
+	if err := node.SetPotsoRewardConfig(cfg); err == nil {
+		t.Fatalf("expected zero-emission config to be rejected")
+	}
+}
+
+func TestPotsoHeartbeatRateLimitAndMetrics(t *testing.T) {
+	db := storage.NewMemDB()
+	key, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	node, err := core.NewNode(db, key, "", true)
+	if err != nil {
+		t.Fatalf("new node: %v", err)
+	}
+	treasury := bech32Addr(t, key)
+	cfg := potso.RewardConfig{
+		EpochLengthBlocks:  5,
+		EmissionPerEpoch:   big.NewInt(100),
+		TreasuryAddress:    treasury,
+		MinPayoutWei:       big.NewInt(0),
+		MaxWinnersPerEpoch: 0,
+	}
+	if err := node.SetPotsoRewardConfig(cfg); err != nil {
+		t.Fatalf("set reward config: %v", err)
+	}
+	if err := node.SetPotsoEngineParams(potso.EngineParams{MaxHeartbeatsPerEpoch: 2}); err != nil {
+		t.Fatalf("set engine params: %v", err)
+	}
+
+	block, err := node.Chain().GetBlockByHeight(0)
+	if err != nil {
+		t.Fatalf("load genesis block: %v", err)
+	}
+	hash, err := block.Header.Hash()
+	if err != nil {
+		t.Fatalf("hash block: %v", err)
+	}
+	addr := key.PubKey().Address()
+	var participant [20]byte
+	copy(participant[:], addr.Bytes())
+
+	ts := time.Now().UTC().Unix()
+	metrics.Potso().ResetHeartbeatMetrics()
+
+	meter, delta, err := node.PotsoHeartbeat(participant, block.Header.Height, hash, ts)
+	if err != nil {
+		t.Fatalf("first heartbeat: %v", err)
+	}
+	if delta == 0 {
+		t.Fatalf("expected positive uptime delta on first heartbeat")
+	}
+	firstUptime := meter.UptimeSeconds
+
+	secondTS := ts + potso.HeartbeatIntervalSeconds + 5
+	meter, delta, err = node.PotsoHeartbeat(participant, block.Header.Height, hash, secondTS)
+	if err != nil {
+		t.Fatalf("second heartbeat: %v", err)
+	}
+	if delta == 0 {
+		t.Fatalf("expected positive uptime delta on second heartbeat")
+	}
+	secondUptime := meter.UptimeSeconds
+	if secondUptime <= firstUptime {
+		t.Fatalf("expected uptime to increase")
+	}
+
+	thirdTS := secondTS + potso.HeartbeatIntervalSeconds + 5
+	if _, _, err = node.PotsoHeartbeat(participant, block.Header.Height, hash, thirdTS); !errors.Is(err, potso.ErrHeartbeatRateLimited) {
+		t.Fatalf("expected rate limit error, got %v", err)
+	}
+
+	latest, err := node.PotsoUserMeters(participant, meter.Day)
+	if err != nil {
+		t.Fatalf("load meter: %v", err)
+	}
+	if latest.UptimeSeconds != secondUptime {
+		t.Fatalf("expected uptime to remain %d after rate limit, got %d", secondUptime, latest.UptimeSeconds)
+	}
+
+	epochLabel := "0"
+	addrLabel := strings.ToLower("0x" + hex.EncodeToString(participant[:]))
+	potsoMetrics := metrics.Potso()
+
+	if got := testutil.ToFloat64(potsoMetrics.HeartbeatCounterVec().WithLabelValues(epochLabel, addrLabel)); got != 2 {
+		t.Fatalf("expected 2 accepted heartbeats, got %f", got)
+	}
+	if got := testutil.ToFloat64(potsoMetrics.HeartbeatRateLimitedVec().WithLabelValues(epochLabel, addrLabel)); got != 1 {
+		t.Fatalf("expected 1 rate-limited heartbeat, got %f", got)
+	}
+	if got := testutil.ToFloat64(potsoMetrics.HeartbeatUniquePeersGauge().WithLabelValues(epochLabel)); got != 1 {
+		t.Fatalf("expected 1 unique peer, got %f", got)
+	}
+	avg := testutil.ToFloat64(potsoMetrics.HeartbeatAvgSessionGauge().WithLabelValues(epochLabel))
+	expectedAvg := float64(secondUptime) / 2.0
+	if diff := avg - expectedAvg; diff > 0.1 || diff < -0.1 {
+		t.Fatalf("unexpected avg session: got %f want %f", avg, expectedAvg)
+	}
+	if got := testutil.ToFloat64(potsoMetrics.HeartbeatWashVec().WithLabelValues(epochLabel, addrLabel)); got != 0 {
+		t.Fatalf("expected no wash engagement, got %f", got)
+	}
+}
+
+func bech32Addr(t *testing.T, key *crypto.PrivateKey) [20]byte {
+	t.Helper()
+	addr := key.PubKey().Address()
+	var out [20]byte
+	copy(out[:], addr.Bytes())
+	return out
+}


### PR DESCRIPTION
## Summary
- add POTSO heartbeat engine with per-epoch rate limiting, wash-engagement tracking, and telemetry hooks
- require positive emissions when epochs are enabled and expose new heartbeat abuse metrics and documentation
- add regression tests covering emission invariants and heartbeat rate-limiting metrics

## Testing
- go test ./native/potso/...
- (fails: go test ./...)


------
https://chatgpt.com/codex/tasks/task_e_68d8a8f3e528832d992c2ffad8443d92