### PR TITLE
Enforce TLS requirement for network client dials

### DIFF
--- a/config-local.toml
+++ b/config-local.toml
@@ -43,6 +43,9 @@ ClientVersion = "nhbchain/node"
 # Leave the shared secret empty for single-host development. Set SharedSecret or
 # SharedSecretEnv when deploying consensusd and p2pd on separate machines.
 SharedSecret = ""
+# Local development defaults to plaintext; production operators must provision TLS
+# and set AllowInsecure = false.
+AllowInsecure = true
 # ServerTLSCertFile = "./tls/p2pd.crt"
 # ServerTLSKeyFile = "./tls/p2pd.key"
 # ClientTLSCertFile = "./tls/consensus.crt"

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ type NetworkSecurity struct {
 	ClientCAFile             string   `toml:"ClientCAFile"`
 	ClientTLSCertFile        string   `toml:"ClientTLSCertFile"`
 	ClientTLSKeyFile         string   `toml:"ClientTLSKeyFile"`
+	AllowInsecure            bool     `toml:"AllowInsecure"`
 	SharedSecret             string   `toml:"SharedSecret"`
 	SharedSecretFile         string   `toml:"SharedSecretFile"`
 	SharedSecretEnv          string   `toml:"SharedSecretEnv"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -150,6 +150,9 @@ PEX = false
 	if cfg.NetworkSecurity.ClientTLSCertFile != "./tls/client.crt" || cfg.NetworkSecurity.ClientTLSKeyFile != "./tls/client.key" {
 		t.Fatalf("unexpected client tls paths: %+v", cfg.NetworkSecurity)
 	}
+	if cfg.NetworkSecurity.AllowInsecure {
+		t.Fatalf("expected AllowInsecure to default to false")
+	}
 	if cfg.NetworkSecurity.ServerName != "p2pd.internal" {
 		t.Fatalf("unexpected server name: %s", cfg.NetworkSecurity.ServerName)
 	}

--- a/docs/networking/ops.md
+++ b/docs/networking/ops.md
@@ -47,6 +47,8 @@ connection:
 SharedSecretEnv = "NHB_NETWORK_SHARED_SECRET"
 SharedSecretFile = "/etc/nhb/network.token"
 SharedSecret = ""
+# Explicit opt-in is required for plaintext connections.
+AllowInsecure = false
 # Metadata header that carries the token (default: "authorization").
 AuthorizationHeader = "x-nhb-network-token"
 
@@ -71,7 +73,10 @@ service enforces it on `Gossip`, `DialPeer`, and `BanPeer` requests; client
 certificates are validated against the `AllowedClientCommonNames` allowlist when
 provided. `consensusd` consumes the same block to dial with
 `grpc.WithTransportCredentials` and per-RPC metadata so authenticated traffic
-continues to flow while unauthenticated requests are rejected.
+continues to flow while unauthenticated requests are rejected. Beginning with
+this release, `consensusd` refuses to fall back to plaintext; operators must
+ship valid TLS material or explicitly set `AllowInsecure = true` for short-lived
+lab environments.
 
 ## Seeds
 

--- a/docs/runbooks/p2pd-failover.md
+++ b/docs/runbooks/p2pd-failover.md
@@ -32,8 +32,9 @@ If a warm standby is available:
 ## 5. Post-Recovery Checks
 
 * Confirm `consensusd` reports height progression.
-* Run `grpcurl -plaintext <p2pd>:9091 network.v1.NetworkService/ListPeers` to verify
-  active peers.
+* Run `grpcurl <p2pd>:9091 network.v1.NetworkService/ListPeers` with the issued TLS
+  material to verify active peers. Use `-plaintext` only when the deployment has
+  explicitly set `AllowInsecure = true` for a lab environment.
 * Ensure rate limits and scoring metrics reset as expected.
 
 ## 6. Root Cause Analysis

--- a/tests/system/network_security_test.go
+++ b/tests/system/network_security_test.go
@@ -41,7 +41,7 @@ func TestNetworkServiceSharedSecretAuth(t *testing.T) {
 	// Unauthenticated gossip stream should fail.
 	unauthCtx, cancelUnauth := context.WithTimeout(context.Background(), 2*time.Second)
 	t.Cleanup(cancelUnauth)
-	unauthClient, err := network.Dial(unauthCtx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	unauthClient, err := network.Dial(unauthCtx, addr, true, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("dial unauth: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestNetworkServiceSharedSecretAuth(t *testing.T) {
 	// Authenticated stream should remain connected until the context is cancelled.
 	authCtx, cancelAuth := context.WithCancel(context.Background())
 	defer cancelAuth()
-	authClient, err := network.Dial(authCtx, addr,
+	authClient, err := network.Dial(authCtx, addr, true,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithPerRPCCredentials(network.NewStaticTokenCredentials(header, secret)),
 	)


### PR DESCRIPTION
## Summary
- default the network client to TLS, requiring callers to opt-in before allowing insecure transports
- plumb an AllowInsecure switch through consensusd configuration and tests so plaintext is only used intentionally
- document the TLS requirement in operator guides and local configuration samples

## Testing
- go test ./... *(fails: deploy/compose/Dockerfile.go:1:1: illegal character U+0023 '#')*

------
https://chatgpt.com/codex/tasks/task_e_68d8cd64005c832d9b9d09fb41aa5262