### PR TITLE
Retain mempool transactions across failed commits

### DIFF
--- a/consensus/service/server.go
+++ b/consensus/service/server.go
@@ -79,7 +79,7 @@ func (s *Server) GetHeight(ctx context.Context, _ *consensusv1.GetHeightRequest)
 	return &consensusv1.GetHeightResponse{Height: s.node.GetHeight()}, nil
 }
 
-// GetMempool drains the current mempool contents.
+// GetMempool retrieves queued transactions that have not yet been committed.
 func (s *Server) GetMempool(ctx context.Context, _ *consensusv1.GetMempoolRequest) (*consensusv1.GetMempoolResponse, error) {
 	if s == nil || s.node == nil {
 		return nil, fmt.Errorf("consensus service not initialised")


### PR DESCRIPTION
## Summary
- track proposed transactions in the node so GetMempool no longer drains the queue and trim proposed entries when the mempool is resized
- requeue transactions when CommitBlock fails and prune only the committed ones on success
- add regression tests covering failed commit requeue behaviour and successful commit pruning

## Testing
- go test ./core -run 'TestCommitBlock(FailureRetainsMempool|SuccessPrunesMempool)'


------
https://chatgpt.com/codex/tasks/task_e_68db5fba3080832d8c081147fc775b9e