### PR TITLE
Validate network transactions before entering mempool

### DIFF
--- a/core/node_network_test.go
+++ b/core/node_network_test.go
@@ -1,0 +1,44 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"math/big"
+	"testing"
+
+	"nhbchain/crypto"
+	"nhbchain/p2p"
+)
+
+func TestProcessNetworkMessageRejectsInvalidTransaction(t *testing.T) {
+	node := newTestNode(t)
+
+	senderKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	invalidChainID := big.NewInt(0xdead)
+	tx := prepareSignedTransaction(t, node, senderKey, 0, invalidChainID)
+	payload, err := json.Marshal(tx)
+	if err != nil {
+		t.Fatalf("marshal transaction: %v", err)
+	}
+
+	msg := &p2p.Message{Type: p2p.MsgTypeTx, Payload: payload}
+	err = node.ProcessNetworkMessage(msg)
+	if err == nil {
+		t.Fatalf("expected invalid payload error")
+	}
+	if !errors.Is(err, p2p.ErrInvalidPayload) {
+		t.Fatalf("expected ErrInvalidPayload, got %v", err)
+	}
+
+	if mempool := node.GetMempool(); len(mempool) != 0 {
+		t.Fatalf("expected empty mempool, got %d", len(mempool))
+	}
+
+	if _, err := node.CreateBlock(nil); err != nil {
+		t.Fatalf("create block after invalid tx: %v", err)
+	}
+}

--- a/core/state_transition_nonce_test.go
+++ b/core/state_transition_nonce_test.go
@@ -68,12 +68,14 @@ func TestApplyTransactionRejectsNativeNonceReplay(t *testing.T) {
 					Amount   *big.Int `json:"amount"`
 					FeeBps   uint32   `json:"feeBps"`
 					Deadline int64    `json:"deadline"`
+					Nonce    uint64   `json:"nonce"`
 				}{
 					Payee:    payee,
 					Token:    "NHB",
 					Amount:   big.NewInt(100),
 					FeeBps:   0,
 					Deadline: time.Now().Add(time.Hour).Unix(),
+					Nonce:    1,
 				}
 				data, err := json.Marshal(payload)
 				if err != nil {

--- a/p2p/errors.go
+++ b/p2p/errors.go
@@ -1,0 +1,11 @@
+package p2p
+
+import "errors"
+
+// ErrInvalidPayload indicates that a peer supplied a syntactically correct message with invalid contents.
+var ErrInvalidPayload = errors.New("p2p: invalid payload")
+
+// IsInvalidPayload reports whether the error originated from a malformed or invalid payload.
+func IsInvalidPayload(err error) bool {
+	return errors.Is(err, ErrInvalidPayload)
+}

--- a/p2p/invalid_payload_test.go
+++ b/p2p/invalid_payload_test.go
@@ -1,0 +1,102 @@
+package p2p
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+type invalidPayloadHandler struct{}
+
+func (invalidPayloadHandler) HandleMessage(msg *Message) error {
+	return fmt.Errorf("%w: invalid", ErrInvalidPayload)
+}
+
+func TestInvalidPayloadDisconnectsPeer(t *testing.T) {
+	handler := invalidPayloadHandler{}
+	genesis := bytes.Repeat([]byte{0xAB}, 32)
+	cfg := baseConfig(genesis)
+	cfg.PeerBanDuration = 100 * time.Millisecond
+	cfg.RateMsgsPerSec = 10
+	cfg.RateBurst = 10
+
+	server := NewServer(handler, mustKey(t), cfg)
+	remote := NewServer(noopHandler{}, mustKey(t), cfg)
+
+	left, right := net.Pipe()
+	defer right.Close()
+
+	go server.handleInbound(left)
+
+	reader := bufio.NewReader(right)
+	if _, err := reader.ReadBytes('\n'); err != nil {
+		t.Fatalf("read local handshake: %v", err)
+	}
+	payload, err := remote.buildHandshake()
+	if err != nil {
+		t.Fatalf("build handshake: %v", err)
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal handshake: %v", err)
+	}
+	if _, err := right.Write(append(data, '\n')); err != nil {
+		t.Fatalf("write handshake: %v", err)
+	}
+
+	wait := func(cond func() bool) bool {
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			if cond() {
+				return true
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		return cond()
+	}
+
+	if !wait(func() bool {
+		server.mu.RLock()
+		_, ok := server.peers[remote.nodeID]
+		server.mu.RUnlock()
+		return ok
+	}) {
+		t.Fatal("peer never registered after handshake")
+	}
+
+	msgData, err := json.Marshal(&Message{Type: MsgTypeTx, Payload: []byte("{}")})
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+	if _, err := right.Write(append(msgData, '\n')); err != nil {
+		if !strings.Contains(err.Error(), "closed") {
+			t.Fatalf("write invalid message: %v", err)
+		}
+	}
+
+	if !wait(func() bool {
+		server.mu.RLock()
+		_, ok := server.peers[remote.nodeID]
+		server.mu.RUnlock()
+		return !ok
+	}) {
+		t.Fatal("peer should have been disconnected after invalid payload")
+	}
+
+	statuses := server.reputation.Snapshot(server.now())
+	status, ok := statuses[remote.nodeID]
+	if !ok {
+		t.Fatal("expected reputation entry for remote peer")
+	}
+	if status.Score >= 0 {
+		t.Fatalf("expected negative score after invalid payload, got %d", status.Score)
+	}
+	if status.Misbehavior == 0 {
+		t.Fatalf("expected misbehavior count to increase")
+	}
+}

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -213,6 +213,10 @@ func (p *Peer) readLoop() {
 		}
 
 		if err := p.server.handler.HandleMessage(&msg); err != nil {
+			if p.server != nil && IsInvalidPayload(err) {
+				p.server.handleProtocolViolation(p, err)
+				return
+			}
 			fmt.Printf("Error handling message from %s: %v\n", p.id, err)
 		}
 		p.server.recordValidMessage(p.id)


### PR DESCRIPTION
## Summary
- validate incoming transactions before they enter the mempool, including signature recovery, chain ID checks, and pre-execution against a state copy
- introduce a dedicated p2p invalid payload error and terminate peers that send malformed transactions, with regression coverage for both node and server paths
- update tests to use signed heartbeat transactions, add network regression coverage, and ensure escrow payloads include the required nonce field

## Testing
- go test ./core
- go test ./p2p

------
https://chatgpt.com/codex/tasks/task_e_68db0d32ec28832d989e6cff6c453560