### PR TITLE
Require TLS for shared-secret RPC credentials

### DIFF
--- a/docs/networking/ops.md
+++ b/docs/networking/ops.md
@@ -43,7 +43,9 @@ connection:
 ```toml
 [network_security]
 # Shared-secret token transmitted with every RPC. The value is resolved in the
-# following order: environment variable, external file, inline string.
+# following order: environment variable, external file, inline string. When a
+# shared secret is configured the client now requires TLS unless
+# `AllowInsecure = true` is explicitly set for a throwaway lab environment.
 SharedSecretEnv = "NHB_NETWORK_SHARED_SECRET"
 SharedSecretFile = "/etc/nhb/network.token"
 SharedSecret = ""

--- a/tests/system/network_security_test.go
+++ b/tests/system/network_security_test.go
@@ -66,7 +66,7 @@ func TestNetworkServiceSharedSecretAuth(t *testing.T) {
 	defer cancelAuth()
 	authClient, err := network.Dial(authCtx, addr, true,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithPerRPCCredentials(network.NewStaticTokenCredentials(header, secret)),
+		grpc.WithPerRPCCredentials(network.NewStaticTokenCredentialsAllowInsecure(header, secret)),
 	)
 	if err != nil {
 		t.Fatalf("dial auth: %v", err)
@@ -85,7 +85,7 @@ func TestNetworkServiceSharedSecretAuth(t *testing.T) {
 	// Authenticated unary calls should reach the service (even if the relay has no backing server).
 	authConn, err := grpc.DialContext(context.Background(), addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithPerRPCCredentials(network.NewStaticTokenCredentials(header, secret)),
+		grpc.WithPerRPCCredentials(network.NewStaticTokenCredentialsAllowInsecure(header, secret)),
 	)
 	if err != nil {
 		t.Fatalf("dial auth conn: %v", err)


### PR DESCRIPTION
## Summary
- require TLS for shared-secret per-RPC credentials when a token is configured
- add an explicit insecure helper for tests and update the system harness accordingly
- document that shared-secret authentication now mandates TLS unless insecure mode is enabled

## Testing
- `go test ./network -count=1`
- `go test ./tests/system -run NetworkServiceSharedSecretAuth -count=1` *(fails: build error in core/node.go: "no new variables on left side of :=")*

------
https://chatgpt.com/codex/tasks/task_e_68d8cf74b1c8832d9704c5823cc5f13e