### PR TITLE
Persist creator rate limit windows

### DIFF
--- a/tests/creator/state_test.go
+++ b/tests/creator/state_test.go
@@ -12,6 +12,7 @@ type testState struct {
 	stakes   map[string]*creator.Stake
 	ledgers  map[string]*creator.PayoutLedger
 	accounts map[string]*types.Account
+	rate     *creator.RateLimitSnapshot
 }
 
 func newTestState() *testState {
@@ -107,6 +108,22 @@ func (s *testState) CreatorPayoutLedgerPut(ledger *creator.PayoutLedger) error {
 		return nil
 	}
 	s.ledgers[string(ledger.Creator[:])] = ledger.Clone()
+	return nil
+}
+
+func (s *testState) CreatorRateLimitGet() (*creator.RateLimitSnapshot, bool, error) {
+	if s.rate == nil {
+		return nil, false, nil
+	}
+	return s.rate.Clone(), true, nil
+}
+
+func (s *testState) CreatorRateLimitPut(snapshot *creator.RateLimitSnapshot) error {
+	if snapshot == nil {
+		s.rate = nil
+		return nil
+	}
+	s.rate = snapshot.Clone()
 	return nil
 }
 

--- a/tests/fuzz/creator_uri_fuzz.go
+++ b/tests/fuzz/creator_uri_fuzz.go
@@ -66,6 +66,12 @@ func (s *fuzzCreatorState) GetAccount([]byte) (*types.Account, error) { return n
 
 func (s *fuzzCreatorState) PutAccount([]byte, *types.Account) error { return nil }
 
+func (s *fuzzCreatorState) CreatorRateLimitGet() (*creator.RateLimitSnapshot, bool, error) {
+	return nil, false, nil
+}
+
+func (s *fuzzCreatorState) CreatorRateLimitPut(*creator.RateLimitSnapshot) error { return nil }
+
 func FuzzCreatorURISanitization(f *testing.F) {
 	seeds := []string{
 		"https://example.com/content",


### PR DESCRIPTION
## Summary
- persist stake and tip rate limit windows through a state-backed snapshot in the creator engine
- add rate limit snapshot types plus storage support for encoding/decoding the windows
- update mocks and add regression tests covering rate-limit persistence across restarts

## Testing
- go test ./native/creator

------
https://chatgpt.com/codex/tasks/task_e_68d8e1b55e30832db7dd79c906482a47