### PR TITLE
Instrument relay queue metrics and make size configurable

### DIFF
--- a/cmd/consensusd/main.go
+++ b/cmd/consensusd/main.go
@@ -243,7 +243,7 @@ func main() {
 		panic(fmt.Sprintf("failed to initialise network client security: %v", err))
 	}
 
-	go maintainNetworkStream(ctx, *networkAddress, broadcaster, node, allowInsecureNetwork, networkDialOpts)
+	go maintainNetworkStream(ctx, *networkAddress, broadcaster, node, allowInsecureNetwork, networkDialOpts, cfg.NetworkSecurity.StreamQueueSize)
 
 	bftEngine := bft.NewEngine(node, privKey, broadcaster)
 	node.SetBftEngine(bftEngine)
@@ -283,7 +283,7 @@ const (
 	networkReconnectMaxDelay  = 30 * time.Second
 )
 
-func maintainNetworkStream(ctx context.Context, target string, broadcaster *resilientBroadcaster, node *core.Node, allowInsecure bool, dialOpts []grpc.DialOption) {
+func maintainNetworkStream(ctx context.Context, target string, broadcaster *resilientBroadcaster, node *core.Node, allowInsecure bool, dialOpts []grpc.DialOption, queueSize int) {
 	if broadcaster == nil || node == nil {
 		return
 	}
@@ -311,6 +311,7 @@ func maintainNetworkStream(ctx context.Context, target string, broadcaster *resi
 			continue
 		}
 
+		client.SetSendQueueSize(queueSize)
 		broadcaster.SetClient(client)
 		backoff = networkReconnectBaseDelay
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -162,6 +162,12 @@ PEX = false
 	if len(cfg.NetworkSecurity.AllowedClientCommonNames) != 1 || cfg.NetworkSecurity.AllowedClientCommonNames[0] != "consensusd" {
 		t.Fatalf("unexpected allowed common names: %v", cfg.NetworkSecurity.AllowedClientCommonNames)
 	}
+	if cfg.NetworkSecurity.StreamQueueSize != defaultStreamQueueSize {
+		t.Fatalf("unexpected stream queue size: %d", cfg.NetworkSecurity.StreamQueueSize)
+	}
+	if cfg.NetworkSecurity.RelayDropLogRatio != defaultRelayDropLogRatio {
+		t.Fatalf("unexpected relay drop log ratio: %f", cfg.NetworkSecurity.RelayDropLogRatio)
+	}
 	if len(cfg.Bootnodes) != 1 || cfg.Bootnodes[0] != "1.1.1.1:6001" {
 		t.Fatalf("bootnodes not parsed: %v", cfg.Bootnodes)
 	}

--- a/docs/runbooks/p2pd-failover.md
+++ b/docs/runbooks/p2pd-failover.md
@@ -7,6 +7,7 @@ consensus connectivity.
 
 * Alert triggers for missing heartbeats or gRPC health failures.
 * Logs from `consensusd` showing repeated reconnect attempts.
+* Prometheus alerts on sustained `nhb_network_relay_queue_dropped_total` increases or elevated queue occupancy.
 
 ## 2. Validate Environment
 
@@ -36,6 +37,11 @@ If a warm standby is available:
   material to verify active peers. Use `-plaintext` only when the deployment has
   explicitly set `AllowInsecure = true` for a lab environment.
 * Ensure rate limits and scoring metrics reset as expected.
+* Inspect relay queue health:
+  - `nhb_network_relay_queue_enqueued_total` vs `nhb_network_relay_queue_dropped_total` to confirm drop ratio is below the configured threshold.
+  - `nhb_network_relay_queue_occupancy` should trend well under the configured queue size except during brief spikes.
+  - Structured logs tagged `component=network_relay` emit warnings once the drop ratio breaches `network_security.RelayDropLogRatio` (default 0.1).
+* Tune `network_security.StreamQueueSize` when sustained occupancy nears capacity. Increase the buffer gradually (e.g., +64) and redeploy both `p2pd` and `consensusd` so the client send queue stays aligned with the relay size.
 
 ## 6. Root Cause Analysis
 

--- a/network/metrics.go
+++ b/network/metrics.go
@@ -1,0 +1,49 @@
+package network
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type relayMetrics struct {
+	enqueued  prometheus.Counter
+	dropped   prometheus.Counter
+	occupancy prometheus.Gauge
+}
+
+var (
+	relayMetricsOnce sync.Once
+	relayRegistry    *relayMetrics
+)
+
+func defaultRelayMetrics() *relayMetrics {
+	relayMetricsOnce.Do(func() {
+		relayRegistry = &relayMetrics{
+			enqueued: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: "nhb",
+				Subsystem: "network_relay",
+				Name:      "queue_enqueued_total",
+				Help:      "Total envelopes successfully enqueued onto the consensus relay stream.",
+			}),
+			dropped: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: "nhb",
+				Subsystem: "network_relay",
+				Name:      "queue_dropped_total",
+				Help:      "Total envelopes dropped because the consensus relay queue was full.",
+			}),
+			occupancy: prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace: "nhb",
+				Subsystem: "network_relay",
+				Name:      "queue_occupancy",
+				Help:      "Point-in-time occupancy of the consensus relay send queue prior to enqueue attempts.",
+			}),
+		}
+		prometheus.MustRegister(
+			relayRegistry.enqueued,
+			relayRegistry.dropped,
+			relayRegistry.occupancy,
+		)
+	})
+	return relayRegistry
+}


### PR DESCRIPTION
## Summary
- instrument the network relay queue with Prometheus counters, a live occupancy gauge, and structured alerts when drops breach the configured ratio
- add network_security knobs for stream queue size and drop alert ratio, wiring them through p2pd and consensusd to keep relay and client buffers aligned
- document the new metrics and tuning guidance in the p2pd failover runbook for SRE alerting and capacity planning

## Testing
- go test ./... *(fails: deploy/compose/Dockerfile.go:1:1: illegal character U+0023 '#')*
- go build ./network


------
https://chatgpt.com/codex/tasks/task_e_68d8d3530c7c832d98ea03f18d3a8dbe