### PR TITLE
Expose configurable consensus timeouts

### DIFF
--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -295,7 +295,12 @@ func main() {
 	p2pServer.SetPeerstore(peerstore)
 
 	// 3. Create the BFT engine, passing the node (as NodeInterface) and P2P server (as Broadcaster).
-	bftEngine := bft.NewEngine(node, privKey, p2pServer)
+	bftEngine := bft.NewEngine(node, privKey, p2pServer, bft.WithTimeouts(bft.TimeoutConfig{
+		Proposal:  cfg.Consensus.ProposalTimeout,
+		Prevote:   cfg.Consensus.PrevoteTimeout,
+		Precommit: cfg.Consensus.PrecommitTimeout,
+		Commit:    cfg.Consensus.CommitTimeout,
+	}))
 
 	// 4. Set the fully configured BFT engine on the node.
 	node.SetBftEngine(bftEngine)

--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	Lending               lending.Config  `toml:"lending"`
 	Mempool               MempoolConfig   `toml:"mempool"`
 	Global                Global          `toml:"global"`
+	Consensus             Consensus       `toml:"consensus"`
 	NetworkSecurity       NetworkSecurity `toml:"network_security"`
 }
 
@@ -134,6 +135,15 @@ func defaultGlobalConfig() Global {
 		Mempool: Mempool{MaxBytes: 16 << 20},
 		Blocks:  Blocks{MaxTxs: 5000},
 		Pauses:  Pauses{},
+	}
+}
+
+func defaultConsensusConfig() Consensus {
+	return Consensus{
+		ProposalTimeout:  2 * time.Second,
+		PrevoteTimeout:   2 * time.Second,
+		PrecommitTimeout: 2 * time.Second,
+		CommitTimeout:    4 * time.Second,
 	}
 }
 
@@ -311,6 +321,7 @@ func Load(path string, opts ...LoadOption) (*Config, error) {
 	cfg.Lending.EnsureDefaults()
 	cfg.ensureMempoolDefaults()
 	cfg.ensureGlobalDefaults(meta)
+	cfg.ensureConsensusDefaults(meta)
 
 	if strings.TrimSpace(cfg.NetworkName) == "" {
 		cfg.NetworkName = "nhb-local"
@@ -494,6 +505,23 @@ func (cfg *Config) ensureGlobalDefaults(meta toml.MetaData) {
 	}
 	if !meta.IsDefined("global", "blocks", "MaxTxs") {
 		cfg.Global.Blocks.MaxTxs = defaults.Blocks.MaxTxs
+	}
+}
+
+func (cfg *Config) ensureConsensusDefaults(meta toml.MetaData) {
+	defaults := defaultConsensusConfig()
+
+	if !meta.IsDefined("consensus", "ProposalTimeout") {
+		cfg.Consensus.ProposalTimeout = defaults.ProposalTimeout
+	}
+	if !meta.IsDefined("consensus", "PrevoteTimeout") {
+		cfg.Consensus.PrevoteTimeout = defaults.PrevoteTimeout
+	}
+	if !meta.IsDefined("consensus", "PrecommitTimeout") {
+		cfg.Consensus.PrecommitTimeout = defaults.PrecommitTimeout
+	}
+	if !meta.IsDefined("consensus", "CommitTimeout") {
+		cfg.Consensus.CommitTimeout = defaults.CommitTimeout
 	}
 }
 
@@ -955,6 +983,7 @@ func createDefault(path string, passphrase string) (*Config, error) {
 		},
 	}
 	cfg.Global = defaultGlobalConfig()
+	cfg.Consensus = defaultConsensusConfig()
 	cfg.ValidatorKeystorePath = keystorePath
 	cfg.syncTopLevelToP2P()
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -366,6 +366,28 @@ ValidatorKeystorePath = "%s"
 	}
 }
 
+func TestLoadSetsConsensusDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	keystorePath := filepath.Join(dir, "validator.keystore")
+	contents := fmt.Sprintf(`ListenAddress = "0.0.0.0:6001"
+ValidatorKeystorePath = "%s"
+`, keystorePath)
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path, WithKeystorePassphrase(testKeystorePassphrase))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	want := defaultConsensusConfig()
+	if cfg.Consensus != want {
+		t.Fatalf("unexpected consensus defaults: %+v", cfg.Consensus)
+	}
+}
+
 func TestLoadWithoutPassphraseFailsToCreateDefault(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")

--- a/config/types.go
+++ b/config/types.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // Governance captures global governance policy knobs that must be validated
 // before applying runtime configuration updates.
 type Governance struct {
@@ -22,6 +24,14 @@ type Mempool struct {
 // Blocks captures block production limits for transaction counts.
 type Blocks struct {
 	MaxTxs int64
+}
+
+// Consensus controls the BFT round timeouts.
+type Consensus struct {
+	ProposalTimeout  time.Duration `toml:"ProposalTimeout"`
+	PrevoteTimeout   time.Duration `toml:"PrevoteTimeout"`
+	PrecommitTimeout time.Duration `toml:"PrecommitTimeout"`
+	CommitTimeout    time.Duration `toml:"CommitTimeout"`
 }
 
 type Pauses struct {

--- a/config/validate.go
+++ b/config/validate.go
@@ -24,3 +24,20 @@ func ValidateConfig(g Global) error {
 	}
 	return nil
 }
+
+// ValidateConsensus ensures consensus timeouts are positive durations.
+func ValidateConsensus(c Consensus) error {
+	if c.ProposalTimeout <= 0 {
+		return fmt.Errorf("consensus: proposal timeout must be positive")
+	}
+	if c.PrevoteTimeout <= 0 {
+		return fmt.Errorf("consensus: prevote timeout must be positive")
+	}
+	if c.PrecommitTimeout <= 0 {
+		return fmt.Errorf("consensus: precommit timeout must be positive")
+	}
+	if c.CommitTimeout <= 0 {
+		return fmt.Errorf("consensus: commit timeout must be positive")
+	}
+	return nil
+}

--- a/docs/consensusd/getting-started.md
+++ b/docs/consensusd/getting-started.md
@@ -22,6 +22,10 @@ for deployments where the validator stack is isolated from external clients.
 | `--allow-autogenesis` | `false` | Development flag enabling automatic genesis creation when no data exists. |
 | `--grpc` | `127.0.0.1:9090` | Listen address for the consensus gRPC API. |
 | `--p2p` | `localhost:9091` | Target address of the `p2pd` gRPC service. |
+| `--consensus-timeout-proposal` | Config (default `2s`) | Wait for a proposal before prevoting. |
+| `--consensus-timeout-prevote` | Config (default `2s`) | Wait after prevoting before moving to precommit. |
+| `--consensus-timeout-precommit` | Config (default `2s`) | Wait after precommitting before attempting commit. |
+| `--consensus-timeout-commit` | Config (default `4s`) | Maximum time allotted for committing a block before starting a new round. |
 
 Environment helpers:
 
@@ -30,6 +34,25 @@ Environment helpers:
 * `NHB_VALIDATOR_PASS` – required to decrypt the validator keystore unless KMS is configured.
 * `NHB_NETWORK_SHARED_SECRET` (or the value of `network_security.SharedSecretEnv`)
   – supplies the shared-secret token used to authorize gRPC requests.
+* `NHB_CONSENSUS_TIMEOUT_PROPOSAL`, `NHB_CONSENSUS_TIMEOUT_PREVOTE`, `NHB_CONSENSUS_TIMEOUT_PRECOMMIT`, and `NHB_CONSENSUS_TIMEOUT_COMMIT`
+  – override the matching CLI flags with duration strings such as `500ms` or `3s`.
+
+## Consensus Timeouts
+
+`consensusd` reads the round timers from the `[consensus]` section of `config.toml`
+and falls back to the built-in defaults when the values are omitted. All duration
+values accept the Go duration format (`750ms`, `2s`, `1m30s`, etc.).
+
+```toml
+[consensus]
+ProposalTimeout = "2s"
+PrevoteTimeout = "2s"
+PrecommitTimeout = "2s"
+CommitTimeout = "4s"
+```
+
+Operators can adjust the timers at runtime with CLI flags or the environment
+variables listed above to better match their network latency profile.
 
 ## Ports and Connectivity
 

--- a/tests/config/invariants_test.go
+++ b/tests/config/invariants_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"testing"
+	"time"
 
 	"nhbchain/config"
 )
@@ -138,6 +139,74 @@ func TestValidateConfig(t *testing.T) {
 			err := config.ValidateConfig(tc.cfg)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("ValidateConfig() error = %v, wantErr %t", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateConsensus(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.Consensus
+		wantErr bool
+	}{
+		{
+			name: "valid timeouts",
+			cfg: config.Consensus{
+				ProposalTimeout:  time.Second,
+				PrevoteTimeout:   time.Second,
+				PrecommitTimeout: time.Second,
+				CommitTimeout:    2 * time.Second,
+			},
+		},
+		{
+			name: "proposal timeout non-positive",
+			cfg: config.Consensus{
+				ProposalTimeout:  0,
+				PrevoteTimeout:   time.Second,
+				PrecommitTimeout: time.Second,
+				CommitTimeout:    2 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "prevote timeout non-positive",
+			cfg: config.Consensus{
+				ProposalTimeout:  time.Second,
+				PrevoteTimeout:   -time.Second,
+				PrecommitTimeout: time.Second,
+				CommitTimeout:    2 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "precommit timeout non-positive",
+			cfg: config.Consensus{
+				ProposalTimeout:  time.Second,
+				PrevoteTimeout:   time.Second,
+				PrecommitTimeout: 0,
+				CommitTimeout:    2 * time.Second,
+			},
+			wantErr: true,
+		},
+		{
+			name: "commit timeout non-positive",
+			cfg: config.Consensus{
+				ProposalTimeout:  time.Second,
+				PrevoteTimeout:   time.Second,
+				PrecommitTimeout: time.Second,
+				CommitTimeout:    -time.Second,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := config.ValidateConsensus(tc.cfg)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateConsensus() error = %v, wantErr %t", err, tc.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add consensus timeout fields, defaults, and validation alongside unit coverage for loading and invariants
- allow the BFT engine to accept configurable round timeouts and wire them through nhb/consensusd
- expose CLI and environment overrides for consensusd and document the new operator controls

## Testing
- go test ./config
- go test ./consensus/bft
- go test ./tests/config
- go test ./cmd/consensusd

------
https://chatgpt.com/codex/tasks/task_e_68ddc1fe89c0832da2f46c0567e094c9