### PR TITLE
Require credentials for network read RPCs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,19 +64,20 @@ type Config struct {
 // NetworkSecurity captures TLS and shared-secret settings for the internal gRPC
 // bridge between consensusd and p2pd.
 type NetworkSecurity struct {
-	ServerTLSCertFile        string   `toml:"ServerTLSCertFile"`
-	ServerTLSKeyFile         string   `toml:"ServerTLSKeyFile"`
-	ServerCAFile             string   `toml:"ServerCAFile"`
-	ClientCAFile             string   `toml:"ClientCAFile"`
-	ClientTLSCertFile        string   `toml:"ClientTLSCertFile"`
-	ClientTLSKeyFile         string   `toml:"ClientTLSKeyFile"`
-	AllowInsecure            bool     `toml:"AllowInsecure"`
-	SharedSecret             string   `toml:"SharedSecret"`
-	SharedSecretFile         string   `toml:"SharedSecretFile"`
-	SharedSecretEnv          string   `toml:"SharedSecretEnv"`
-	AuthorizationHeader      string   `toml:"AuthorizationHeader"`
-	AllowedClientCommonNames []string `toml:"AllowedClientCommonNames"`
-	ServerName               string   `toml:"ServerName"`
+	ServerTLSCertFile         string   `toml:"ServerTLSCertFile"`
+	ServerTLSKeyFile          string   `toml:"ServerTLSKeyFile"`
+	ServerCAFile              string   `toml:"ServerCAFile"`
+	ClientCAFile              string   `toml:"ClientCAFile"`
+	ClientTLSCertFile         string   `toml:"ClientTLSCertFile"`
+	ClientTLSKeyFile          string   `toml:"ClientTLSKeyFile"`
+	AllowInsecure             bool     `toml:"AllowInsecure"`
+	AllowUnauthenticatedReads bool     `toml:"AllowUnauthenticatedReads"`
+	SharedSecret              string   `toml:"SharedSecret"`
+	SharedSecretFile          string   `toml:"SharedSecretFile"`
+	SharedSecretEnv           string   `toml:"SharedSecretEnv"`
+	AuthorizationHeader       string   `toml:"AuthorizationHeader"`
+	AllowedClientCommonNames  []string `toml:"AllowedClientCommonNames"`
+	ServerName                string   `toml:"ServerName"`
 }
 
 // AuthorizationHeaderName returns the metadata header that carries the

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,6 +153,9 @@ PEX = false
 	if cfg.NetworkSecurity.AllowInsecure {
 		t.Fatalf("expected AllowInsecure to default to false")
 	}
+	if cfg.NetworkSecurity.AllowUnauthenticatedReads {
+		t.Fatalf("expected AllowUnauthenticatedReads to default to false")
+	}
 	if cfg.NetworkSecurity.ServerName != "p2pd.internal" {
 		t.Fatalf("unexpected server name: %s", cfg.NetworkSecurity.ServerName)
 	}


### PR DESCRIPTION
## Summary
- require the NetworkService GetView and ListPeers RPCs to authorize requests and add a read-authenticator override
- thread a new AllowUnauthenticatedReads toggle through configuration so p2pd can allow anonymous reads when explicitly enabled
- extend the network security tests and documentation to cover the tightened defaults and optional anonymous access

## Testing
- `go test ./network ./tests/system` *(fails: core/node.go build error unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d29811f4832dbe1544321e1b5579