### PR TITLE
Document network security requirements for consensusd startup

### DIFF
--- a/config-local.toml
+++ b/config-local.toml
@@ -41,7 +41,8 @@ ClientVersion = "nhbchain/node"
 
 [network_security]
 # Configure a shared secret for local development so consensusd only accepts
-# authenticated requests. Production deployments should supply the secret via
+# authenticated requests. The daemon refuses to start when this block resolves
+# to an empty secret. Production deployments should supply the secret via
 # SharedSecretFile or SharedSecretEnv and/or enable mutual TLS.
 SharedSecret = "local-dev-shared-secret"
 # Local development defaults to plaintext; production operators must provision TLS

--- a/config-peer.toml
+++ b/config-peer.toml
@@ -33,6 +33,22 @@ BanDurationSeconds = 3600
 DialBackoffSeconds = 30
 PEX = true
 
+[network_security]
+# Remote validators must configure a shared secret (via env, file, or inline)
+# so consensusd can authenticate to p2pd. Populate SharedSecretEnv/SharedSecretFile
+# for production deployments; consensusd will refuse to start if this block
+# resolves to an empty token.
+SharedSecretEnv = "NHB_NETWORK_SHARED_SECRET"
+SharedSecretFile = "/etc/nhb/network.token"
+SharedSecret = ""
+AllowInsecure = false
+# Leave the TLS paths commented until certificates are provisioned. Production
+# clusters should enable mutual TLS and keep AllowInsecure = false.
+# ServerTLSCertFile = "/etc/nhb/tls/p2pd.crt"
+# ServerTLSKeyFile = "/etc/nhb/tls/p2pd.key"
+# ClientTLSCertFile = "/etc/nhb/tls/consensus.crt"
+# ClientTLSKeyFile = "/etc/nhb/tls/consensus.key"
+
 PeerBanSeconds = 3600
 ReadTimeout = 90
 WriteTimeout = 5

--- a/config.toml
+++ b/config.toml
@@ -33,6 +33,28 @@ BanDurationSeconds = 3600
 DialBackoffSeconds = 30
 PEX = true
 
+[network_security]
+# Shared-secret token distributed out-of-band. Configure one of the following
+# sources so consensusd and p2pd can authenticate each other. The daemon will
+# refuse to start if none resolve to a non-empty value.
+SharedSecretEnv = "NHB_NETWORK_SHARED_SECRET"
+SharedSecretFile = "/etc/nhb/network.token"
+SharedSecret = ""
+# Production deployments must disable plaintext by leaving AllowInsecure=false
+# and provisioning TLS certificates. Local lab setups can flip this to true
+# temporarily when TLS is not available.
+AllowInsecure = false
+AuthorizationHeader = "x-nhb-network-token"
+AllowUnauthenticatedReads = false
+ServerTLSCertFile = "/etc/nhb/tls/p2pd.crt"
+ServerTLSKeyFile = "/etc/nhb/tls/p2pd.key"
+ClientTLSCertFile = "/etc/nhb/tls/consensus.crt"
+ClientTLSKeyFile = "/etc/nhb/tls/consensus.key"
+ClientCAFile = "/etc/nhb/tls/consensus-ca.pem"
+ServerCAFile = "/etc/nhb/tls/p2pd-ca.pem"
+AllowedClientCommonNames = ["consensusd"]
+ServerName = "p2pd.internal"
+
 PeerBanSeconds = 3600
 ReadTimeout = 90
 WriteTimeout = 5

--- a/docs/consensusd/getting-started.md
+++ b/docs/consensusd/getting-started.md
@@ -13,6 +13,14 @@ for deployments where the validator stack is isolated from external clients.
 * Shared-secret or mutual TLS credentials so that only trusted peers can reach
   the consensus gRPC API.
 
+> **Important:** `consensusd` refuses to start when the `[network_security]`
+> block is missing or resolves to an empty shared secret. For quick local
+> experiments, copy the inline example from `config-local.toml` (set
+> `AllowInsecure = true` and provide a short `SharedSecret`). Production
+> deployments must supply the token via `SharedSecretEnv` or `SharedSecretFile`,
+> leave `AllowInsecure = false`, and provision TLS material so both `consensusd`
+> and `p2pd` authenticate each other.
+
 ## Command Flags
 
 | Flag | Default | Description |
@@ -33,7 +41,8 @@ Environment helpers:
 * `NHB_ALLOW_AUTOGENESIS` – mirrors the `--allow-autogenesis` flag.
 * `NHB_VALIDATOR_PASS` – required to decrypt the validator keystore unless KMS is configured.
 * `NHB_NETWORK_SHARED_SECRET` (or the value of `network_security.SharedSecretEnv`)
-  – supplies the shared-secret token used to authorize gRPC requests.
+  – supplies the shared-secret token used to authorize gRPC requests. The daemon
+  exits during startup if the resolved secret is blank.
 * `NHB_CONSENSUS_TIMEOUT_PROPOSAL`, `NHB_CONSENSUS_TIMEOUT_PREVOTE`, `NHB_CONSENSUS_TIMEOUT_PRECOMMIT`, and `NHB_CONSENSUS_TIMEOUT_COMMIT`
   – override the matching CLI flags with duration strings such as `500ms` or `3s`.
 

--- a/docs/networking/ops.md
+++ b/docs/networking/ops.md
@@ -38,7 +38,12 @@ interface when deploying across hosts and configure authentication before doing
 so.
 
 The `[network_security]` section in `config.toml` drives both ends of the
-connection:
+connection. `consensusd` validates this block on startup and will refuse to run
+when the shared secret resolves to an empty string. Use the inline example from
+`config-local.toml` for lab environments (`AllowInsecure = true` with a short
+`SharedSecret`) and promote to the production pattern below—external token via
+`SharedSecretEnv`/`SharedSecretFile` plus TLS—before exposing the services
+outside of localhost:
 
 ```toml
 [network_security]


### PR DESCRIPTION
## Summary
- add a `[network_security]` section to the default and peer configuration templates with shared-secret and TLS guidance
- clarify the local template comments to note consensusd will not start without a resolved secret
- update consensusd getting started and networking docs with dev vs production guidance and the new startup requirement

## Testing
- not run (docs/config changes only)


------
https://chatgpt.com/codex/tasks/task_e_68de25c78604832db169220d733b03c7