### PR TITLE
Add audit and operations documentation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ NHBCoin abstracts away the traditional complexities of crypto networks. Native a
 - [Command-Line Interface](#command-line-interface)
 - [APIs, SDKs, and Documentation](#apis-sdks-and-documentation)
 - [Security, Compliance, and Operations](#security-compliance-and-operations)
+  - [Audit & Operations Reference Library](#audit--operations-reference-library)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
 - [Legal Notice & License](#legal-notice--license)
@@ -217,6 +218,14 @@ All protocol modules ship with reference documentation under [`docs/`](./docs):
 - **Observability** — Monitor validator uptime, engagement scores, and staking state using CLI commands or forthcoming telemetry dashboards. Forward RPC/WAF logs to your SIEM so abuse attempts can be correlated with P2P events.
 - **Compliance Alignment** — Native identity modules provide audit trails, verified contact points, and consent-driven discovery suitable for regulatory review.
 - **Audits & Bug Bounty** — We run an ongoing [bug bounty program](docs/security/bug-bounty.md) and maintain an [audit readiness guide](docs/security/audit-readiness.md) with frozen commits, reproducible builds, and fixtures for third-party assessors.
+
+### Audit & Operations Reference Library
+
+- **Audit phases:** [Overview](docs/audit/overview.md), [Static analysis](docs/audit/static-analysis.md), [Fuzzing](docs/audit/fuzzing.md), [End-to-end flows](docs/audit/e2e-flows.md), [Documentation quality](docs/audit/docs-quality.md), and [Reconnaissance](docs/audit/recon.md).
+- **Consensus:** [BFT height sync](docs/consensus/bft-height-sync.md), [Consensus invariants](docs/consensus/invariants.md).
+- **Performance:** [Baselines](docs/perf/baselines.md), [Tuning guide](docs/perf/tuning.md).
+- **Security:** [Network security](docs/security/networking.md), [Supply chain security](docs/security/supply-chain.md).
+- **Operations:** [Configuration guardrails](docs/ops/configuration.md), [Snapshot operations](docs/ops/snapshots.md), [Validator runbook](docs/ops/validator-runbook.md).
 
 ### Operational Audit Harness
 

--- a/docs/audit/docs-quality.md
+++ b/docs/audit/docs-quality.md
@@ -1,0 +1,37 @@
+# Documentation Quality Review Guide
+
+Strong documentation ensures audit findings can be reproduced and remediations can be executed quickly. Use this checklist to evaluate the completeness and accuracy of technical content across the project.
+
+## Scope
+
+- Service READMEs (`services/*/README.md`)
+- Operational runbooks (`docs/runbooks/`, `docs/ops/`)
+- Architecture overviews (`docs/architecture/`, `docs/consensus/`)
+- Onboarding guides (`docs/overview/`, `docs/sdk/`)
+
+## Evaluation criteria
+
+1. **Accuracy.** Verify instructions align with the current codebase and configuration defaults.
+2. **Completeness.** Ensure critical workflows (deployment, upgrade, rollback, incident response) are covered end-to-end.
+3. **Freshness.** Check commit history or embedded version tags to confirm the document has been updated within the last two releases.
+4. **Traceability.** Confirm references link to actual code paths, dashboards, or runbooks.
+5. **Accessibility.** Content should be concise, use consistent terminology, and provide prerequisite context.
+
+## Review process
+
+- Sample at least one document from each scope category.
+- Walk through the steps as if you were a new operator; note missing prerequisites or ambiguous commands.
+- Capture screenshots or logs when instructions are unclear or produce unexpected results.
+- Create tickets for stale diagrams, broken links, or missing cross-references.
+
+## Deliverables
+
+- Annotated checklist summarizing which documents were reviewed and any action items.
+- Pull requests or issues filed to address identified gaps.
+- Suggested improvements to the documentation style guide (if recurring problems emerge).
+
+## Exit criteria
+
+- No critical documentation gaps remain unresolved.
+- Runbooks and READMEs referenced during the audit include working commands and updated links.
+- Audit artifact bundle includes the completed checklist and remediation tickets.

--- a/docs/audit/e2e-flows.md
+++ b/docs/audit/e2e-flows.md
@@ -1,0 +1,43 @@
+# End-to-End Flow Validation Guide
+
+End-to-end (E2E) testing verifies that user-critical workflows continue to operate once code and configuration changes land. This guide covers environment setup, execution, and interpreting the resulting telemetry.
+
+## Core flows
+
+| Flow | Components | Success signals |
+| --- | --- | --- |
+| Retail payment | Wallet → Gateway → Consensus | Transaction confirmed on-chain, receipt in gateway logs, customer notification emitted. |
+| OTC voucher mint | Back-office → Swap RPC → Reconciler | Voucher minted on-chain, reconciler exports CSV/Parquet with no anomalies. |
+| Validator join | Bootstrapper → Consensus node → Monitoring | Node catches up to latest height, shares state snapshot, alerts remain green. |
+| Bridge transfer | External chain → Relayer → nhbchain | Proof accepted, assets minted/burned with finality metrics recorded. |
+
+## Environment preparation
+
+1. **Select a target network.** Use devnet for rapid iteration, staging for production-like checks, and mainnet only for observability audits.
+2. **Provision data.** Seed accounts with known balances, configure OTC vouchers, and prepare validator keys as needed.
+3. **Enable tracing and metrics.** Ensure Jaeger/Tempo, Prometheus, and log aggregation are active so failures can be diagnosed.
+4. **Snapshot baseline dashboards.** Capture pre-run metrics for comparison.
+
+## Running test scenarios
+
+- Execute scripted flows using `make e2e` or service-specific CLI helpers (e.g., `cmd/nhbchain` for validator actions).
+- For manual runs, follow the runbooks referenced in `docs/runbooks/` and record every command executed.
+- Tag test transactions with unique memos or metadata so they can be located in block explorers and logs.
+
+## Observability checklist
+
+- **Logs:** Confirm expected log entries appear in gateway, consensus, and relayer services. Flag errors and warnings for follow-up.
+- **Metrics:** Compare latency, error rate, and throughput counters to baseline values. Note any deviations larger than 10%.
+- **Traces:** Inspect distributed traces for long spans (>2x baseline) or missing instrumentation.
+
+## Failure handling
+
+1. Capture logs, metrics screenshots, and trace IDs immediately.
+2. File an incident or bug ticket with reproduction steps and environment details.
+3. Coordinate with service owners to triage and verify fixes.
+
+## Exit criteria
+
+- All core flows complete without critical alerts or untriaged regressions.
+- Evidence (logs, metrics, traces) is archived in the audit artifact store.
+- Runbooks are updated if manual steps changed or new remediation procedures were required.

--- a/docs/audit/fuzzing.md
+++ b/docs/audit/fuzzing.md
@@ -1,0 +1,46 @@
+# Fuzzing Guide
+
+Fuzzing validates the resilience of consensus-critical, cryptographic, and financial components under unexpected input. Follow this guide to configure fuzzers, capture crashes, and interpret results.
+
+## Targets
+
+| Component | Location | Harness |
+| --- | --- | --- |
+| Consensus state transitions | `consensus/` | `go test ./consensus/... -run TestStateTransitionFuzz -fuzz=.` |
+| Crypto primitives | `crypto/` | Go fuzz targets under `*_test.go` files (e.g., `TestSignatureFuzz`). |
+| Gateway order processing | `services/otc-gateway/` | `go test ./services/otc-gateway/... -run TestVoucherFuzz -fuzz=.` |
+| SDK transaction builders | `sdk/` | `go test ./sdk/... -run TestTxBuilderFuzz -fuzz=.` |
+
+## Setup
+
+1. Ensure Go 1.20+ is installed (`go env GOVERSION`).
+2. Set `GOFUZZNOCOMPRESS=1` and `GOMAXPROCS` to match available cores for deterministic reproduction.
+3. Configure timeouts using `-fuzztime=5m` (adjust per target) to balance coverage and runtime.
+4. Create a dedicated `artifacts/fuzz/` directory to store crash seeds and logs.
+
+## Running fuzzers
+
+```bash
+GOFUZZNOCOMPRESS=1 go test ./consensus/... -run TestStateTransitionFuzz -fuzz=. -fuzztime=10m -fuzzminimize
+```
+
+Repeat for each target, adjusting packages and time budgets. Monitor CPU and memory usage to prevent host instability.
+
+## Crash triage
+
+1. **Reproduce.** Run the reported seed with `go test -run TestStateTransitionFuzz -fuzz=. -fuzztime=1x -fuzzseed=<seed>`.
+2. **Classify impact.** Determine whether the failure affects consensus safety, liveness, or results in denial-of-service.
+3. **File an issue.** Include stack traces, minimized corpus inputs, and suspected root cause.
+4. **Verify fixes.** Add regression unit tests or invariants and re-run the fuzzer to ensure the seed no longer crashes.
+
+## Corpus management
+
+- Commit known-good seed corpora under `tests/fuzz/<target>/` for reproducibility.
+- Periodically prune redundant seeds to keep iterations fast.
+- Share crash artifacts via the audit folder with timestamps and reproduction commands.
+
+## Exit criteria
+
+- No unreproduced crashes remain.
+- High-impact bugs have validated fixes with associated regression tests.
+- Fuzzer coverage reports show steady state (no new edges found) for at least two runs of the configured duration.

--- a/docs/audit/overview.md
+++ b/docs/audit/overview.md
@@ -1,0 +1,40 @@
+# Audit Overview
+
+This guide outlines how to plan and execute the multi-phase audit program for the nhbchain stack. Teams should use it as the entry point when preparing an engagement or triaging findings.
+
+## Objectives
+
+- Establish the scope of services, smart contracts, infrastructure, and operational processes under review.
+- Define audit phases, owners, timelines, and the expected artifacts for each deliverable.
+- Capture success criteria and exit gates so the team knows when the audit is considered complete.
+
+## Phase sequencing
+
+1. **Reconnaissance & documentation review.** Inventory system diagrams, data flows, third-party dependencies, and production infrastructure notes. Confirm that operators can supply configuration snapshots and chain state exports on request.
+2. **Static analysis.** Run automated code scanning across the repository, tracking suppressions and interpreting rule coverage gaps.
+3. **Fuzzing.** Stress consensus-critical and financial components to surface panics, invariant violations, and state divergence.
+4. **End-to-end flows.** Exercise integration paths (wallets, gateways, bridge jobs) against realistic environments to detect regressions that automation may miss.
+5. **Documentation quality.** Ensure runbooks and READMEs enable operators and auditors to reproduce findings and respond to incidents.
+6. **Remediation & sign-off.** Track fixes through issue management, confirm regression tests exist, and capture the closing statement for leadership.
+
+## Roles & responsibilities
+
+| Role | Responsibilities |
+| --- | --- |
+| Audit coordinator | Maintains the schedule, collects artifacts, and facilitates sign-off. |
+| Security engineer | Leads technical review of code, infrastructure, and operational configurations. |
+| Service owner | Provides subject matter expertise, performs fixes, and validates remediation tests. |
+| Compliance | Confirms controls alignment, ensures retention policies are respected, and signs off on procedural coverage. |
+
+## Artifact checklist
+
+- Scoped checklist describing in-scope repositories, services, and chains.
+- Static-analysis findings report with issue owners and statuses.
+- Fuzzer crash triage spreadsheet with reproduction steps and mitigations.
+- E2E test transcripts (logs, traces, metrics dashboards) for each major workflow.
+- Documentation gaps list referencing the relevant runbooks or READMEs.
+- Final audit summary with outstanding risks, compensating controls, and follow-up actions.
+
+## Using this directory
+
+Each phase has its own guide under `docs/audit/`. Start with this overview, then work through the specific playbooks as you execute the engagement.

--- a/docs/audit/static-analysis.md
+++ b/docs/audit/static-analysis.md
@@ -1,0 +1,41 @@
+# Static Analysis Guide
+
+This playbook explains how to run and interpret static-analysis tooling across nhbchain repositories. Use it to produce repeatable reports and to prioritize actionable findings.
+
+## Toolchain
+
+| Tool | Location | Purpose |
+| --- | --- | --- |
+| `golangci-lint` | `make lint` | Go code linting, vetting, and static checks across services. |
+| `buf lint` | `proto/` | Protocol buffer linting and breaking change detection. |
+| `npm run lint` | `gateway/`, `services/` front-end packages | Ensures TypeScript/JavaScript adherence to project style and catches unsafe patterns. |
+| `semgrep` | Repository root | Searches for vulnerability patterns beyond language-specific linters. |
+
+## Running the pipeline
+
+1. **Bootstrap dependencies.** Run `make deps` to install Go linters and ensure Node packages are present where required.
+2. **Execute language linters.**
+   - For Go services, run `make lint` from the repository root.
+   - For protocol buffers, run `buf lint` within the `proto/` directory.
+   - For TypeScript packages, run `npm run lint` inside each package (`gateway/`, `services/web/`, etc.).
+3. **Semgrep sweep.** Execute `semgrep ci --config=auto` from the root to aggregate rule packs. Capture the SARIF output for archival.
+4. **Record suppressions.** Any rule suppressions must be justified in the findings tracker with a link to the code and the rationale.
+
+## Triage workflow
+
+- **Categorize findings** as blocker, high, medium, low, or informational based on impact and exploitability.
+- **Validate reachability.** Confirm whether flagged code is reachable in production deployments; false positives should be documented.
+- **Check remediation status.** Track each issue in the audit board with an owner, fix version, and verification notes.
+- **Re-run linters** after fixes to confirm the findings no longer appear and to catch regressions.
+
+## Reporting
+
+- Export linter logs (`make lint`, `buf lint`, package-specific linting) and attach them to the audit artifact bundle.
+- Summarize outstanding issues in the static-analysis section of the final audit report, including remediation ETAs and compensating controls.
+- Highlight systemic themes (for example, missing input validation or unchecked errors) that require broader engineering action.
+
+## Exit criteria
+
+- No blocker or high findings remain untriaged without an approved mitigation plan.
+- All suppressions are reviewed and documented.
+- Final report contains links to raw logs and tracking tickets.

--- a/docs/consensus/invariants.md
+++ b/docs/consensus/invariants.md
@@ -1,0 +1,30 @@
+# Consensus Invariants
+
+This document records the safety and liveness invariants that consensus engineers and auditors must uphold when modifying nhbchain's core protocols.
+
+## State machine invariants
+
+1. **Deterministic execution.** Given the same block inputs and prior state, every validator must produce the same resulting state root. Side-effecting I/O or non-deterministic randomness is prohibited in state transitions.
+2. **Monotonic heights.** Block heights increase by exactly one with each committed block. Any deviation signals a fork or database corruption.
+3. **Validator set consistency.** Changes to the validator set must be applied at the end of a block and take effect on the subsequent height, ensuring all nodes agree on the active set.
+4. **Total stake conservation.** Slashing, staking, and rewards must balance so that total recorded stake equals previous stake plus net issuance minus penalties.
+5. **Fee accounting.** Gas and transaction fees must be deducted exactly once and routed to the configured sink address.
+
+## Networking invariants
+
+- **Quorum availability.** At least `2f + 1` voting power must participate in pre-commit for a block to finalize. Monitor for persistent drops below quorum.
+- **Peer scoring.** Misbehaving peers should be demoted or banned without affecting well-behaved connections.
+- **Evidence propagation.** Equivocation and light-client attack evidence must be gossiped across the network within the unbonding window.
+
+## Upgrade invariants
+
+- **Genesis compatibility.** Upgrades must transform state in a single block and preserve existing account balances and governance records.
+- **Parameter migrations.** Changes to parameter schemas require default values for legacy fields and migration routines that backfill missing data.
+- **Replay protection.** Nodes that replay blocks through an upgrade must produce identical app hashes to freshly synced nodes.
+
+## Validation checklist
+
+- Add unit tests asserting invariant preservation for new state-transition code.
+- Run the integration test suite (`make test-integration`) after protocol changes.
+- Capture before/after snapshots of validator sets and stake totals for manual verification.
+- Document any temporary deviations (e.g., emergency governance actions) in the upgrade notes with rollback instructions.

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -94,3 +94,22 @@ block events when a client breaches either ceiling.【F:native/system/quotas/sto
 See [Pause and quota runbook](../runbooks/pause-and-quotas.md) for operational
 recipes, including copy-paste commands that dump the live pause state, submit a
 pause transaction, inspect quota usage, and stage a safe cap increase.
+
+## Change management
+
+- Stage configuration changes in staging using the same templates as production.
+- Submit configuration diffs through version control; avoid editing files directly on servers.
+- Require dual approval for parameter changes impacting governance, slashing, or block production.
+
+## Drift detection
+
+- Export effective runtime configuration weekly using `nhbchain config dump` and store in the configuration repository.
+- Compare dumps against the committed templates using `git diff` or `terraform plan` (for infrastructure-managed configs).
+- Alert when critical fields (pauses, quotas, peer limits) diverge from approved values.
+
+## Emergency procedures
+
+1. Document the triggering event and the configuration change requested.
+2. Take a snapshot or backup of the current configuration files.
+3. Apply the minimal necessary change and record the command history.
+4. Notify governance and security within 24 hours, and file a post-incident review.

--- a/docs/ops/snapshots.md
+++ b/docs/ops/snapshots.md
@@ -1,0 +1,35 @@
+# Snapshot Operations Guide
+
+Snapshots let operators bootstrap validators and archive historical state efficiently. This guide documents creation, distribution, and restoration procedures.
+
+## Snapshot cadence
+
+- Produce full snapshots weekly for each network (devnet, staging, mainnet).
+- Generate incremental snapshots daily between full exports.
+- Retain at least four weeks of snapshots to support delayed recovery.
+
+## Creation workflow
+
+1. Pause heavy background jobs to reduce I/O contention.
+2. Run `nhbchain snapshot export --output /data/snapshots/<height>.tar.gz` on a healthy validator.
+3. Record the app hash, block height, and exporter node ID in the snapshot manifest.
+4. Resume background jobs and confirm the validator rejoins consensus.
+
+## Distribution
+
+- Upload snapshots to the dedicated object storage bucket with server-side encryption.
+- Generate SHA256 checksums and publish them alongside download URLs.
+- Restrict write access to snapshot buckets and monitor access logs.
+
+## Restoration
+
+1. Download the desired snapshot and verify the checksum.
+2. Extract to the node data directory: `tar -xzf <height>.tar.gz -C $NHB_HOME`.
+3. Start `consensusd` with `--statesync.snapshot-height <height>` if state sync is required.
+4. Monitor logs for fast-sync completion and compare app hash to the manifest.
+
+## Validation
+
+- After each snapshot cycle, perform a restore test in staging.
+- Track restore duration and document any manual interventions required.
+- Update this guide if tooling or retention policies change.

--- a/docs/perf/baselines.md
+++ b/docs/perf/baselines.md
@@ -1,0 +1,40 @@
+# Performance Baselines
+
+Use this document to record the throughput and latency expectations for nhbchain components. Operators should track these metrics continuously to detect regressions during releases.
+
+## Consensus
+
+| Metric | Target | Measurement |
+| --- | --- | --- |
+| Block time | 2.5s ± 0.5s | `consensus.block_interval_seconds` Prometheus gauge |
+| Transactions per second | 300 TPS sustained | `consensus.tx_applied_total` rate |
+| Finality lag | < 5s | Difference between block time and `consensus.finalized_height` timestamps |
+
+## Gateway
+
+| Metric | Target | Measurement |
+| --- | --- | --- |
+| API p95 latency | < 250ms | `http_server_request_duration_seconds` histogram |
+| Order ingest rate | 100 rps sustained | `gateway.orders_ingested_total` rate |
+| Voucher mint SLA | < 60s | Difference between request timestamp and mint confirmation |
+
+## OTC Reconciler
+
+| Metric | Target | Measurement |
+| --- | --- | --- |
+| Reconciliation duration | < 10 minutes per 24h window | Scheduler logs and `recon_run_duration_seconds` metric |
+| Anomaly rate | < 1% of invoices | Ratio of flagged rows to total invoices |
+
+## Validator operations
+
+| Metric | Target | Measurement |
+| --- | --- | --- |
+| State sync duration | < 30 minutes from snapshot | Operator logs and `consensus.statesync_duration_seconds` |
+| Gossip peers | ≥ 30 stable peers | `p2p_peer_count` gauge |
+| CPU utilization | < 75% sustained | Node exporter metrics |
+
+## Tracking and alerts
+
+- Store baseline values in Grafana dashboards tagged `baseline:true`.
+- Configure alert rules to trigger when metrics exceed ±20% of baseline for two consecutive evaluation periods.
+- Re-baseline after major releases or infrastructure changes and update this document with the new targets.

--- a/docs/perf/tuning.md
+++ b/docs/perf/tuning.md
@@ -1,0 +1,31 @@
+# Performance Tuning Guide
+
+This guide captures tuning levers that help operators meet or exceed the performance baselines for nhbchain services.
+
+## Consensus nodes
+
+- **Database tuning.**
+  - Enable `GODEBUG=memprofilerate=0` when profiling to reduce allocation overhead during benchmarking.
+  - Configure RocksDB or the underlying KV store with high-compaction trigger thresholds to avoid background stalls.
+  - Place state and WAL directories on separate NVMe volumes where possible.
+- **Mempool sizing.** Set `global.mempool.MaxBytes` to at least 64 MB on high-throughput validators. Monitor eviction rates (`mempool_evicted_total`).
+- **P2P networking.** Increase the inbound/outbound peer limits in `config.toml` for data centers with sufficient bandwidth, but keep them symmetric to prevent gossip imbalances.
+
+## Gateway services
+
+- **Connection pools.** Tune database and RPC client pools based on p95 latency. Start at 2× CPU cores and adjust after load testing.
+- **Caching.** Configure HTTP response caching for idempotent endpoints (account lookups, rate tables). Validate cache TTLs against compliance requirements.
+- **Async processing.** Offload blocking operations (file exports, invoicing) to background workers to keep API latency predictable.
+
+## Observability-driven tuning
+
+1. **Profile hotspots.** Use `pprof` or `go tool trace` during load tests to identify CPU or lock contention.
+2. **Adjust parameters.** Modify relevant configuration (mempool size, worker counts, queue depths) and document the change.
+3. **Measure impact.** Re-run the benchmark and compare to the baselines recorded in `docs/perf/baselines.md`.
+4. **Roll out carefully.** Apply changes to staging first, monitor for 24 hours, then promote to production with a rollback plan.
+
+## Capacity planning
+
+- Run quarterly load tests using the `tests/load/` scenarios.
+- Capture TPS, latency, and resource usage across consensus, gateway, and database layers.
+- Update the operations runbooks with new resource requirements (CPU, RAM, storage) when sustained usage approaches 70% of capacity.

--- a/docs/security/networking.md
+++ b/docs/security/networking.md
@@ -1,0 +1,34 @@
+# Network Security Playbook
+
+This guide documents the controls and monitoring required to protect nhbchain's networking stack.
+
+## Perimeter controls
+
+- **Ingress filtering.** Allow RPC, gRPC, and P2P ports only from trusted CIDR ranges. Deny all other inbound traffic by default.
+- **DDoS mitigation.** Front public RPC endpoints with rate limiting (Cloudflare, Envoy) and enable SYN flood protection at the load balancer.
+- **TLS enforcement.** Use mutual TLS for validator-to-validator links and TLS 1.2+ with modern ciphers for public APIs.
+
+## Internal segmentation
+
+- Place validators, gateways, and data stores in separate network segments. Use firewall rules to restrict lateral movement.
+- Require jump hosts or VPN for administrative access, with MFA and hardware-backed SSH keys.
+- Monitor East-West traffic for unusual spikes or protocol usage.
+
+## Monitoring
+
+- Collect NetFlow or VPC flow logs and store them for at least 90 days.
+- Configure IDS/IPS (Zeek, Suricata) on validator segments. Alert on protocol violations, known malware signatures, or unexpected ports.
+- Instrument Prometheus with connection count, handshake failure, and TLS renegotiation metrics.
+
+## Incident response
+
+1. Isolate affected nodes by updating security groups or firewall rules.
+2. Rotate validator keys if compromise is suspected.
+3. Replay flow logs to determine ingress origin and attack duration.
+4. File an incident report and coordinate with the governance body for any on-chain mitigations.
+
+## Maintenance
+
+- Review firewall rules quarterly.
+- Patch network appliances and load balancers within 14 days of a critical CVE.
+- Test failover paths and firewall backups annually.

--- a/docs/security/supply-chain.md
+++ b/docs/security/supply-chain.md
@@ -1,0 +1,34 @@
+# Supply Chain Security Guide
+
+This document covers controls for managing dependencies, build systems, and release artifacts.
+
+## Dependency management
+
+- **Lockfiles.** Commit `go.sum`, `package-lock.json`, and equivalent files. Regenerate on updates to detect tampering.
+- **Source pinning.** Use tagged releases or commit hashes for third-party modules. Avoid floating `latest` references.
+- **Vulnerability scanning.** Run `go list -m -u all` and `npm audit` monthly. Track findings in the security backlog.
+
+## Build pipeline
+
+- **Reproducible builds.** Configure CI to build from clean containers with pinned base images. Compare build hashes between CI and local reproducible runs.
+- **Code signing.** Sign binaries and container images using `cosign` with keys stored in HSM or KMS.
+- **Access controls.** Restrict who can modify CI/CD pipelines. Require code review for pipeline changes.
+
+## Artifact distribution
+
+- Store release artifacts in immutable object storage with versioning enabled.
+- Publish checksums and signatures alongside downloads.
+- Maintain an SBOM (e.g., `syft packages dir`) for each release and archive it with the release notes.
+
+## Incident handling
+
+1. Freeze releases and notify stakeholders.
+2. Identify the compromised dependency or build step.
+3. Patch or replace affected components, regenerate artifacts, and update signatures.
+4. Document the incident in `docs/security/disclosure.md` with remediation steps and follow-up actions.
+
+## Continuous improvement
+
+- Conduct quarterly dependency review meetings with engineering leads.
+- Rotate signing keys annually or after any suspected compromise.
+- Automate SBOM generation and verification in CI to catch drift early.


### PR DESCRIPTION
## Summary
- add dedicated audit playbooks for each phase including static analysis, fuzzing, e2e validation, and documentation review
- document consensus invariants, performance baselines, tuning levers, security controls, and operational snapshot procedures
- cross-link the new references from the README for quick discovery during reviews

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d940f2d834832d94cec79d8455a50a