### PR TITLE
Persist velocity window for swap risk engine

### DIFF
--- a/core/node.go
+++ b/core/node.go
@@ -3675,7 +3675,7 @@ func (n *Node) SwapSubmitVoucher(submission *swap.VoucherSubmission) (string, bo
 		return "", false, err
 	}
 
-	if err := riskEngine.RecordMint(voucher.Recipient, voucher.Amount); err != nil {
+	if err := riskEngine.RecordMint(voucher.Recipient, voucher.Amount, riskParams.VelocityWindowSeconds); err != nil {
 		return "", false, err
 	}
 


### PR DESCRIPTION
## Summary
- pass the configured velocity window through mint recording so velocity samples prune against the active interval and persist the chosen window alongside samples
- extend swap risk tests to verify both enforcement and stored samples honor the configured velocity window

## Testing
- go test ./native/swap

------
https://chatgpt.com/codex/tasks/task_e_68d8f2adccbc832db9ecddceee480cef