### PR TITLE
Add stable cash-out observability metrics and alerts

### DIFF
--- a/docs/ops/observability-stable.md
+++ b/docs/ops/observability-stable.md
@@ -1,0 +1,69 @@
+# Stable cash-out observability
+
+This guide captures the dashboards, metrics, and alert responses for the stable voucher → payout pipeline.
+
+## Metrics
+
+The following Prometheus series are emitted by the services that participate in the pipeline:
+
+| Metric | Service | Labels | Description |
+| --- | --- | --- | --- |
+| `nhb_oracle_attesterd_voucher_rate` | `oracle-attesterd` | `asset` | Counter of deposit vouchers minted after webhook validation. |
+| `nhb_oracle_attesterd_oracle_freshness_seconds` | `oracle-attesterd` | `asset` | Age in seconds between the upstream webhook timestamp and the successful mint. |
+| `nhb_swapd_stable_requests_total` | `swapd` | `operation`, `outcome` | Count of quote, reserve, and cash-out intent requests observed by the experimental stable engine. |
+| `nhb_swapd_stable_request_duration_seconds` | `swapd` | `operation` | Histogram tracking the latency of each stable engine operation. |
+| `nhb_payoutd_payout_latency_seconds` | `payoutd` | `asset` | Histogram of end-to-end payout latency from processor admission to attestation submission. |
+| `nhb_payoutd_cap_remaining` | `payoutd` | `asset` | Remaining soft cap (in integer stable units) for the current window. |
+| `nhb_payoutd_cap_utilization` | `payoutd` | `asset` | Ratio of cap consumed in the current window. |
+| `nhb_payoutd_errors_total` | `payoutd` | `asset`, `reason` | Counter of payout failures segmented by error reason. |
+| `nhb_payoutd_pause_engaged` | `payoutd` | — | Gauge that is `1` when the processor pause guard is enabled. |
+
+### Tracing
+
+OpenTelemetry spans now cover the two critical paths:
+
+* `swapd/stable` emits spans for quote, reserve, and cash-out intent creation so traces show the quote → reserve → credit transition.
+* `payoutd/processor` emits spans for processing intents, wallet transfers, confirmation polling, and receipt attestation to capture the intent → payout → receipt lifecycle.
+
+Each span carries the relevant IDs (quote, reservation, intent, transaction hash) to make correlating traces with logs straightforward.
+
+## Dashboards
+
+Add the following panels to the **Stable Cash-Out** Grafana dashboard:
+
+* **Voucher Mint Rate** – plot `rate(nhb_oracle_attesterd_voucher_rate[5m])` by `asset`.
+* **Oracle Freshness** – graph `max by (asset) (nhb_oracle_attesterd_oracle_freshness_seconds)` with a 120s threshold line.
+* **Payout Latency (p95)** – use `histogram_quantile(0.95, sum(rate(nhb_payoutd_payout_latency_seconds_bucket[5m])) by (asset, le))`.
+* **Cap Remaining vs Utilisation** – dual panel showing `nhb_payoutd_cap_remaining` and `nhb_payoutd_cap_utilization` by `asset`.
+* **Stable Engine Throughput** – table of `increase(nhb_swapd_stable_requests_total[1h])` by `operation`/`outcome` for quick smoke checks.
+
+## Alerts
+
+The following alerts were added to `observability/alerts.yaml`:
+
+| Alert | Condition | Owner | Response |
+| --- | --- | --- | --- |
+| `OracleAttestationFreshness` | `max(nhb_oracle_attesterd_oracle_freshness_seconds) > 120s` for 5m | Data | Check oracle-attesterd logs for stuck webhooks. Verify NowPayments webhook delivery and consensus submissions. |
+| `PayoutdErrorSpike` | `sum(increase(nhb_payoutd_errors_total[5m])) > 3` for 10m | Treasury | Inspect payoutd logs for `transfer`, `confirmations`, or `attest` failures. Coordinate with treasury ops if on-chain congestion persists. |
+| `PayoutdLatencyP95Breached` | p95 latency above 30s for 15m | Treasury | Review wallet RPC health and blockchain congestion. Pause payouts if latency keeps increasing. |
+| `PayoutdCapUtilizationHigh` | `max_over_time(nhb_payoutd_cap_utilization[10m]) > 0.8` for 10m | Treasury | Refill the soft balance or raise the daily cap; communicate expected impact to finance. |
+| `PayoutdPauseEngaged` | `max_over_time(nhb_payoutd_pause_engaged[5m]) >= 1` for 5m | Treasury | Confirm whether the pause is intentional. Follow the incident checklist to resume service safely. |
+
+## Runbooks
+
+1. **Oracle freshness degraded**
+   * Check the **Voucher Mint Rate** panel for drops. If the rate is zero, confirm webhook delivery with the payment provider.
+   * Review `oracle-attesterd` logs for the corresponding `voucher minted` entries to see if consensus submissions are failing.
+   * If the service is healthy, escalate to the integration team to re-send the stuck invoices.
+
+2. **Payout latency regression**
+   * Inspect the Grafana latency panel to confirm whether the regression is limited to a single asset.
+   * Review `payoutd` logs for `payout settled` entries and measure the time between transfer, confirmation, and attestation spans.
+   * Coordinate with treasury to pause payouts (`admin/pause`) if the backlog keeps growing, then resume once on-chain congestion clears.
+
+3. **Cap nearly exhausted**
+   * Check `nhb_payoutd_cap_remaining` for the affected asset.
+   * Reconcile soft inventory with finance and adjust the policy YAML if additional headroom is needed.
+   * Notify stakeholders about the expected time to cap reset and whether manual minting is required.
+
+These runbooks must be exercised in staging before pushing changes to production. Validate that `/metrics` on each service exposes the new series (`voucher_rate`, `oracle_freshness_seconds`, `cap_utilization`, `pause_engaged`, and the updated payout latency histogram) using either localnet smoke tests or replay scripts.

--- a/observability/alerts.yaml
+++ b/observability/alerts.yaml
@@ -84,3 +84,66 @@ groups:
           description: |
             Module {{ $labels.module }} exhausted its address quota in the last ten minutes.
             Coordinate with consumers on request backoff or increase the configured limits.
+
+      - alert: OracleAttestationFreshness
+        expr: max(nhb_oracle_attesterd_oracle_freshness_seconds) > 120
+        for: 5m
+        labels:
+          severity: critical
+          team: data
+        annotations:
+          summary: "Oracle attestation freshness degraded"
+          description: |
+            The latest attested voucher is more than two minutes old. Check oracle-attesterd
+            logs for stalled webhooks or consensus submission failures.
+
+      - alert: PayoutdErrorSpike
+        expr: sum(increase(nhb_payoutd_errors_total[5m])) by (asset) > 3
+        for: 10m
+        labels:
+          severity: warning
+          team: treasury
+        annotations:
+          summary: "Payoutd error spike"
+          description: |
+            More than three payout failures occurred within five minutes for asset {{ $labels.asset }}.
+            Inspect payoutd logs to identify transfer, confirmation, or attestation failures.
+
+      - alert: PayoutdLatencyP95Breached
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(nhb_payoutd_payout_latency_seconds_bucket[5m])) by (asset, le)
+          ) > 30
+        for: 15m
+        labels:
+          severity: critical
+          team: treasury
+        annotations:
+          summary: "Payout latency regression"
+          description: |
+            The p95 settlement latency exceeded 30s for asset {{ $labels.asset }} over the last 15 minutes.
+            Review wallet health, blockchain congestion, and attestor availability.
+
+      - alert: PayoutdCapUtilizationHigh
+        expr: max_over_time(nhb_payoutd_cap_utilization[10m]) > 0.8
+        for: 10m
+        labels:
+          severity: warning
+          team: treasury
+        annotations:
+          summary: "Payout cap utilisation above 80%"
+          description: |
+            Cap utilisation for asset {{ $labels.asset }} exceeded 80% in the past 10 minutes.
+            Consider replenishing treasury inventory or raising the configured daily cap.
+
+      - alert: PayoutdPauseEngaged
+        expr: max_over_time(nhb_payoutd_pause_engaged[5m]) >= 1
+        for: 5m
+        labels:
+          severity: critical
+          team: treasury
+        annotations:
+          summary: "Payoutd pause engaged"
+          description: |
+            The payout processor pause toggle has been active within the last five minutes.
+            Confirm the pause is intentional and execute the payout incident runbook if required.

--- a/observability/logging/logging.go
+++ b/observability/logging/logging.go
@@ -41,6 +41,7 @@ func Setup(service, env string) *slog.Logger {
 	}
 
 	base := slog.New(handler).With(withArgs...)
+	slog.SetDefault(base)
 
 	// Bridge the standard library logger so existing packages continue to work.
 	stdBridge := slog.NewLogLogger(handler.WithAttrs(attrs), slog.LevelInfo)

--- a/observability/metrics.go
+++ b/observability/metrics.go
@@ -2,6 +2,9 @@ package observability
 
 import (
 	"fmt"
+	"math"
+	"math/big"
+	"strings"
 	"sync"
 	"time"
 
@@ -18,6 +21,15 @@ type moduleMetrics struct {
 var (
 	moduleMetricsOnce sync.Once
 	moduleRegistry    *moduleMetrics
+
+	swapStableOnce sync.Once
+	swapStableReg  *SwapStableMetrics
+
+	payoutMetricsOnce sync.Once
+	payoutRegistry    *PayoutdMetrics
+
+	oracleMetricsOnce sync.Once
+	oracleRegistry    *OracleAttesterdMetrics
 )
 
 // ModuleMetrics returns the lazily-initialised module metrics registry used to
@@ -98,4 +110,242 @@ func (m *moduleMetrics) RecordThrottle(module, reason string) {
 		reason = "unspecified"
 	}
 	m.throttles.WithLabelValues(module, reason).Inc()
+}
+
+// SwapStableMetrics captures metrics for the experimental stable swap flows.
+type SwapStableMetrics struct {
+	requests *prometheus.CounterVec
+	latency  *prometheus.HistogramVec
+	errors   *prometheus.CounterVec
+}
+
+// SwapStable returns the singleton metrics registry for swapd stable endpoints.
+func SwapStable() *SwapStableMetrics {
+	swapStableOnce.Do(func() {
+		swapStableReg = &SwapStableMetrics{
+			requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "nhb",
+				Subsystem: "swapd_stable",
+				Name:      "requests_total",
+				Help:      "Count of stable swap operations segmented by step and outcome.",
+			}, []string{"operation", "outcome"}),
+			latency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Namespace: "nhb",
+				Subsystem: "swapd_stable",
+				Name:      "request_duration_seconds",
+				Help:      "Latency distribution for stable swap operations.",
+				Buckets:   prometheus.DefBuckets,
+			}, []string{"operation"}),
+			errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "nhb",
+				Subsystem: "swapd_stable",
+				Name:      "errors_total",
+				Help:      "Count of stable swap failures segmented by operation and reason.",
+			}, []string{"operation", "reason"}),
+		}
+		prometheus.MustRegister(
+			swapStableReg.requests,
+			swapStableReg.latency,
+			swapStableReg.errors,
+		)
+	})
+	return swapStableReg
+}
+
+// Observe records the execution metrics for a stable swap operation.
+func (m *SwapStableMetrics) Observe(operation string, duration time.Duration, err error) {
+	if m == nil {
+		return
+	}
+	op := strings.TrimSpace(operation)
+	if op == "" {
+		op = "unknown"
+	}
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+		reason := strings.TrimSpace(err.Error())
+		if reason == "" {
+			reason = "unknown"
+		}
+		m.errors.WithLabelValues(op, reason).Inc()
+	}
+	m.requests.WithLabelValues(op, outcome).Inc()
+	m.latency.WithLabelValues(op).Observe(duration.Seconds())
+}
+
+// PayoutdMetrics wraps collectors tracking payout engine health.
+type PayoutdMetrics struct {
+	payoutLatency  *prometheus.HistogramVec
+	capRemaining   *prometheus.GaugeVec
+	capUtilization *prometheus.GaugeVec
+	errors         *prometheus.CounterVec
+	pauseEngaged   prometheus.Gauge
+}
+
+// Payoutd exposes the metrics registry for payoutd.
+func Payoutd() *PayoutdMetrics {
+	payoutMetricsOnce.Do(func() {
+		payoutRegistry = &PayoutdMetrics{
+			payoutLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Namespace: "nhb",
+				Subsystem: "payoutd",
+				Name:      "payout_latency_seconds",
+				Help:      "Latency distribution for completed payouts.",
+				Buckets:   prometheus.DefBuckets,
+			}, []string{"asset"}),
+			capRemaining: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: "nhb",
+				Subsystem: "payoutd",
+				Name:      "cap_remaining",
+				Help:      "Remaining soft cap per asset in integer stable units.",
+			}, []string{"asset"}),
+			capUtilization: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: "nhb",
+				Subsystem: "payoutd",
+				Name:      "cap_utilization",
+				Help:      "Ratio of consumed cap for the current payout window (0-1).",
+			}, []string{"asset"}),
+			errors: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "nhb",
+				Subsystem: "payoutd",
+				Name:      "errors_total",
+				Help:      "Count of payout failures segmented by asset and reason.",
+			}, []string{"asset", "reason"}),
+			pauseEngaged: prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace: "nhb",
+				Subsystem: "payoutd",
+				Name:      "pause_engaged",
+				Help:      "Indicates whether the payout processor pause guard is active (1) or not (0).",
+			}),
+		}
+		prometheus.MustRegister(
+			payoutRegistry.payoutLatency,
+			payoutRegistry.capRemaining,
+			payoutRegistry.capUtilization,
+			payoutRegistry.errors,
+			payoutRegistry.pauseEngaged,
+		)
+	})
+	return payoutRegistry
+}
+
+// ObserveLatency records the processing latency for a payout.
+func (m *PayoutdMetrics) ObserveLatency(asset string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.payoutLatency.WithLabelValues(labelAsset(asset)).Observe(d.Seconds())
+}
+
+// RecordCap updates the remaining cap and utilisation gauge for an asset.
+func (m *PayoutdMetrics) RecordCap(asset string, remaining, total *big.Int) {
+	if m == nil {
+		return
+	}
+	label := labelAsset(asset)
+	remainingVal := bigToFloat(remaining)
+	m.capRemaining.WithLabelValues(label).Set(remainingVal)
+	totalVal := bigToFloat(total)
+	utilisation := 0.0
+	if totalVal > 0 {
+		used := totalVal - remainingVal
+		if used < 0 {
+			used = 0
+		}
+		utilisation = used / totalVal
+		if utilisation > 1 {
+			utilisation = 1
+		}
+	}
+	m.capUtilization.WithLabelValues(label).Set(utilisation)
+}
+
+// RecordError increments the error counter for the supplied reason.
+func (m *PayoutdMetrics) RecordError(asset, reason string) {
+	if m == nil {
+		return
+	}
+	if reason = strings.TrimSpace(reason); reason == "" {
+		reason = "unspecified"
+	}
+	m.errors.WithLabelValues(labelAsset(asset), reason).Inc()
+}
+
+// SetPause toggles the pause_engaged gauge.
+func (m *PayoutdMetrics) SetPause(engaged bool) {
+	if m == nil {
+		return
+	}
+	if engaged {
+		m.pauseEngaged.Set(1)
+		return
+	}
+	m.pauseEngaged.Set(0)
+}
+
+// OracleAttesterdMetrics bundles collectors for voucher minting and freshness tracking.
+type OracleAttesterdMetrics struct {
+	voucherRate *prometheus.CounterVec
+	freshness   *prometheus.GaugeVec
+}
+
+// OracleAttesterd returns the metrics registry for oracle-attesterd.
+func OracleAttesterd() *OracleAttesterdMetrics {
+	oracleMetricsOnce.Do(func() {
+		oracleRegistry = &OracleAttesterdMetrics{
+			voucherRate: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "nhb",
+				Subsystem: "oracle_attesterd",
+				Name:      "voucher_rate",
+				Help:      "Count of vouchers minted via oracle attestations.",
+			}, []string{"asset"}),
+			freshness: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: "nhb",
+				Subsystem: "oracle_attesterd",
+				Name:      "oracle_freshness_seconds",
+				Help:      "Age in seconds between settlement confirmation and attestation mint time.",
+			}, []string{"asset"}),
+		}
+		prometheus.MustRegister(oracleRegistry.voucherRate, oracleRegistry.freshness)
+	})
+	return oracleRegistry
+}
+
+// RecordVoucherMint increments the voucher mint counter for an asset.
+func (m *OracleAttesterdMetrics) RecordVoucherMint(asset string) {
+	if m == nil {
+		return
+	}
+	m.voucherRate.WithLabelValues(labelAsset(asset)).Inc()
+}
+
+// RecordFreshness records how stale the processed event was.
+func (m *OracleAttesterdMetrics) RecordFreshness(asset string, age time.Duration) {
+	if m == nil {
+		return
+	}
+	m.freshness.WithLabelValues(labelAsset(asset)).Set(age.Seconds())
+}
+
+func labelAsset(asset string) string {
+	trimmed := strings.TrimSpace(asset)
+	if trimmed == "" {
+		return "UNKNOWN"
+	}
+	return strings.ToUpper(trimmed)
+}
+
+func bigToFloat(value *big.Int) float64 {
+	if value == nil {
+		return 0
+	}
+	floatVal, acc := new(big.Float).SetInt(value).Float64()
+	if acc != big.Exact {
+		// Guard against NaN/Inf when conversion fails.
+		if math.IsNaN(floatVal) || math.IsInf(floatVal, 0) {
+			return 0
+		}
+	}
+	return floatVal
 }

--- a/services/payoutd/metrics.go
+++ b/services/payoutd/metrics.go
@@ -1,94 +1,9 @@
 package payoutd
 
-import (
-	"math"
-	"math/big"
-	"strings"
-	"sync"
-	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
-)
-
-var (
-	metricsOnce   sync.Once
-	sharedMetrics *Metrics
-)
+import "nhbchain/observability"
 
 // Metrics exposes Prometheus collectors for payoutd instrumentation.
-type Metrics struct {
-	payoutLatency *prometheus.HistogramVec
-	capRemaining  *prometheus.GaugeVec
-	errors        *prometheus.CounterVec
-}
+type Metrics = observability.PayoutdMetrics
 
 // NewMetrics returns a lazily initialised metrics registry.
-func NewMetrics() *Metrics {
-	metricsOnce.Do(func() {
-		sharedMetrics = &Metrics{
-			payoutLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: "nhb",
-				Subsystem: "payoutd",
-				Name:      "payout_latency_seconds",
-				Help:      "Latency distribution for completed payouts.",
-				Buckets:   prometheus.DefBuckets,
-			}, []string{"asset"}),
-			capRemaining: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-				Namespace: "nhb",
-				Subsystem: "payoutd",
-				Name:      "cap_remaining",
-				Help:      "Remaining soft cap per asset in integer stable units.",
-			}, []string{"asset"}),
-			errors: prometheus.NewCounterVec(prometheus.CounterOpts{
-				Namespace: "nhb",
-				Subsystem: "payoutd",
-				Name:      "errors_total",
-				Help:      "Count of payout failures segmented by asset and reason.",
-			}, []string{"asset", "reason"}),
-		}
-		prometheus.MustRegister(sharedMetrics.payoutLatency, sharedMetrics.capRemaining, sharedMetrics.errors)
-	})
-	return sharedMetrics
-}
-
-// ObserveLatency records the processing latency for a payout.
-func (m *Metrics) ObserveLatency(asset string, d time.Duration) {
-	if m == nil {
-		return
-	}
-	m.payoutLatency.WithLabelValues(labelAsset(asset)).Observe(d.Seconds())
-}
-
-// RecordCap updates the remaining cap gauge for an asset.
-func (m *Metrics) RecordCap(asset string, remaining *big.Int) {
-	if m == nil {
-		return
-	}
-	value := 0.0
-	if remaining != nil {
-		if floatVal, _ := new(big.Float).SetInt(remaining).Float64(); !math.IsInf(floatVal, 0) && !math.IsNaN(floatVal) {
-			value = floatVal
-		} else if remaining.Sign() > 0 {
-			value = math.MaxFloat64
-		}
-	}
-	m.capRemaining.WithLabelValues(labelAsset(asset)).Set(value)
-}
-
-// RecordError increments the error counter for the supplied reason.
-func (m *Metrics) RecordError(asset, reason string) {
-	if m == nil {
-		return
-	}
-	if reason == "" {
-		reason = "unspecified"
-	}
-	m.errors.WithLabelValues(labelAsset(asset), reason).Inc()
-}
-
-func labelAsset(asset string) string {
-	if asset == "" {
-		return "unknown"
-	}
-	return strings.ToUpper(asset)
-}
+func NewMetrics() *Metrics { return observability.Payoutd() }

--- a/services/payoutd/policy.go
+++ b/services/payoutd/policy.go
@@ -248,6 +248,18 @@ func (p *PolicyEnforcer) RemainingCap(asset string, now time.Time) *big.Int {
 	return remaining
 }
 
+// DailyCap returns the configured total cap for the asset.
+func (p *PolicyEnforcer) DailyCap(asset string) *big.Int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	key := strings.ToUpper(strings.TrimSpace(asset))
+	policy, ok := p.policies[key]
+	if !ok || policy.DailyCap == nil {
+		return big.NewInt(0)
+	}
+	return new(big.Int).Set(policy.DailyCap)
+}
+
 // RemainingInventory returns the current tracked soft inventory for an asset.
 func (p *PolicyEnforcer) RemainingInventory(asset string) *big.Int {
 	p.mu.Lock()


### PR DESCRIPTION
## Summary
- add shared observability registries for swapd stable flows, payoutd, and oracle-attesterd and wire them into structured logging and tracing
- record voucher mint/freshness, payout latency/cap utilisation, and swapd stable operation metrics with OTEL spans on quote→reserve→cash-out and intent→payout→receipt paths
- extend Prometheus alerts and document dashboards/runbooks for the stable cash-out pipeline

## Testing
- `go test ./services/payoutd ./services/oracle-attesterd ./services/swapd/...` *(hangs on dependency downloads; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d26e5ad8832da2a123bae6eab06e