### PR TITLE
Optimize RPC transaction deduplication sweeper

### DIFF
--- a/rpc/http_benchmark_test.go
+++ b/rpc/http_benchmark_test.go
@@ -1,0 +1,41 @@
+package rpc
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func BenchmarkServerRememberTx(b *testing.B) {
+	server := NewServer(nil, nil, ServerConfig{})
+	start := time.Now()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hash := fmt.Sprintf("tx-%d", i)
+		// Advance the logical clock enough to keep the sliding window bounded.
+		now := start.Add(time.Duration(i) * (txSeenTTL + time.Second))
+		if !server.rememberTx(hash, now) {
+			b.Fatalf("unexpected duplicate rejection for %s", hash)
+		}
+	}
+}
+
+func BenchmarkServerRememberTxParallel(b *testing.B) {
+	server := NewServer(nil, nil, ServerConfig{})
+	var counter uint64
+	start := time.Now()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			id := atomic.AddUint64(&counter, 1)
+			hash := fmt.Sprintf("tx-%d", id)
+			now := start.Add(time.Duration(id) * (txSeenTTL + time.Second))
+			if !server.rememberTx(hash, now) {
+				b.Fatalf("unexpected duplicate rejection for %s", hash)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- replace the per-call txSeen sweep with a queue-backed TTL eviction to keep dedupe checks O(1)
- add targeted tests that cover duplicate handling and expiry cleanup of remembered transactions
- introduce sequential and parallel benchmarks to watch rememberTx throughput under load

## Testing
- go test ./rpc -run TestServerRememberTx -vet=off
- go test ./rpc -run=^$ -bench=ServerRememberTx -benchtime=100x -vet=off

------
https://chatgpt.com/codex/tasks/task_e_68dad27a32a8832d8b9b2c45ac32df42