### PR TITLE
Add preview scaffolding for stable swapd engine

### DIFF
--- a/docs/swap/stable-api.md
+++ b/docs/swap/stable-api.md
@@ -1,0 +1,43 @@
+# Stable Swapd API (Preview)
+
+> **Note**: The stable engine is under active development. The current implementation exposes
+> endpoints that respond with `501 Not Implemented` until the pricing, reservation, and
+> cash-out flows are fully wired in.
+
+## Configuration
+
+The `services/swapd/config.yaml` file now contains an optional `stable` section to describe
+preview parameters for the future engine:
+
+```yaml
+stable:
+  paused: true
+  quote_ttl: "1m"
+  max_slippage_bps: 50
+  soft_inventory: 1000000
+  assets:
+    - symbol: ZNHB
+      base: ZNHB
+      quote: USD
+```
+
+Setting `paused: true` keeps the engine disabled while allowing operators to stage
+asset definitions. When `paused` is `false`, at least one asset entry is required.
+
+## HTTP Endpoints
+
+The server reserves the following paths:
+
+- `POST /v1/stable/quote`
+- `POST /v1/stable/reserve`
+- `POST /v1/stable/cashout`
+- `GET /v1/stable/status`
+- `GET /v1/stable/limits`
+
+All endpoints currently return:
+
+```json
+{"error": "stable engine not enabled"}
+```
+
+Future revisions will flesh out request/response schemas and enforcement logic.

--- a/services/swapd/config.yaml
+++ b/services/swapd/config.yaml
@@ -22,3 +22,12 @@ policy:
   mint_limit: 10
   redeem_limit: 5
   window: "1h"
+stable:
+  paused: true
+  quote_ttl: "1m"
+  max_slippage_bps: 50
+  soft_inventory: 1000000
+  assets:
+    - symbol: ZNHB
+      base: ZNHB
+      quote: USD

--- a/services/swapd/server/server.go
+++ b/services/swapd/server/server.go
@@ -57,6 +57,7 @@ func (s *Server) Run(ctx context.Context) error {
 	mux.Handle("/healthz", otelhttp.NewHandler(http.HandlerFunc(s.handleHealth), "swapd.health"))
 	mux.Handle("/admin/policy", otelhttp.NewHandler(http.HandlerFunc(s.handlePolicy), "swapd.policy"))
 	mux.Handle("/admin/throttle/check", otelhttp.NewHandler(http.HandlerFunc(s.handleThrottleCheck), "swapd.throttle"))
+	s.registerStableHandlers(mux)
 
 	srv := &http.Server{Addr: s.cfg.ListenAddress, Handler: mux}
 

--- a/services/swapd/server/stable_handlers.go
+++ b/services/swapd/server/stable_handlers.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (s *Server) registerStableHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/stable/quote", s.handleStableNotImplemented)
+	mux.HandleFunc("/v1/stable/reserve", s.handleStableNotImplemented)
+	mux.HandleFunc("/v1/stable/cashout", s.handleStableNotImplemented)
+	mux.HandleFunc("/v1/stable/status", s.handleStableNotImplemented)
+	mux.HandleFunc("/v1/stable/limits", s.handleStableNotImplemented)
+}
+
+func (s *Server) handleStableNotImplemented(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotImplemented)
+	json.NewEncoder(w).Encode(map[string]string{"error": "stable engine not enabled"})
+}

--- a/services/swapd/stable/cashout.go
+++ b/services/swapd/stable/cashout.go
@@ -1,0 +1,22 @@
+package stable
+
+import "context"
+
+// CashOutRequest represents a request to create a cash-out intent.
+type CashOutRequest struct {
+	ReservationID string
+}
+
+// CashOutResponse wraps the newly created intent.
+type CashOutResponse struct {
+	Intent CashOutIntent
+}
+
+// CashOut creates a placeholder intent from a reservation.
+func (e *Engine) CashOut(ctx context.Context, req CashOutRequest) (CashOutResponse, error) {
+	intent, err := e.CreateCashOutIntent(ctx, req.ReservationID)
+	if err != nil {
+		return CashOutResponse{}, err
+	}
+	return CashOutResponse{Intent: intent}, nil
+}

--- a/services/swapd/stable/engine.go
+++ b/services/swapd/stable/engine.go
@@ -1,0 +1,168 @@
+package stable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Engine provides a high level facade for pricing and reservation flows.
+type Engine struct {
+	mu      sync.RWMutex
+	assets  map[string]Asset
+	limits  Limits
+	quotes  map[string]Quote
+	reserve map[string]Reservation
+	clock   func() time.Time
+}
+
+// Asset captures a supported stable asset and its parameters.
+type Asset struct {
+	Symbol         string
+	BasePair       string
+	QuotePair      string
+	QuoteTTL       time.Duration
+	MaxSlippageBps int
+	SoftInventory  int64
+}
+
+// Limits represent soft throttles for intents.
+type Limits struct {
+	DailyCap int64
+}
+
+// Quote represents a computed exchange quote.
+type Quote struct {
+	ID        string
+	Asset     string
+	Price     float64
+	ExpiresAt time.Time
+}
+
+// Reservation represents a reserved quote.
+type Reservation struct {
+	QuoteID   string
+	AmountIn  float64
+	AmountOut float64
+	ExpiresAt time.Time
+	Account   string
+}
+
+// ErrNotSupported is returned when an asset or action is unavailable.
+var ErrNotSupported = errors.New("asset not supported")
+
+// NewEngine constructs an Engine from assets and limits.
+func NewEngine(assets []Asset, limits Limits) (*Engine, error) {
+	if len(assets) == 0 {
+		return nil, fmt.Errorf("at least one asset must be configured")
+	}
+	assetMap := make(map[string]Asset, len(assets))
+	for _, asset := range assets {
+		if strings.TrimSpace(asset.Symbol) == "" {
+			return nil, fmt.Errorf("asset missing symbol")
+		}
+		assetMap[strings.ToUpper(asset.Symbol)] = asset
+	}
+	return &Engine{
+		assets:  assetMap,
+		limits:  limits,
+		quotes:  make(map[string]Quote),
+		reserve: make(map[string]Reservation),
+		clock:   time.Now,
+	}, nil
+}
+
+// WithClock overrides the engine clock for deterministic tests.
+func (e *Engine) WithClock(clock func() time.Time) {
+	if clock == nil {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.clock = clock
+}
+
+// PriceQuote calculates a simple quote placeholder.
+func (e *Engine) PriceQuote(ctx context.Context, asset string, amount float64) (Quote, error) {
+	_ = ctx
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	assetCfg, ok := e.assets[strings.ToUpper(asset)]
+	if !ok {
+		return Quote{}, ErrNotSupported
+	}
+	now := e.clock()
+	quote := Quote{
+		ID:        fmt.Sprintf("q-%d", now.UnixNano()),
+		Asset:     assetCfg.Symbol,
+		Price:     amount,
+		ExpiresAt: now.Add(assetCfg.QuoteTTL),
+	}
+	e.quotes[quote.ID] = quote
+	return quote, nil
+}
+
+// ReserveQuote reserves an existing quote for execution.
+func (e *Engine) ReserveQuote(ctx context.Context, id, account string, amountIn float64) (Reservation, error) {
+	_ = ctx
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	quote, ok := e.quotes[id]
+	if !ok {
+		return Reservation{}, fmt.Errorf("quote not found")
+	}
+	now := e.clock()
+	if !quote.ExpiresAt.IsZero() && now.After(quote.ExpiresAt) {
+		delete(e.quotes, id)
+		return Reservation{}, fmt.Errorf("quote expired")
+	}
+	res := Reservation{
+		QuoteID:   quote.ID,
+		AmountIn:  amountIn,
+		AmountOut: amountIn,
+		ExpiresAt: quote.ExpiresAt,
+		Account:   account,
+	}
+	e.reserve[quote.ID] = res
+	return res, nil
+}
+
+// CashOutIntent is a placeholder for intent creation.
+type CashOutIntent struct {
+	ReservationID string
+	Amount        float64
+	CreatedAt     time.Time
+}
+
+// CreateCashOutIntent returns a stub intent.
+func (e *Engine) CreateCashOutIntent(ctx context.Context, reservationID string) (CashOutIntent, error) {
+	_ = ctx
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	res, ok := e.reserve[reservationID]
+	if !ok {
+		return CashOutIntent{}, fmt.Errorf("reservation not found")
+	}
+	return CashOutIntent{
+		ReservationID: reservationID,
+		Amount:        res.AmountOut,
+		CreatedAt:     e.clock(),
+	}, nil
+}
+
+// Status summarises in-memory counters for observability.
+type Status struct {
+	Quotes       int
+	Reservations int
+	Assets       int
+}
+
+// Status returns a lightweight snapshot of the engine state.
+func (e *Engine) Status(ctx context.Context) Status {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return Status{Quotes: len(e.quotes), Reservations: len(e.reserve), Assets: len(e.assets)}
+}

--- a/services/swapd/stable/quotes.go
+++ b/services/swapd/stable/quotes.go
@@ -1,0 +1,23 @@
+package stable
+
+import "context"
+
+// QuoteRequest describes input for a quote calculation.
+type QuoteRequest struct {
+	Asset  string
+	Amount float64
+}
+
+// QuoteResponse wraps the result of a quote lookup.
+type QuoteResponse struct {
+	Quote Quote
+}
+
+// Price computes a quote using the engine.
+func (e *Engine) Price(ctx context.Context, req QuoteRequest) (QuoteResponse, error) {
+	quote, err := e.PriceQuote(ctx, req.Asset, req.Amount)
+	if err != nil {
+		return QuoteResponse{}, err
+	}
+	return QuoteResponse{Quote: quote}, nil
+}

--- a/services/swapd/stable/reserve.go
+++ b/services/swapd/stable/reserve.go
@@ -1,0 +1,24 @@
+package stable
+
+import "context"
+
+// ReserveRequest captures the required fields for a reservation.
+type ReserveRequest struct {
+	QuoteID  string
+	Account  string
+	AmountIn float64
+}
+
+// ReserveResponse returns the confirmed reservation details.
+type ReserveResponse struct {
+	Reservation Reservation
+}
+
+// Reserve locks a quote and creates a reservation placeholder.
+func (e *Engine) Reserve(ctx context.Context, req ReserveRequest) (ReserveResponse, error) {
+	reservation, err := e.ReserveQuote(ctx, req.QuoteID, req.Account, req.AmountIn)
+	if err != nil {
+		return ReserveResponse{}, err
+	}
+	return ReserveResponse{Reservation: reservation}, nil
+}

--- a/tests/swapd/stable_e2e_test.go
+++ b/tests/swapd/stable_e2e_test.go
@@ -1,0 +1,7 @@
+package swapd
+
+import "testing"
+
+func TestStablePreview(t *testing.T) {
+	t.Skip("stable engine preview not yet implemented")
+}


### PR DESCRIPTION
## Summary
- extend swapd configuration with a preview `stable` section and document the upcoming API
- add stub stable engine types plus HTTP endpoints that currently respond with not-implemented
- add a placeholder end-to-end test that is skipped until the stable engine is complete

## Testing
- go test ./... *(fails: deploy/compose/Dockerfile.go:1:1: illegal character U+0023 '#')*


------
https://chatgpt.com/codex/tasks/task_e_68d98c657d8c832d8edcce082fd41f61