### PR TITLE
Add module telemetry metrics and gateway token costs

### DIFF
--- a/observability/alerts.yaml
+++ b/observability/alerts.yaml
@@ -1,0 +1,86 @@
+groups:
+  - name: module-runtime
+    interval: 30s
+    rules:
+      - alert: ModuleHighErrorRate
+        expr: |
+          sum(rate(nhb_module_requests_total{outcome="error"}[5m])) by (module)
+            /
+          clamp_min(sum(rate(nhb_module_requests_total[5m])) by (module), 1e-9)
+            > 0.05
+        for: 10m
+        labels:
+          severity: critical
+          team: platform
+        annotations:
+          summary: "High module error rate"
+          description: |
+            Module {{ $labels.module }} is returning errors for more than 5% of
+            requests over the last 10 minutes (current error rate: {{ $value | printf "%.2f" }}).
+            Inspect nhb_module_errors_total for offending methods and review the RPC logs.
+
+      - alert: ModuleLatencyP95Degraded
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(nhb_module_request_duration_seconds_bucket[5m])) by (module, method, le)
+          ) > 1
+        for: 15m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "Module latency regression"
+          description: |
+            The p95 latency for module {{ $labels.module }} method {{ $labels.method }}
+            exceeded 1s for the past 15 minutes. Review downstream dependencies and
+            recent deployments.
+
+      - alert: ModuleThrottleSaturation
+        expr: sum(increase(nhb_module_throttles_total[5m])) by (module, reason) > 25
+        for: 5m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "Module throttles saturating"
+          description: |
+            Module {{ $labels.module }} is rejecting requests due to {{ $labels.reason }}
+            more than 25 times in 5 minutes. Validate quota configuration and client behaviour.
+
+      - alert: ModulePauseEngaged
+        expr: |
+          max_over_time(nhb_module_throttles_total{reason="pause"}[1h])
+            - min_over_time(nhb_module_throttles_total{reason="pause"}[1h]) > 0
+        for: 30m
+        labels:
+          severity: critical
+          team: platform
+        annotations:
+          summary: "Module pause engaged"
+          description: |
+            A pause guard for module {{ $labels.module }} engaged within the last hour.
+            Confirm the pause was intentional and follow the incident response runbook.
+
+      - alert: OracleFeedStale
+        expr: max(nhb_oracle_update_age_seconds) > 120
+        for: 5m
+        labels:
+          severity: critical
+          team: data
+        annotations:
+          summary: "Oracle feed stale"
+          description: |
+            The latest oracle update age exceeded two minutes. Verify upstream feeds
+            and restart the swap oracle pipeline if required.
+
+      - alert: ModuleQuotaExhausted
+        expr: sum(increase(nhb_module_throttles_total{reason="quota"}[10m])) by (module) > 0
+        for: 10m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "Module quota exhaustion"
+          description: |
+            Module {{ $labels.module }} exhausted its address quota in the last ten minutes.
+            Coordinate with consumers on request backoff or increase the configured limits.

--- a/observability/metrics.go
+++ b/observability/metrics.go
@@ -1,0 +1,101 @@
+package observability
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type moduleMetrics struct {
+	requests  *prometheus.CounterVec
+	errors    *prometheus.CounterVec
+	latency   *prometheus.HistogramVec
+	throttles *prometheus.CounterVec
+}
+
+var (
+	moduleMetricsOnce sync.Once
+	moduleRegistry    *moduleMetrics
+)
+
+// ModuleMetrics returns the lazily-initialised module metrics registry used to
+// record RPC module activity.
+func ModuleMetrics() *moduleMetrics {
+	moduleMetricsOnce.Do(func() {
+		moduleRegistry = &moduleMetrics{
+			requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "nhb",
+				Subsystem: "module",
+				Name:      "requests_total",
+				Help:      "Total JSON-RPC module requests segmented by module and method.",
+			}, []string{"module", "method", "outcome"}),
+			errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "nhb",
+				Subsystem: "module",
+				Name:      "errors_total",
+				Help:      "Total JSON-RPC module errors segmented by module, method, and status code.",
+			}, []string{"module", "method", "status"}),
+			latency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Namespace: "nhb",
+				Subsystem: "module",
+				Name:      "request_duration_seconds",
+				Help:      "Latency distribution for JSON-RPC module handlers.",
+				Buckets:   prometheus.DefBuckets,
+			}, []string{"module", "method"}),
+			throttles: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "nhb",
+				Subsystem: "module",
+				Name:      "throttles_total",
+				Help:      "Count of module requests rejected due to throttling policies.",
+			}, []string{"module", "reason"}),
+		}
+		prometheus.MustRegister(
+			moduleRegistry.requests,
+			moduleRegistry.errors,
+			moduleRegistry.latency,
+			moduleRegistry.throttles,
+		)
+	})
+	return moduleRegistry
+}
+
+// Observe records the outcome of a module request. The status code should be
+// the HTTP status that was ultimately written to the response writer.
+func (m *moduleMetrics) Observe(module, method string, status int, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	if module == "" {
+		module = "unknown"
+	}
+	if method == "" {
+		method = "unknown"
+	}
+	outcome := "success"
+	if status >= 400 {
+		outcome = "error"
+	}
+	m.requests.WithLabelValues(module, method, outcome).Inc()
+	if status >= 400 {
+		m.errors.WithLabelValues(module, method, fmt.Sprintf("%d", status)).Inc()
+	}
+	m.latency.WithLabelValues(module, method).Observe(duration.Seconds())
+}
+
+// RecordThrottle increments the throttle counter for the supplied module and
+// reason. Reasons should be stable strings such as "rate_limit" or
+// "quota_exceeded" so dashboards and alerts remain consistent.
+func (m *moduleMetrics) RecordThrottle(module, reason string) {
+	if m == nil {
+		return
+	}
+	if module == "" {
+		module = "unknown"
+	}
+	if reason == "" {
+		reason = "unspecified"
+	}
+	m.throttles.WithLabelValues(module, reason).Inc()
+}


### PR DESCRIPTION
## Summary
- add a shared module metrics helper with counters, histograms, and throttle tracking
- instrument the JSON-RPC server to emit per-method metrics and record throttles
- extend the gateway rate limiter to support per-route token costs and add tests
- ship module observability alert rules and document the new metrics and policies

## Testing
- go test ./gateway/middleware -run TestRateLimiterAppliesRouteTokens -count=1

------
https://chatgpt.com/codex/tasks/task_e_68d8bbcf295c832db8363d268c4adf49