### PR TITLE
Add swap risk guardrails and invariants

### DIFF
--- a/docs/swap/risk-controls.md
+++ b/docs/swap/risk-controls.md
@@ -4,17 +4,32 @@ The SWAP-4 upgrade introduces deterministic guardrails around on-ramp mints so o
 
 ## Configuration
 
-Configure limits in `config.toml` under `[swap.risk]` and the provider allow list under `[swap.providers]`.
+Configure limits in `config.toml` under `[swap]`, `[swap.risk]`, and `[swap.providers]`.
 
 ```toml
-[swap.risk]
-PerAddressDailyCapWei = "10000e18"
-PerAddressMonthlyCapWei = "300000e18"
-PerTxMinWei = "1e18"
-PerTxMaxWei = "50000e18"
-VelocityWindowSeconds = 600
-VelocityMaxMints = 5
-SanctionsCheckEnabled = true
+[swap]
+SlippageBps = 50
+MaxQuoteAgeSeconds = 120
+PriceProofMaxDeviationBps = 100
+
+  [swap.risk]
+  PerAddressDailyCapWei = "10000e18"
+  PerAddressMonthlyCapWei = "300000e18"
+  PerTxMinWei = "1e18"
+  PerTxMaxWei = "50000e18"
+  VelocityWindowSeconds = 600
+  VelocityMaxMints = 5
+  SanctionsCheckEnabled = true
+
+    [swap.risk.cashOut]
+    [[swap.risk.cashOut.AssetCaps]]
+    Asset = "USDC"
+    DailyCapWei = "750000e6"
+
+    [[swap.risk.cashOut.Tiers]]
+    Tier = "gold"
+    DailyCapWei = "25000e18"
+    MonthlyCapWei = "750000e18"
 
 [swap.providers]
 Allow = ["nowpayments"]
@@ -22,12 +37,17 @@ Allow = ["nowpayments"]
 
 | Setting | Description |
 | --- | --- |
+| `SlippageBps` | Maximum allowed voucher/mint deviation in basis points. `0` disables the guard. |
+| `MaxQuoteAgeSeconds` | Oracle quote freshness window; stale samples block minting. |
+| `PriceProofMaxDeviationBps` | Maximum deviation between the signed price proof and the previous observation. |
 | `PerTxMinWei` | Reject vouchers below this mint amount. `0` disables the check. |
 | `PerTxMaxWei` | Reject vouchers above this mint amount. |
 | `PerAddressDailyCapWei` | Aggregate recipient mints per UTC day and block the next mint when the cap is exceeded. |
 | `PerAddressMonthlyCapWei` | Aggregate per calendar month using UTC. |
 | `VelocityWindowSeconds` & `VelocityMaxMints` | Count successful mints inside a rolling window and block the next mint when the count reaches `VelocityMaxMints`. |
 | `SanctionsCheckEnabled` | When `true`, run the sanctions hook before minting. |
+| `cashOut.AssetCaps` | Per-stable-asset daily ceilings for fiat redemptions. Pending escrow counts toward the limit. |
+| `cashOut.Tiers` | KYC tier caps for cash-outs. Supply daily and monthly limits; blank values disable the guard. |
 | `[swap.providers].Allow` | Lower-case allow list of PSP identifiers. Empty array allows all providers. |
 
 All numeric values accept scientific notation (e.g. `10000e18`).
@@ -36,9 +56,13 @@ All numeric values accept scientific notation (e.g. `10000e18`).
 
 1. **Provider allow-list** – Rejects vouchers whose `provider` field is not in the allow list. Emits `swap.alert.limit_hit` with `limit=provider`.
 2. **Sanctions hook** – Calls the configured checker. A `false` response blocks the mint and emits `swap.alert.sanction`.
-3. **Per-transaction limits** – Enforced before checking historical buckets. Violations emit `swap.alert.limit_hit` with `limit=per_tx_min` or `per_tx_max`.
-4. **Daily & monthly caps** – UTC buckets keyed per address. Hitting a cap blocks the mint and emits `swap.alert.limit_hit` with `limit=daily_cap` or `monthly_cap`.
-5. **Velocity window** – Evaluates mints inside the configured rolling window and emits `swap.alert.velocity` when the threshold is met. The event reports `windowSeconds`, `allowedMints`, and the observed count.
+3. **Oracle guardrails** – The signed price proof must be fresh (`MaxQuoteAgeSeconds`) and within the configured deviation window (`PriceProofMaxDeviationBps`). Violations emit `swap.alert.oracle` with `limit=oracle_stale` or `limit=oracle_deviation`.
+4. **Slippage tolerance** – The computed mint amount must be within `SlippageBps` of the voucher amount. Violations emit `swap.alert.limit_hit` with `limit=slippage`.
+5. **Per-transaction limits** – Enforced before checking historical buckets. Violations emit `swap.alert.limit_hit` with `limit=per_tx_min` or `per_tx_max`.
+6. **Daily & monthly caps** – UTC buckets keyed per address. Hitting a cap blocks the mint and emits `swap.alert.limit_hit` with `limit=daily_cap` or `monthly_cap`.
+7. **Velocity window** – Evaluates mints inside the configured rolling window and emits `swap.alert.velocity` when the threshold is met. The event reports `windowSeconds`, `allowedMints`, and the observed count.
+8. **Cash-out caps** – Asset and tier caps include pending escrow before locking additional NHB. Violations emit `swap.alert.limit_hit` with `limit=cashout_asset_cap` or `limit=cashout_tier_cap`.
+9. **Pause lever** – Governance can flip `Pauses.Swap` to immediately reject voucher submissions with `swap.alert.limit_hit` (`limit=module_paused`). The same switch blocks cash-out intents.
 
 All alerts are appended to the state event log for audit trails.
 
@@ -47,14 +71,29 @@ All alerts are appended to the state event log for audit trails.
 Use governance or manual updates to raise limits temporarily:
 
 ```toml
-[swap.risk]
-PerAddressDailyCapWei = "25000e18"
-PerAddressMonthlyCapWei = "500000e18"
-PerTxMinWei = "5e18"
-PerTxMaxWei = "75000e18"
-VelocityWindowSeconds = 900
-VelocityMaxMints = 3
-SanctionsCheckEnabled = true
+[swap]
+SlippageBps = 75
+MaxQuoteAgeSeconds = 90
+PriceProofMaxDeviationBps = 50
+
+  [swap.risk]
+  PerAddressDailyCapWei = "25000e18"
+  PerAddressMonthlyCapWei = "500000e18"
+  PerTxMinWei = "5e18"
+  PerTxMaxWei = "75000e18"
+  VelocityWindowSeconds = 900
+  VelocityMaxMints = 3
+  SanctionsCheckEnabled = true
+
+    [swap.risk.cashOut]
+    [[swap.risk.cashOut.AssetCaps]]
+    Asset = "USDT"
+    DailyCapWei = "500000e6"
+
+    [[swap.risk.cashOut.Tiers]]
+    Tier = "silver"
+    DailyCapWei = "15000e18"
+    MonthlyCapWei = "250000e18"
 ```
 
 Restart the node (or trigger a config reload) after editing the file to apply the new guardrails.
@@ -65,6 +104,7 @@ Restart the node (or trigger a config reload) after editing the file to apply th
   * `swap.alert.limit_hit`
   * `swap.alert.velocity`
   * `swap.alert.sanction`
+  * `swap.alert.oracle`
 * Inspect counters via the new RPC:
 
 ```json
@@ -76,14 +116,15 @@ Restart the node (or trigger a config reload) after editing the file to apply th
 }
 ```
 
-The response includes day/month totals, remaining capacity, and velocity observations for the address.
+The response includes day/month totals, remaining capacity, velocity observations, and cash-out cap status for the address.
 
 ## Operational Tips
 
 * Use `go run ./examples/docs/ops/read_pauses` to double-check that the swap
   module remains active before investigating PSP escalations. Engage governance
   with `go run ./examples/docs/ops/pause_toggle --module swap --state pause`
-  when you need to halt minting.
+  when you need to halt minting. Pausing the module also blocks cash-out intents.
 * Set `VelocityWindowSeconds` high enough to account for expected PSP bursts but low enough to prevent scripted abuse.
+* Tune `SlippageBps`, `MaxQuoteAgeSeconds`, and `PriceProofMaxDeviationBps` together so the oracle and voucher pipeline stay aligned.
 * Use the optional `cmd/swap-audit` tool to print the currently loaded configuration: `go run ./cmd/swap-audit --config ./config.toml`.
 * When raising limits for incident response, document the change in the compliance log and ensure alerts are reviewed for potential abuse attempts.

--- a/native/swap/params.go
+++ b/native/swap/params.go
@@ -1,0 +1,232 @@
+package swap
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"strings"
+	"time"
+)
+
+// SlippageTolerance captures the allowed deviation between the computed mint amount
+// and the submitted voucher amount. Values are expressed in basis points.
+type SlippageTolerance struct {
+	MaxBps uint64
+}
+
+// NewSlippageTolerance constructs a slippage tolerance guardrail, validating the
+// configured ceiling falls within a reasonable domain.
+func NewSlippageTolerance(bps uint64) (SlippageTolerance, error) {
+	if bps > 10000 {
+		return SlippageTolerance{}, fmt.Errorf("swap: slippage tolerance must not exceed 10000 bps")
+	}
+	return SlippageTolerance{MaxBps: bps}, nil
+}
+
+// Enabled reports whether the tolerance will enforce deviations.
+func (s SlippageTolerance) Enabled() bool {
+	return s.MaxBps > 0
+}
+
+// OracleGuardrails describes oracle freshness and deviation tolerances.
+type OracleGuardrails struct {
+	MaxAge          time.Duration
+	MaxDeviationBps uint64
+}
+
+// NewOracleGuardrails normalises the supplied parameters and verifies bounds.
+func NewOracleGuardrails(maxAge time.Duration, deviation uint64) (OracleGuardrails, error) {
+	if maxAge < 0 {
+		return OracleGuardrails{}, fmt.Errorf("swap: oracle max age must be positive")
+	}
+	if deviation > 10000 {
+		return OracleGuardrails{}, fmt.Errorf("swap: oracle deviation must not exceed 10000 bps")
+	}
+	return OracleGuardrails{MaxAge: maxAge, MaxDeviationBps: deviation}, nil
+}
+
+// CashOutAssetCapConfig models a per-asset daily cap parsed from configuration.
+type CashOutAssetCapConfig struct {
+	Asset       string `toml:"Asset"`
+	DailyCapWei string `toml:"DailyCapWei"`
+}
+
+// CashOutTierConfig models a KYC tier cap parsed from configuration.
+type CashOutTierConfig struct {
+	Tier          string `toml:"Tier"`
+	DailyCapWei   string `toml:"DailyCapWei"`
+	MonthlyCapWei string `toml:"MonthlyCapWei"`
+}
+
+// CashOutConfig aggregates the cash-out risk controls sourced from configuration.
+type CashOutConfig struct {
+	AssetCaps []CashOutAssetCapConfig `toml:"AssetCaps"`
+	Tiers     []CashOutTierConfig     `toml:"Tiers"`
+}
+
+// Normalise trims whitespace, removes duplicates, and applies canonical casing.
+func (cfg CashOutConfig) Normalise() CashOutConfig {
+	normalized := CashOutConfig{}
+	if len(cfg.AssetCaps) > 0 {
+		seen := make(map[string]struct{}, len(cfg.AssetCaps))
+		for _, entry := range cfg.AssetCaps {
+			asset := strings.ToUpper(strings.TrimSpace(entry.Asset))
+			if asset == "" {
+				continue
+			}
+			if _, exists := seen[asset]; exists {
+				continue
+			}
+			seen[asset] = struct{}{}
+			normalized.AssetCaps = append(normalized.AssetCaps, CashOutAssetCapConfig{
+				Asset:       asset,
+				DailyCapWei: strings.TrimSpace(entry.DailyCapWei),
+			})
+		}
+		sort.Slice(normalized.AssetCaps, func(i, j int) bool {
+			return normalized.AssetCaps[i].Asset < normalized.AssetCaps[j].Asset
+		})
+	}
+	if len(cfg.Tiers) > 0 {
+		seen := make(map[string]struct{}, len(cfg.Tiers))
+		for _, entry := range cfg.Tiers {
+			tier := strings.TrimSpace(entry.Tier)
+			if tier == "" {
+				continue
+			}
+			key := strings.ToLower(tier)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			normalized.Tiers = append(normalized.Tiers, CashOutTierConfig{
+				Tier:          tier,
+				DailyCapWei:   strings.TrimSpace(entry.DailyCapWei),
+				MonthlyCapWei: strings.TrimSpace(entry.MonthlyCapWei),
+			})
+		}
+		sort.Slice(normalized.Tiers, func(i, j int) bool {
+			return strings.ToLower(normalized.Tiers[i].Tier) < strings.ToLower(normalized.Tiers[j].Tier)
+		})
+	}
+	return normalized
+}
+
+// CashOutTierLimits represents the parsed daily/monthly limits for a KYC tier.
+type CashOutTierLimits struct {
+	Tier          string
+	DailyCapWei   *big.Int
+	MonthlyCapWei *big.Int
+}
+
+// CashOutParameters contains runtime representations of the cash-out guardrails.
+type CashOutParameters struct {
+	AssetDailyCaps map[StableAsset]*big.Int
+	TierCaps       map[string]CashOutTierLimits
+}
+
+// Parameters converts the textual configuration into runtime big integers and bounds.
+func (cfg CashOutConfig) Parameters() (CashOutParameters, error) {
+	normalized := cfg.Normalise()
+	params := CashOutParameters{
+		AssetDailyCaps: make(map[StableAsset]*big.Int, len(normalized.AssetCaps)),
+		TierCaps:       make(map[string]CashOutTierLimits, len(normalized.Tiers)),
+	}
+	for _, entry := range normalized.AssetCaps {
+		asset, err := normaliseAsset(StableAsset(entry.Asset))
+		if err != nil {
+			return params, fmt.Errorf("risk: invalid cash-out asset cap for %s: %w", entry.Asset, err)
+		}
+		amount, err := parseWeiAmount(entry.DailyCapWei)
+		if err != nil {
+			return params, fmt.Errorf("risk: invalid cash-out daily cap for %s: %w", asset, err)
+		}
+		params.AssetDailyCaps[asset] = amount
+	}
+	for _, entry := range normalized.Tiers {
+		tierName := strings.TrimSpace(entry.Tier)
+		if tierName == "" {
+			return params, fmt.Errorf("risk: tier identifier required")
+		}
+		dailyCap, err := parseWeiAmount(entry.DailyCapWei)
+		if err != nil {
+			return params, fmt.Errorf("risk: invalid tier daily cap for %s: %w", tierName, err)
+		}
+		monthlyCap, err := parseWeiAmount(entry.MonthlyCapWei)
+		if err != nil {
+			return params, fmt.Errorf("risk: invalid tier monthly cap for %s: %w", tierName, err)
+		}
+		key := strings.ToLower(tierName)
+		params.TierCaps[key] = CashOutTierLimits{
+			Tier:          tierName,
+			DailyCapWei:   dailyCap,
+			MonthlyCapWei: monthlyCap,
+		}
+	}
+	return params, nil
+}
+
+// Clone returns a deep copy of the parameters.
+func (p CashOutParameters) Clone() CashOutParameters {
+	clone := CashOutParameters{
+		AssetDailyCaps: make(map[StableAsset]*big.Int, len(p.AssetDailyCaps)),
+		TierCaps:       make(map[string]CashOutTierLimits, len(p.TierCaps)),
+	}
+	for asset, cap := range p.AssetDailyCaps {
+		if cap != nil {
+			clone.AssetDailyCaps[asset] = new(big.Int).Set(cap)
+		} else {
+			clone.AssetDailyCaps[asset] = nil
+		}
+	}
+	for key, limits := range p.TierCaps {
+		copyLimits := CashOutTierLimits{Tier: limits.Tier}
+		if limits.DailyCapWei != nil {
+			copyLimits.DailyCapWei = new(big.Int).Set(limits.DailyCapWei)
+		}
+		if limits.MonthlyCapWei != nil {
+			copyLimits.MonthlyCapWei = new(big.Int).Set(limits.MonthlyCapWei)
+		}
+		clone.TierCaps[key] = copyLimits
+	}
+	return clone
+}
+
+// AssetDailyCap returns a defensive copy of the configured per-asset daily cap.
+func (p CashOutParameters) AssetDailyCap(asset StableAsset) (*big.Int, bool) {
+	cap, ok := p.AssetDailyCaps[asset]
+	if !ok || cap == nil {
+		return nil, false
+	}
+	return new(big.Int).Set(cap), true
+}
+
+// Tier returns the guardrails configured for the supplied tier identifier.
+func (p CashOutParameters) Tier(tier string) (CashOutTierLimits, bool) {
+	trimmed := strings.ToLower(strings.TrimSpace(tier))
+	if trimmed == "" {
+		return CashOutTierLimits{}, false
+	}
+	limits, ok := p.TierCaps[trimmed]
+	if !ok {
+		return CashOutTierLimits{}, false
+	}
+	clone := CashOutTierLimits{Tier: limits.Tier}
+	if limits.DailyCapWei != nil {
+		clone.DailyCapWei = new(big.Int).Set(limits.DailyCapWei)
+	}
+	if limits.MonthlyCapWei != nil {
+		clone.MonthlyCapWei = new(big.Int).Set(limits.MonthlyCapWei)
+	}
+	return clone, true
+}
+
+// SlippageTolerance returns a runtime representation of the slippage guardrail.
+func (c Config) SlippageTolerance() (SlippageTolerance, error) {
+	return NewSlippageTolerance(c.SlippageBps)
+}
+
+// OracleGuardrails returns the oracle guardrails derived from configuration.
+func (c Config) OracleGuardrails() (OracleGuardrails, error) {
+	return NewOracleGuardrails(c.MaxQuoteAge(), c.PriceProofMaxDeviationBps)
+}

--- a/native/swap/validate.go
+++ b/native/swap/validate.go
@@ -1,0 +1,175 @@
+package swap
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	nativecommon "nhbchain/native/common"
+)
+
+var (
+	// ErrOracleStale indicates the oracle quote exceeded the freshness window.
+	ErrOracleStale = errors.New("swap: oracle quote stale")
+	// ErrOracleDeviation indicates the oracle observation deviated beyond tolerance.
+	ErrOracleDeviation = errors.New("swap: oracle deviation exceeded")
+	// ErrSlippageExceeded indicates the voucher amount fell outside the allowed tolerance.
+	ErrSlippageExceeded = errors.New("swap: slippage exceeds tolerance")
+	// ErrCashOutDailyCapExceeded indicates the asset-level daily cap would be breached.
+	ErrCashOutDailyCapExceeded = errors.New("swap: cash-out asset cap exceeded")
+	// ErrCashOutTierCapExceeded indicates the submitter's tier allowance would be exceeded.
+	ErrCashOutTierCapExceeded = errors.New("swap: cash-out tier cap exceeded")
+	// ErrSwapPaused indicates the swap module has been paused by governance.
+	ErrSwapPaused = errors.New("swap: module paused")
+)
+
+// ValidateOracleFreshness enforces the oracle freshness window using the supplied guardrails.
+func ValidateOracleFreshness(guard OracleGuardrails, now, observed time.Time) (*RiskViolation, error) {
+	if guard.MaxAge <= 0 {
+		return nil, nil
+	}
+	if observed.IsZero() {
+		violation := &RiskViolation{
+			Code:          RiskCodeOracleStale,
+			Message:       "oracle timestamp missing",
+			WindowSeconds: uint64(guard.MaxAge / time.Second),
+		}
+		return violation, ErrOracleStale
+	}
+	if now.Before(observed) {
+		return nil, fmt.Errorf("swap: oracle observation in future")
+	}
+	if now.Sub(observed) > guard.MaxAge {
+		violation := &RiskViolation{
+			Code:          RiskCodeOracleStale,
+			Message:       fmt.Sprintf("oracle sample older than %s", guard.MaxAge),
+			WindowSeconds: uint64(guard.MaxAge / time.Second),
+		}
+		return violation, ErrOracleStale
+	}
+	return nil, nil
+}
+
+// ValidateOracleDeviation enforces that a new oracle observation does not deviate beyond tolerance.
+func ValidateOracleDeviation(guard OracleGuardrails, previous, current *big.Rat) (*RiskViolation, error) {
+	if guard.MaxDeviationBps == 0 {
+		return nil, nil
+	}
+	if previous == nil || current == nil {
+		return nil, fmt.Errorf("swap: oracle deviation requires observations")
+	}
+	if previous.Sign() <= 0 || current.Sign() <= 0 {
+		return nil, fmt.Errorf("swap: oracle observations must be positive")
+	}
+	diff := new(big.Rat).Sub(current, previous)
+	if diff.Sign() < 0 {
+		diff.Neg(diff)
+	}
+	ratio := new(big.Rat).Quo(diff, previous)
+	ratio.Mul(ratio, big.NewRat(10000, 1))
+	num := new(big.Int).Set(ratio.Num())
+	den := new(big.Int).Set(ratio.Denom())
+	if den.Sign() == 0 {
+		return nil, fmt.Errorf("swap: oracle deviation denominator zero")
+	}
+	bps := num.Quo(num, den)
+	threshold := big.NewInt(int64(guard.MaxDeviationBps))
+	if bps.Cmp(threshold) > 0 {
+		violation := &RiskViolation{
+			Code:          RiskCodeOracleDeviation,
+			Message:       fmt.Sprintf("oracle deviation %s bps above %d", bps.String(), guard.MaxDeviationBps),
+			Limit:         new(big.Int).Set(threshold),
+			Current:       new(big.Int).Set(bps),
+			WindowSeconds: uint64(guard.MaxAge / time.Second),
+		}
+		return violation, ErrOracleDeviation
+	}
+	return nil, nil
+}
+
+// ValidateSlippage enforces the configured slippage tolerance between expected and submitted amounts.
+func ValidateSlippage(tolerance SlippageTolerance, expected, submitted *big.Int) (*RiskViolation, error) {
+	if !tolerance.Enabled() {
+		return nil, nil
+	}
+	if expected == nil || submitted == nil {
+		return nil, fmt.Errorf("swap: slippage requires amounts")
+	}
+	if expected.Sign() <= 0 {
+		return nil, fmt.Errorf("swap: expected amount must be positive")
+	}
+	diff := new(big.Int).Sub(expected, submitted)
+	if diff.Sign() < 0 {
+		diff.Neg(diff)
+	}
+	bps := new(big.Int).Mul(diff, big.NewInt(10000))
+	bps.Div(bps, expected)
+	threshold := big.NewInt(int64(tolerance.MaxBps))
+	if bps.Cmp(threshold) > 0 {
+		violation := &RiskViolation{
+			Code:    RiskCodeSlippage,
+			Message: fmt.Sprintf("slippage %s bps exceeds %d", bps.String(), tolerance.MaxBps),
+			Limit:   new(big.Int).Set(threshold),
+			Current: bps,
+		}
+		return violation, ErrSlippageExceeded
+	}
+	return nil, nil
+}
+
+// ValidateDailyCashOut enforces per-asset and per-tier daily caps, including pending escrow.
+func (p CashOutParameters) ValidateDailyCashOut(asset StableAsset, tier string, settledToday, pendingEscrow, requested *big.Int) (*RiskViolation, error) {
+	if requested == nil || requested.Sign() <= 0 {
+		return nil, fmt.Errorf("swap: requested cash-out must be positive")
+	}
+	total := new(big.Int).Set(requested)
+	if settledToday != nil {
+		total.Add(total, settledToday)
+	}
+	if pendingEscrow != nil {
+		total.Add(total, pendingEscrow)
+	}
+	if cap, ok := p.AssetDailyCaps[asset]; ok && cap != nil && cap.Sign() > 0 {
+		if total.Cmp(cap) > 0 {
+			violation := &RiskViolation{
+				Code:    RiskCodeCashOutAssetCap,
+				Message: fmt.Sprintf("asset %s daily cap %s exceeded", asset, cap.String()),
+				Limit:   new(big.Int).Set(cap),
+				Current: total,
+			}
+			return violation, ErrCashOutDailyCapExceeded
+		}
+	}
+	trimmedTier := strings.TrimSpace(tier)
+	if trimmedTier != "" {
+		if limits, ok := p.TierCaps[strings.ToLower(trimmedTier)]; ok && limits.DailyCapWei != nil && limits.DailyCapWei.Sign() > 0 {
+			if total.Cmp(limits.DailyCapWei) > 0 {
+				violation := &RiskViolation{
+					Code:    RiskCodeCashOutTierCap,
+					Message: fmt.Sprintf("tier %s daily cap %s exceeded", limits.Tier, limits.DailyCapWei.String()),
+					Limit:   new(big.Int).Set(limits.DailyCapWei),
+					Current: total,
+				}
+				return violation, ErrCashOutTierCapExceeded
+			}
+		}
+	}
+	return nil, nil
+}
+
+// ValidateSwapActive reports a violation when the swap module is paused.
+func ValidateSwapActive(pauseView nativecommon.PauseView) (*RiskViolation, error) {
+	if pauseView == nil {
+		return nil, nil
+	}
+	if pauseView.IsPaused("swap") {
+		violation := &RiskViolation{
+			Code:    RiskCodeModulePaused,
+			Message: "swap module paused by governance",
+		}
+		return violation, ErrSwapPaused
+	}
+	return nil, nil
+}

--- a/tests/swap/risk_invariants_test.go
+++ b/tests/swap/risk_invariants_test.go
@@ -1,0 +1,87 @@
+package swap_test
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	swap "nhbchain/native/swap"
+)
+
+type pauseStub struct {
+	paused bool
+}
+
+func (p pauseStub) IsPaused(module string) bool {
+	if !p.paused {
+		return false
+	}
+	return module == "swap"
+}
+
+func TestOracleStale_Blocks(t *testing.T) {
+	guard, err := swap.NewOracleGuardrails(time.Minute, 100)
+	if err != nil {
+		t.Fatalf("new guardrails: %v", err)
+	}
+	now := time.Unix(1700000000, 0).UTC()
+	observed := now.Add(-2 * time.Minute)
+	violation, err := swap.ValidateOracleFreshness(guard, now, observed)
+	if !errors.Is(err, swap.ErrOracleStale) {
+		t.Fatalf("expected ErrOracleStale, got %v", err)
+	}
+	if violation == nil || violation.Code != swap.RiskCodeOracleStale {
+		t.Fatalf("unexpected violation: %+v", violation)
+	}
+}
+
+func TestDeviation_Blocks(t *testing.T) {
+	guard, err := swap.NewOracleGuardrails(time.Minute, 50)
+	if err != nil {
+		t.Fatalf("new guardrails: %v", err)
+	}
+	prev := big.NewRat(1, 1)
+	curr := big.NewRat(103, 100) // 3% deviation
+	violation, err := swap.ValidateOracleDeviation(guard, prev, curr)
+	if !errors.Is(err, swap.ErrOracleDeviation) {
+		t.Fatalf("expected ErrOracleDeviation, got %v", err)
+	}
+	if violation == nil || violation.Code != swap.RiskCodeOracleDeviation {
+		t.Fatalf("unexpected violation: %+v", violation)
+	}
+}
+
+func TestDailyCap_Blocks(t *testing.T) {
+	caps := swap.CashOutParameters{
+		AssetDailyCaps: map[swap.StableAsset]*big.Int{
+			swap.StableAssetUSDC: big.NewInt(1000),
+		},
+		TierCaps: map[string]swap.CashOutTierLimits{
+			"gold": {
+				Tier:        "gold",
+				DailyCapWei: big.NewInt(500),
+			},
+		},
+	}
+	settled := big.NewInt(400)
+	pending := big.NewInt(50)
+	requested := big.NewInt(60)
+	violation, err := caps.ValidateDailyCashOut(swap.StableAssetUSDC, "gold", settled, pending, requested)
+	if !errors.Is(err, swap.ErrCashOutTierCapExceeded) {
+		t.Fatalf("expected ErrCashOutTierCapExceeded, got %v", err)
+	}
+	if violation == nil || violation.Code != swap.RiskCodeCashOutTierCap {
+		t.Fatalf("unexpected violation: %+v", violation)
+	}
+}
+
+func TestPause_Blocks(t *testing.T) {
+	violation, err := swap.ValidateSwapActive(pauseStub{paused: true})
+	if !errors.Is(err, swap.ErrSwapPaused) {
+		t.Fatalf("expected ErrSwapPaused, got %v", err)
+	}
+	if violation == nil || violation.Code != swap.RiskCodeModulePaused {
+		t.Fatalf("unexpected violation: %+v", violation)
+	}
+}


### PR DESCRIPTION
## Summary
- extend swap risk parameters with slippage tolerances, oracle guardrails, and cash-out cap parsing
- add validation helpers for oracle freshness/deviation, slippage, cash-out tier enforcement, and swap pause handling
- document the expanded governance knobs and add invariant-focused unit tests

## Testing
- `go test ./native/swap -run Risk -timeout 4m`
- `go test ./tests/swap -timeout 4m`


------
https://chatgpt.com/codex/tasks/task_e_68d9cdd029e0832dbd6b1956151ea5a9