### PR TITLE
Include paymaster address in transaction hash

### DIFF
--- a/core/node_transaction_key_test.go
+++ b/core/node_transaction_key_test.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+func TestTransactionKeyDiffersByPaymaster(t *testing.T) {
+	senderKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate sender key: %v", err)
+	}
+
+	paymasterA, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate paymaster A: %v", err)
+	}
+
+	paymasterB, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate paymaster B: %v", err)
+	}
+
+	newTx := func(paymaster []byte) *types.Transaction {
+		to := make([]byte, 20)
+		copy(to, []byte{0x01})
+		tx := &types.Transaction{
+			ChainID:  types.NHBChainID(),
+			Type:     types.TxTypeTransfer,
+			Nonce:    1,
+			To:       to,
+			GasLimit: 21_000,
+			GasPrice: big.NewInt(1_000_000_000),
+			Value:    big.NewInt(10),
+		}
+		if len(paymaster) > 0 {
+			tx.Paymaster = append([]byte(nil), paymaster...)
+		}
+		if err := tx.Sign(senderKey.PrivateKey); err != nil {
+			t.Fatalf("sign tx: %v", err)
+		}
+		return tx
+	}
+
+	txWithA := newTx(paymasterA.PubKey().Address().Bytes())
+	keyA, err := transactionKey(txWithA)
+	if err != nil {
+		t.Fatalf("transactionKey A: %v", err)
+	}
+
+	txWithB := newTx(paymasterB.PubKey().Address().Bytes())
+	keyB, err := transactionKey(txWithB)
+	if err != nil {
+		t.Fatalf("transactionKey B: %v", err)
+	}
+
+	if keyA == keyB {
+		t.Fatalf("expected different keys for different paymasters")
+	}
+
+	txWithAResigned := newTx(paymasterA.PubKey().Address().Bytes())
+	keyAResigned, err := transactionKey(txWithAResigned)
+	if err != nil {
+		t.Fatalf("transactionKey resigned: %v", err)
+	}
+
+	if keyA != keyAResigned {
+		t.Fatalf("expected identical keys for identical paymaster submissions")
+	}
+}

--- a/core/sponsorship_test.go
+++ b/core/sponsorship_test.go
@@ -81,7 +81,6 @@ func TestEvaluateSponsorship(t *testing.T) {
 			GasPrice: big.NewInt(1_000_000_000),
 			Value:    big.NewInt(1),
 		}
-		signTransaction(t, tx, senderKey)
 		return tx
 	}
 
@@ -165,6 +164,7 @@ func TestEvaluateSponsorship(t *testing.T) {
 			if tc.prepare != nil {
 				tc.prepare(tx)
 			}
+			signTransaction(t, tx, senderKey)
 			if tc.mutateSP != nil {
 				tc.mutateSP()
 				t.Cleanup(func() { sp.SetPaymasterEnabled(true) })

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -80,15 +80,20 @@ var (
 // Hash logic must now include the new Type field.
 func (tx *Transaction) Hash() ([]byte, error) {
 	txData := struct {
-		ChainID  *big.Int
-		Type     TxType
-		Nonce    uint64
-		To       []byte
-		Value    *big.Int
-		Data     []byte
-		GasLimit uint64
-		GasPrice *big.Int
-	}{tx.ChainID, tx.Type, tx.Nonce, tx.To, tx.Value, tx.Data, tx.GasLimit, tx.GasPrice}
+		ChainID   *big.Int
+		Type      TxType
+		Nonce     uint64
+		To        []byte
+		Value     *big.Int
+		Data      []byte
+		GasLimit  uint64
+		GasPrice  *big.Int
+		Paymaster []byte `json:"paymaster,omitempty"`
+	}{ChainID: tx.ChainID, Type: tx.Type, Nonce: tx.Nonce, To: tx.To, Value: tx.Value, Data: tx.Data, GasLimit: tx.GasLimit, GasPrice: tx.GasPrice}
+
+	if len(tx.Paymaster) > 0 {
+		txData.Paymaster = append([]byte(nil), tx.Paymaster...)
+	}
 
 	b, err := json.Marshal(txData)
 	if err != nil {
@@ -114,6 +119,7 @@ func (tx *Transaction) Sign(privKey *ecdsa.PrivateKey) error {
 	tx.R = new(big.Int).SetBytes(sig[:32])
 	tx.S = new(big.Int).SetBytes(sig[32:64])
 	tx.V = new(big.Int).SetBytes([]byte{sig[64] + 27})
+	tx.from = nil
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- hash transactions with the optional paymaster address and clear cached sender information when re-signing
- update sponsorship tests to sign after paymaster data is applied and add coverage that transactionKey varies by paymaster
- extend RPC duplicate tracking tests to allow resubmissions with different paymasters while still blocking identical repeats

## Testing
- go test ./core -run TestEvaluateSponsorship -count=1
- go test ./core -run TestTransactionKeyDiffersByPaymaster -count=1
- go test ./rpc -run TestServerRememberTxIncludesPaymasterInHash -count=1


------
https://chatgpt.com/codex/tasks/task_e_68dcc9943a74832daeacd92200637cf3