### PR TITLE
Add regression and fuzz coverage for lending, governance, and creator

### DIFF
--- a/tests/fuzz/creator_uri_fuzz.go
+++ b/tests/fuzz/creator_uri_fuzz.go
@@ -1,0 +1,114 @@
+package fuzz
+
+import (
+	"math/big"
+	"net/url"
+	"strings"
+	"testing"
+
+	"nhbchain/core/types"
+	"nhbchain/native/creator"
+)
+
+type fuzzCreatorState struct {
+	contents map[string]*creator.Content
+}
+
+func newFuzzCreatorState() *fuzzCreatorState {
+	return &fuzzCreatorState{contents: make(map[string]*creator.Content)}
+}
+
+func (s *fuzzCreatorState) CreatorContentGet(id string) (*creator.Content, bool, error) {
+	content, ok := s.contents[id]
+	if !ok {
+		return nil, false, nil
+	}
+	clone := *content
+	if content.TotalTips != nil {
+		clone.TotalTips = new(big.Int).Set(content.TotalTips)
+	}
+	if content.TotalStake != nil {
+		clone.TotalStake = new(big.Int).Set(content.TotalStake)
+	}
+	return &clone, true, nil
+}
+
+func (s *fuzzCreatorState) CreatorContentPut(content *creator.Content) error {
+	if content == nil {
+		return nil
+	}
+	clone := *content
+	if content.TotalTips != nil {
+		clone.TotalTips = new(big.Int).Set(content.TotalTips)
+	}
+	if content.TotalStake != nil {
+		clone.TotalStake = new(big.Int).Set(content.TotalStake)
+	}
+	s.contents[content.ID] = &clone
+	return nil
+}
+
+func (s *fuzzCreatorState) CreatorStakeGet([20]byte, [20]byte) (*creator.Stake, bool, error) {
+	return nil, false, nil
+}
+
+func (s *fuzzCreatorState) CreatorStakePut(*creator.Stake) error { return nil }
+
+func (s *fuzzCreatorState) CreatorStakeDelete([20]byte, [20]byte) error { return nil }
+
+func (s *fuzzCreatorState) CreatorPayoutLedgerGet([20]byte) (*creator.PayoutLedger, bool, error) {
+	return nil, false, nil
+}
+
+func (s *fuzzCreatorState) CreatorPayoutLedgerPut(*creator.PayoutLedger) error { return nil }
+
+func (s *fuzzCreatorState) GetAccount([]byte) (*types.Account, error) { return nil, nil }
+
+func (s *fuzzCreatorState) PutAccount([]byte, *types.Account) error { return nil }
+
+func FuzzCreatorURISanitization(f *testing.F) {
+	seeds := []string{
+		"https://example.com/content",
+		" ipfs://QmExample ",
+		"nhb://creator/alpha",
+		"ftp://unsupported",
+		"",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, rawURI string) {
+		engine := creator.NewEngine()
+		engine.SetState(newFuzzCreatorState())
+		engine.SetNowFunc(func() int64 { return 1 })
+
+		content, err := engine.PublishContent([20]byte{0x01}, "content-id", rawURI, rawURI)
+		if err != nil {
+			return
+		}
+		if content == nil {
+			t.Fatalf("publish returned nil without error")
+		}
+		trimmed := strings.TrimSpace(rawURI)
+		if content.URI != trimmed {
+			t.Fatalf("uri was not trimmed: got %q want %q", content.URI, trimmed)
+		}
+		if len(content.URI) == 0 {
+			t.Fatalf("empty uri accepted")
+		}
+		if len(content.URI) > 512 {
+			t.Fatalf("uri exceeds maximum length: %d", len(content.URI))
+		}
+		parsed, parseErr := url.Parse(content.URI)
+		if parseErr != nil || parsed == nil {
+			t.Fatalf("sanitized uri failed to parse: %v", parseErr)
+		}
+		scheme := strings.ToLower(parsed.Scheme)
+		switch scheme {
+		case "https", "ipfs", "ar", "nhb":
+		default:
+			t.Fatalf("unexpected scheme accepted: %q", scheme)
+		}
+	})
+}

--- a/tests/fuzz/gov_policy_fuzz.go
+++ b/tests/fuzz/gov_policy_fuzz.go
@@ -1,0 +1,158 @@
+package fuzz
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"nhbchain/config"
+	govcfg "nhbchain/native/gov"
+)
+
+func FuzzGovernancePolicyDeltas(f *testing.F) {
+	f.Add(uint32(6000), uint32(5000), uint64(604800), uint64(60), uint64(600), int64(16<<20), int64(5000), uint8(0xFF))
+
+	f.Fuzz(func(t *testing.T, quorum uint32, threshold uint32, voting uint64, minWindow uint64, maxWindow uint64, memBytes int64, maxTxs int64, flags uint8) {
+		baseline := govcfg.Baseline{
+			Governance: govcfg.GovernanceBaseline{
+				QuorumBPS:        6000,
+				PassThresholdBPS: 5000,
+				VotingPeriodSecs: config.MinVotingPeriodSeconds + 7200,
+			},
+			Slashing: govcfg.SlashingBaseline{MinWindowSecs: 60, MaxWindowSecs: 600},
+			Mempool:  govcfg.MempoolBaseline{MaxBytes: 16 << 20},
+			Blocks:   govcfg.BlocksBaseline{MaxTxs: 5000},
+		}
+
+		delta := govcfg.PolicyDelta{}
+
+		var govDelta *govcfg.GovernanceDelta
+		var slashDelta *govcfg.SlashingDelta
+		var memDelta *govcfg.MempoolDelta
+		var blockDelta *govcfg.BlocksDelta
+
+		if flags&0x01 != 0 {
+			q := quorum % 10001
+			if govDelta == nil {
+				govDelta = &govcfg.GovernanceDelta{}
+			}
+			govDelta.QuorumBPS = &q
+		}
+		if flags&0x02 != 0 {
+			th := threshold % 10001
+			if govDelta == nil {
+				govDelta = &govcfg.GovernanceDelta{}
+			}
+			govDelta.PassThresholdBPS = &th
+		}
+		if flags&0x04 != 0 {
+			period := voting%(14*24*3600) + 1
+			if govDelta == nil {
+				govDelta = &govcfg.GovernanceDelta{}
+			}
+			govDelta.VotingPeriodSecs = &period
+		}
+		if flags&0x08 != 0 {
+			min := normalizePositive(minWindow)
+			if slashDelta == nil {
+				slashDelta = &govcfg.SlashingDelta{}
+			}
+			slashDelta.MinWindowSecs = &min
+		}
+		if flags&0x10 != 0 {
+			max := normalizePositive(maxWindow)
+			if slashDelta == nil {
+				slashDelta = &govcfg.SlashingDelta{}
+			}
+			slashDelta.MaxWindowSecs = &max
+		}
+		if flags&0x20 != 0 {
+			mb := normalizePositive64(memBytes)%(1<<30) + 1
+			if memDelta == nil {
+				memDelta = &govcfg.MempoolDelta{}
+			}
+			memDelta.MaxBytes = &mb
+		}
+		if flags&0x40 != 0 {
+			mt := normalizePositive64(maxTxs)%1_000_000 + 1
+			if blockDelta == nil {
+				blockDelta = &govcfg.BlocksDelta{}
+			}
+			blockDelta.MaxTxs = &mt
+		}
+
+		delta.Governance = govDelta
+		delta.Slashing = slashDelta
+		delta.Mempool = memDelta
+		delta.Blocks = blockDelta
+
+		err := govcfg.PreflightBaselineApply(baseline, delta)
+		if err != nil {
+			if !errors.Is(err, govcfg.ErrInvalidPolicyInvariants) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			return
+		}
+
+		candidate := config.Global{
+			Governance: config.Governance{
+				QuorumBPS:        baseline.Governance.QuorumBPS,
+				PassThresholdBPS: baseline.Governance.PassThresholdBPS,
+				VotingPeriodSecs: baseline.Governance.VotingPeriodSecs,
+			},
+			Slashing: config.Slashing{
+				MinWindowSecs: baseline.Slashing.MinWindowSecs,
+				MaxWindowSecs: baseline.Slashing.MaxWindowSecs,
+			},
+			Mempool: config.Mempool{MaxBytes: baseline.Mempool.MaxBytes},
+			Blocks:  config.Blocks{MaxTxs: baseline.Blocks.MaxTxs},
+		}
+
+		if govDelta != nil {
+			if govDelta.QuorumBPS != nil {
+				candidate.Governance.QuorumBPS = *govDelta.QuorumBPS
+			}
+			if govDelta.PassThresholdBPS != nil {
+				candidate.Governance.PassThresholdBPS = *govDelta.PassThresholdBPS
+			}
+			if govDelta.VotingPeriodSecs != nil {
+				candidate.Governance.VotingPeriodSecs = *govDelta.VotingPeriodSecs
+			}
+		}
+		if slashDelta != nil {
+			if slashDelta.MinWindowSecs != nil {
+				candidate.Slashing.MinWindowSecs = *slashDelta.MinWindowSecs
+			}
+			if slashDelta.MaxWindowSecs != nil {
+				candidate.Slashing.MaxWindowSecs = *slashDelta.MaxWindowSecs
+			}
+		}
+		if memDelta != nil && memDelta.MaxBytes != nil {
+			candidate.Mempool.MaxBytes = *memDelta.MaxBytes
+		}
+		if blockDelta != nil && blockDelta.MaxTxs != nil {
+			candidate.Blocks.MaxTxs = *blockDelta.MaxTxs
+		}
+
+		if err := config.ValidateConfig(candidate); err != nil {
+			t.Fatalf("preflight succeeded but config invalid: %v", err)
+		}
+	})
+}
+
+func normalizePositive(v uint64) uint64 {
+	if v == 0 {
+		return 1
+	}
+	return v
+}
+
+func normalizePositive64(v int64) int64 {
+	if v == math.MinInt64 {
+		return math.MaxInt64
+	}
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/tests/fuzz/lending_amounts_fuzz.go
+++ b/tests/fuzz/lending_amounts_fuzz.go
@@ -1,0 +1,201 @@
+package fuzz
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	"nhbchain/native/lending"
+)
+
+var (
+	lendingRay     = mustBig("1000000000000000000000000000")
+	lendingHalfRay = new(big.Int).Rsh(lendingRay, 1)
+)
+
+type lendingFuzzState struct {
+	market   *lending.Market
+	users    map[string]*lending.UserAccount
+	accounts map[string]*types.Account
+	fees     *lending.FeeAccrual
+}
+
+func newLendingFuzzState() *lendingFuzzState {
+	return &lendingFuzzState{
+		users:    make(map[string]*lending.UserAccount),
+		accounts: make(map[string]*types.Account),
+	}
+}
+
+func (s *lendingFuzzState) key(addr crypto.Address) string {
+	return string(addr.Bytes())
+}
+
+func (s *lendingFuzzState) GetMarket(string) (*lending.Market, error) { return s.market, nil }
+
+func (s *lendingFuzzState) PutMarket(_ string, market *lending.Market) error {
+	s.market = market
+	return nil
+}
+
+func (s *lendingFuzzState) GetUserAccount(_ string, addr crypto.Address) (*lending.UserAccount, error) {
+	if account, ok := s.users[s.key(addr)]; ok {
+		return account, nil
+	}
+	return nil, nil
+}
+
+func (s *lendingFuzzState) PutUserAccount(_ string, account *lending.UserAccount) error {
+	if account == nil {
+		return nil
+	}
+	s.users[s.key(account.Address)] = account
+	return nil
+}
+
+func (s *lendingFuzzState) GetAccount(addr crypto.Address) (*types.Account, error) {
+	if account, ok := s.accounts[s.key(addr)]; ok {
+		if account.BalanceNHB == nil {
+			account.BalanceNHB = big.NewInt(0)
+		}
+		if account.BalanceZNHB == nil {
+			account.BalanceZNHB = big.NewInt(0)
+		}
+		return account, nil
+	}
+	return nil, nil
+}
+
+func (s *lendingFuzzState) PutAccount(addr crypto.Address, account *types.Account) error {
+	s.accounts[s.key(addr)] = account
+	return nil
+}
+
+func (s *lendingFuzzState) GetFeeAccrual(string) (*lending.FeeAccrual, error) { return s.fees, nil }
+
+func (s *lendingFuzzState) PutFeeAccrual(_ string, fees *lending.FeeAccrual) error {
+	s.fees = fees
+	return nil
+}
+
+func FuzzLendingSupplyWithdrawAmounts(f *testing.F) {
+	moduleAddr := makeAddress(crypto.NHBPrefix, 0x51)
+	collateralAddr := makeAddress(crypto.ZNHBPrefix, 0x52)
+	supplier := makeAddress(crypto.NHBPrefix, 0x53)
+
+	f.Add(int64(1_000_000_000_000), int64(7), int64(3))
+	f.Add(int64(42), int64(13), int64(17))
+
+	f.Fuzz(func(t *testing.T, depositRaw int64, _ int64, indexScale int64) {
+		amount := big.NewInt(absInt64(depositRaw)%1_000_000_000_000_000 + 1)
+		scale := absInt64(indexScale)%50 + 1
+		index := new(big.Int).Mul(lendingRay, big.NewInt(scale))
+		initialShares := mustBig("1000000000000000000000")
+		initialSupply := liquidityFromShares(initialShares, index)
+
+		state := newLendingFuzzState()
+		state.market = &lending.Market{
+			PoolID:            "default",
+			TotalNHBSupplied:  new(big.Int).Set(initialSupply),
+			TotalSupplyShares: new(big.Int).Set(initialShares),
+			TotalNHBBorrowed:  big.NewInt(0),
+			SupplyIndex:       new(big.Int).Set(index),
+			BorrowIndex:       new(big.Int).Set(lendingRay),
+		}
+		state.accounts[state.key(moduleAddr)] = &types.Account{BalanceNHB: new(big.Int).Set(initialSupply), BalanceZNHB: big.NewInt(0)}
+		buffer := mustBig("100000000000000000000")
+		supplierBalance := new(big.Int).Add(buffer, amount)
+		state.accounts[state.key(supplier)] = &types.Account{BalanceNHB: supplierBalance, BalanceZNHB: big.NewInt(0)}
+
+		engine := lending.NewEngine(moduleAddr, collateralAddr, lending.RiskParameters{})
+		engine.SetPoolID("default")
+		engine.SetState(state)
+
+		minted, err := engine.Supply(supplier, amount)
+		if err != nil {
+			if state.market.TotalNHBSupplied.Cmp(initialSupply) != 0 {
+				t.Fatalf("supply failure mutated liquidity: got %s want %s", state.market.TotalNHBSupplied, initialSupply)
+			}
+			return
+		}
+		if minted == nil || minted.Sign() <= 0 {
+			t.Fatalf("minted shares must be positive")
+		}
+
+		expectedShares := new(big.Int).Add(initialShares, minted)
+		if state.market.TotalSupplyShares.Cmp(expectedShares) != 0 {
+			t.Fatalf("share tally mismatch: got %s want %s", state.market.TotalSupplyShares, expectedShares)
+		}
+		if state.market.TotalNHBSupplied.Sign() <= 0 {
+			t.Fatalf("total supplied became non-positive")
+		}
+		moduleAcc, _ := state.GetAccount(moduleAddr)
+		if moduleAcc == nil || moduleAcc.BalanceNHB.Sign() < 0 {
+			t.Fatalf("module balance invalid")
+		}
+		userAccount, _ := state.GetUserAccount("default", supplier)
+		if userAccount == nil || userAccount.SupplyShares.Cmp(minted) != 0 {
+			t.Fatalf("user shares not tracked: got %v want %v", userAccount, minted)
+		}
+
+		redeemed, err := engine.Withdraw(supplier, minted)
+		if err != nil {
+			t.Fatalf("withdrawing freshly minted shares failed: %v", err)
+		}
+		if redeemed == nil || redeemed.Sign() <= 0 {
+			t.Fatalf("redeemed amount must be positive")
+		}
+		if state.market.TotalSupplyShares.Cmp(initialShares) != 0 {
+			t.Fatalf("total shares not restored: got %s want %s", state.market.TotalSupplyShares, initialShares)
+		}
+		if state.market.TotalNHBSupplied.Cmp(initialSupply) < 0 {
+			t.Fatalf("total supplied underflow: got %s want >= %s", state.market.TotalNHBSupplied, initialSupply)
+		}
+		moduleAfter, _ := state.GetAccount(moduleAddr)
+		if moduleAfter == nil || moduleAfter.BalanceNHB.Sign() < 0 {
+			t.Fatalf("module balance negative after withdraw")
+		}
+		if moduleAfter.BalanceNHB.Cmp(state.market.TotalNHBSupplied) != 0 {
+			t.Fatalf("module balance and market supply diverged: %s vs %s", moduleAfter.BalanceNHB, state.market.TotalNHBSupplied)
+		}
+		if userAfter, _ := state.GetUserAccount("default", supplier); userAfter != nil && userAfter.SupplyShares.Sign() != 0 {
+			t.Fatalf("user shares not cleared after withdraw: %s", userAfter.SupplyShares)
+		}
+	})
+}
+
+func makeAddress(prefix crypto.AddressPrefix, suffix byte) crypto.Address {
+	raw := make([]byte, 20)
+	raw[len(raw)-1] = suffix
+	return crypto.NewAddress(prefix, raw)
+}
+
+func mustBig(value string) *big.Int {
+	out, ok := new(big.Int).SetString(value, 10)
+	if !ok {
+		panic("invalid big int constant")
+	}
+	return out
+}
+
+func absInt64(v int64) int64 {
+	if v == math.MinInt64 {
+		return math.MaxInt64
+	}
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func liquidityFromShares(shares, index *big.Int) *big.Int {
+	if shares == nil || shares.Sign() <= 0 || index == nil || index.Sign() == 0 {
+		return big.NewInt(0)
+	}
+	scaled := new(big.Int).Mul(shares, index)
+	scaled.Add(scaled, lendingHalfRay)
+	scaled.Quo(scaled, lendingRay)
+	return scaled
+}


### PR DESCRIPTION
## Summary
- add a regression test ensuring the lending supply half-up rounding behavior accepts dusty deposits
- add fuzz targets covering creator URI sanitization, governance policy deltas, and lending supply/withdrawal accounting

## Testing
- `go test ./tests/lending ./tests/gov ./tests/creator ./tests/fuzz`

------
https://chatgpt.com/codex/tasks/task_e_68d8c507f3dc832d808aa7d34ff33bb2