### PR TITLE
Enforce validator keystore passphrase usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This produces two executables:
 
 ### Initial Configuration
 
-On first launch the node creates `config.toml` alongside an encrypted validator keystore. To pre-configure or inspect settings, edit `config.toml` and point `GenesisFile` at the vetted genesis JSON supplied by network operations (autogenesis is only for isolated dev workflows):
+On first launch the node prompts for a validator keystore passphrase (or uses the `NHB_VALIDATOR_PASS` environment variable) before creating `config.toml` alongside the encrypted validator keystore. The passphrase must be non-empty and should be reused by every binary that reads the validator key (`nhb`, `consensusd`, `p2pd`, etc.). To pre-configure or inspect settings, edit `config.toml` and point `GenesisFile` at the vetted genesis JSON supplied by network operations (autogenesis is only for isolated dev workflows):
 
 ```toml
 ListenAddress = "0.0.0.0:6001"
@@ -129,7 +129,7 @@ PersistentPeers = [
 ]
 ```
 
-Set required secrets as environment variables before bootstrapping:
+Set required secrets as environment variables before bootstrapping (the node will refuse to start without a validator keystore passphrase):
 
 ```bash
 export NHB_VALIDATOR_PASS="choose-a-strong-passphrase"
@@ -214,7 +214,7 @@ All protocol modules ship with reference documentation under [`docs/`](./docs):
 ## Security, Compliance, and Operations
 
 - **Authentication** — RPC bearer tokens protect privileged calls; rotate secrets regularly and enforce mutual TLS or HMAC as described in the [Network Hardening Playbook](docs/security/network-hardening.md).
-- **Key Management** — Validator keys default to encrypted Ethereum-compatible keystores. Integrate with external KMS via `ValidatorKMSURI` and `ValidatorKMSEnv`.
+- **Key Management** — Validator keys default to encrypted Ethereum-compatible keystores protected by a non-empty passphrase (`NHB_VALIDATOR_PASS` or interactive prompt). Integrate with external KMS via `ValidatorKMSURI` and `ValidatorKMSEnv`.
 - **Observability** — Monitor validator uptime, engagement scores, and staking state using CLI commands or forthcoming telemetry dashboards. Forward RPC/WAF logs to your SIEM so abuse attempts can be correlated with P2P events.
 - **Compliance Alignment** — Native identity modules provide audit trails, verified contact points, and consent-driven discovery suitable for regulatory review.
 - **Audits & Bug Bounty** — We run an ongoing [bug bounty program](docs/security/bug-bounty.md) and maintain an [audit readiness guide](docs/security/audit-readiness.md) with frozen commits, reproducible builds, and fixtures for third-party assessors.

--- a/cmd/consensusd/main.go
+++ b/cmd/consensusd/main.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"nhbchain/cmd/internal/passphrase"
 	"nhbchain/config"
 	"nhbchain/consensus/bft"
 	"nhbchain/consensus/service"
@@ -90,7 +91,9 @@ func main() {
 
 	allowAutogenesisCLISet := flagWasProvided("allow-autogenesis")
 
-	cfg, err := config.Load(*configFile)
+	passSource := passphrase.NewSource(validatorPassEnv)
+
+	cfg, err := config.Load(*configFile, config.WithKeystorePassphraseSource(passSource.Get))
 	if err != nil {
 		panic(fmt.Sprintf("Failed to load config: %v", err))
 	}
@@ -117,7 +120,7 @@ func main() {
 	}
 	defer db.Close()
 
-	privKey, err := loadValidatorKey(cfg)
+	privKey, err := loadValidatorKey(cfg, passSource.Get)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to load validator key: %v", err))
 	}
@@ -475,7 +478,7 @@ func flagWasProvided(name string) bool {
 	return provided
 }
 
-func loadValidatorKey(cfg *config.Config) (*crypto.PrivateKey, error) {
+func loadValidatorKey(cfg *config.Config, resolvePassphrase func() (string, error)) (*crypto.PrivateKey, error) {
 	if cfg.ValidatorKMSURI != "" || cfg.ValidatorKMSEnv != "" {
 		return loadFromKMS(cfg)
 	}
@@ -484,9 +487,16 @@ func loadValidatorKey(cfg *config.Config) (*crypto.PrivateKey, error) {
 		return nil, fmt.Errorf("validator keystore path not configured")
 	}
 
-	passphrase, ok := os.LookupEnv(validatorPassEnv)
-	if !ok {
-		return nil, fmt.Errorf("%s environment variable not set", validatorPassEnv)
+	if resolvePassphrase == nil {
+		return nil, fmt.Errorf("validator keystore passphrase required; set %s or run interactively", validatorPassEnv)
+	}
+
+	passphrase, err := resolvePassphrase()
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain validator keystore passphrase: %w", err)
+	}
+	if strings.TrimSpace(passphrase) == "" {
+		return nil, fmt.Errorf("validator keystore passphrase cannot be empty")
 	}
 
 	key, err := crypto.LoadFromKeystore(cfg.ValidatorKeystorePath, passphrase)

--- a/cmd/consensusd/main_test.go
+++ b/cmd/consensusd/main_test.go
@@ -58,7 +58,7 @@ MaxTxs = 0
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run", "^TestConsensusdFailsOnInvalidGlobalConfig$")
-	cmd.Env = append(os.Environ(), subprocessEnv+"=1", configPathEnv+"="+cfgPath)
+	cmd.Env = append(os.Environ(), subprocessEnv+"=1", configPathEnv+"="+cfgPath, "NHB_VALIDATOR_PASS=test-passphrase")
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output

--- a/cmd/internal/passphrase/source.go
+++ b/cmd/internal/passphrase/source.go
@@ -1,0 +1,74 @@
+package passphrase
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"golang.org/x/term"
+)
+
+// Source lazily resolves a keystore passphrase from an environment variable or
+// by prompting the operator. The value is cached after the first successful
+// retrieval so repeated calls reuse the same secret.
+type Source struct {
+	envVar string
+
+	once  sync.Once
+	value string
+	err   error
+}
+
+// NewSource constructs a passphrase source that checks envVar before
+// interactively prompting on the terminal.
+func NewSource(envVar string) *Source {
+	return &Source{envVar: strings.TrimSpace(envVar)}
+}
+
+// Get returns the cached passphrase or resolves it if this is the first call.
+// When the environment variable is set the exact value is used; otherwise the
+// operator is prompted on stderr. Whitespace-only passphrases are rejected to
+// avoid unprotected keystores.
+func (s *Source) Get() (string, error) {
+	s.once.Do(func() {
+		if s.envVar != "" {
+			if value, ok := os.LookupEnv(s.envVar); ok {
+				if strings.TrimSpace(value) == "" {
+					s.err = fmt.Errorf("%s is set but empty", s.envVar)
+					return
+				}
+				s.value = value
+				return
+			}
+		}
+
+		if !term.IsTerminal(int(os.Stdin.Fd())) {
+			if s.envVar != "" {
+				s.err = fmt.Errorf("validator keystore passphrase required; set %s or run interactively", s.envVar)
+			} else {
+				s.err = errors.New("validator keystore passphrase required and no terminal available")
+			}
+			return
+		}
+
+		fmt.Fprint(os.Stderr, "Enter validator keystore passphrase: ")
+		bytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Fprintln(os.Stderr)
+		if err != nil {
+			s.err = fmt.Errorf("failed to read passphrase: %w", err)
+			return
+		}
+
+		passphrase := string(bytes)
+		if strings.TrimSpace(passphrase) == "" {
+			s.err = errors.New("validator keystore passphrase cannot be empty")
+			return
+		}
+
+		s.value = passphrase
+	})
+
+	return s.value, s.err
+}

--- a/cmd/nhb-cli/escrow_cmd_test.go
+++ b/cmd/nhb-cli/escrow_cmd_test.go
@@ -144,6 +144,7 @@ func TestEscrowRPCErrorsAndSuccess(t *testing.T) {
 				"amount":   "100000000000000000000",
 				"feeBps":   uint64(10),
 				"deadline": int64(1_700_000_000 + 3600),
+				"nonce":    uint64(42),
 			}
 			if diff := diffParams(params, expected); diff != "" {
 				t.Fatalf("unexpected params diff: %s", diff)
@@ -162,6 +163,7 @@ func TestEscrowRPCErrorsAndSuccess(t *testing.T) {
 			"--amount", "100e18",
 			"--fee-bps", "10",
 			"--deadline", "+1h",
+			"--nonce", "42",
 		}
 		exitCode := runEscrowCommand(args, stdout, stderr)
 		if exitCode != 0 {

--- a/cmd/nhbctl/main.go
+++ b/cmd/nhbctl/main.go
@@ -100,7 +100,13 @@ func migrateKeystore(configPath, keystorePath, passEnv string, force bool) error
 		if !ok {
 			return fmt.Errorf("environment variable %s is not set", passEnv)
 		}
+		if strings.TrimSpace(val) == "" {
+			return fmt.Errorf("environment variable %s must not be empty", passEnv)
+		}
 		passphrase = val
+	}
+	if strings.TrimSpace(passphrase) == "" {
+		return fmt.Errorf("validator keystore passphrase must be provided via %s", passEnv)
 	}
 
 	key, err := parseLegacyKey(cfg.ValidatorKey)
@@ -141,7 +147,7 @@ func migrateKeystore(configPath, keystorePath, passEnv string, force bool) error
 		return err
 	}
 
-	if _, err := config.Load(configPath); err != nil {
+	if _, err := config.Load(configPath, config.WithKeystorePassphrase(passphrase)); err != nil {
 		return fmt.Errorf("verification failed after migration: %w", err)
 	}
 

--- a/cmd/p2pd/main.go
+++ b/cmd/p2pd/main.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"nhbchain/cmd/internal/passphrase"
 	"nhbchain/config"
 	"nhbchain/core"
 	nhbstate "nhbchain/core/state"
@@ -33,6 +34,7 @@ import (
 )
 
 const (
+	validatorPassEnv    = "NHB_VALIDATOR_PASS"
 	allowAutogenesisEnv = "NHB_ALLOW_AUTOGENESIS"
 	genesisPathEnv      = "NHB_GENESIS"
 )
@@ -74,7 +76,9 @@ func main() {
 
 	allowAutogenesisCLISet := flagWasProvided("allow-autogenesis")
 
-	cfg, err := config.Load(*configFile)
+	passSource := passphrase.NewSource(validatorPassEnv)
+
+	cfg, err := config.Load(*configFile, config.WithKeystorePassphraseSource(passSource.Get))
 	if err != nil {
 		panic(fmt.Sprintf("failed to load config: %v", err))
 	}

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     environment:
       NHB_ENV: local
       NHB_ALLOW_AUTOGENESIS: "true"
-      NHB_VALIDATOR_PASS: ""
+      NHB_VALIDATOR_PASS: "change-me"
     volumes:
       - consensus-data:/var/lib/nhb
       - ./config/consensus.toml:/etc/nhb/consensus.toml:ro

--- a/docs/governance/devnet-runbook.md
+++ b/docs/governance/devnet-runbook.md
@@ -83,7 +83,7 @@ TOML
 Start the node (keep this terminal running):
 
 ```bash
-export NHB_VALIDATOR_PASS=""
+export NHB_VALIDATOR_PASS="devnet-passphrase"
 export NHB_RPC_TOKEN="devnet-token"
 RPC_URL="http://127.0.0.1:8081"
 # Explicitly opt into autogenesis for this throwaway devnet instance.

--- a/examples/compose/mininet/docker-compose.yml
+++ b/examples/compose/mininet/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       p2pd:
         condition: service_healthy
     environment:
-      - NHB_VALIDATOR_PASS=
+      - NHB_VALIDATOR_PASS=change-me
       - NHB_ALLOW_AUTOGENESIS=true
     volumes:
       - consensus-data:/var/lib/nhb


### PR DESCRIPTION
## Summary
- require a non-empty passphrase when config.Load creates validator keystores and expose options for supplying the passphrase
- add a shared passphrase resolver used by nhb, consensusd, and p2pd so the same secret is used for both generation and decryption
- refresh documentation and examples to describe the new passphrase requirement and add regression tests covering keystore generation

## Testing
- go test ./config
- go test ./cmd/consensusd
- go test ./cmd/nhb
- go test ./cmd/nhb-cli
- go test ./... *(fails: existing e2e/system suites)*

------
https://chatgpt.com/codex/tasks/task_e_68db7838bc28832db3e75788da88df7b