### PR TITLE
Handle invalid Bech32 addresses without panicking

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"nhbchain/crypto"
@@ -19,7 +20,7 @@ var (
 		addr[len(addr)-1] = 0x24
 		return addr
 	}()
-	testTreasuryAllowAddrString = crypto.NewAddress(crypto.NHBPrefix, testTreasuryAllowAddrBytes[:]).String()
+	testTreasuryAllowAddrString = crypto.MustNewAddress(crypto.NHBPrefix, testTreasuryAllowAddrBytes[:]).String()
 )
 
 func TestLoadParsesP2PSettings(t *testing.T) {
@@ -341,6 +342,18 @@ func TestGovPolicyParsing(t *testing.T) {
 	}
 	if _, err := (GovConfig{MinDepositWei: "abc"}).Policy(); err == nil {
 		t.Fatalf("expected error for invalid deposit")
+	}
+}
+
+func TestGovPolicyParsingInvalidTreasuryAddress(t *testing.T) {
+	cfg := GovConfig{TreasuryAllowList: []string{"nhb1invalid"}}
+
+	_, err := cfg.Policy()
+	if err == nil {
+		t.Fatalf("expected error for malformed treasury address")
+	}
+	if !strings.Contains(err.Error(), "invalid TreasuryAllowList entry") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/consensus/bft/bft.go
+++ b/consensus/bft/bft.go
@@ -704,7 +704,7 @@ func (e *Engine) selectProposer(round int) []byte {
 	for i, addrBytes := range validators {
 		weight := weights[i]
 		if pick.Cmp(weight) < 0 {
-			fmt.Printf("Deterministic proposer selection: %s (Power: %s)\n", crypto.NewAddress(crypto.NHBPrefix, addrBytes).String(), weight.String())
+			fmt.Printf("Deterministic proposer selection: %s (Power: %s)\n", crypto.MustNewAddress(crypto.NHBPrefix, addrBytes).String(), weight.String())
 			return addrBytes
 		}
 		pick.Sub(pick, weight)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -43,7 +43,7 @@ func TestNewBlockchainLoadsGenesisFromFile(t *testing.T) {
 	db := storage.NewMemDB()
 	defer db.Close()
 
-	addr := crypto.NewAddress(crypto.NHBPrefix, bytes.Repeat([]byte{0x01}, 20)).String()
+	addr := crypto.MustNewAddress(crypto.NHBPrefix, bytes.Repeat([]byte{0x01}, 20)).String()
 	spec := genesis.GenesisSpec{
 		GenesisTime: "2024-01-01T00:00:00Z",
 		NativeTokens: []genesis.NativeTokenSpec{
@@ -237,7 +237,7 @@ func TestNewBlockchainChainIDMismatchDoesNotPersistState(t *testing.T) {
 	db := storage.NewMemDB()
 	defer db.Close()
 
-	addr := crypto.NewAddress(crypto.NHBPrefix, bytes.Repeat([]byte{0x01}, 20)).String()
+	addr := crypto.MustNewAddress(crypto.NHBPrefix, bytes.Repeat([]byte{0x01}, 20)).String()
 
 	spec := genesis.GenesisSpec{
 		GenesisTime: "2024-01-01T00:00:00Z",

--- a/core/events/claimable.go
+++ b/core/events/claimable.go
@@ -32,7 +32,7 @@ func (e ClaimableCreated) Event() *types.Event {
 		Type: TypeClaimableCreated,
 		Attributes: map[string]string{
 			"id":            hex.EncodeToString(e.ID[:]),
-			"payer":         crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
+			"payer":         crypto.MustNewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
 			"token":         e.Token,
 			"amount":        formatAmount(e.Amount),
 			"deadline":      intToString(e.Deadline),
@@ -58,8 +58,8 @@ func (e ClaimableClaimed) Event() *types.Event {
 		Type: TypeClaimableClaimed,
 		Attributes: map[string]string{
 			"id":            hex.EncodeToString(e.ID[:]),
-			"payer":         crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
-			"payee":         crypto.NewAddress(crypto.NHBPrefix, e.Payee[:]).String(),
+			"payer":         crypto.MustNewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
+			"payee":         crypto.MustNewAddress(crypto.NHBPrefix, e.Payee[:]).String(),
 			"token":         e.Token,
 			"amount":        formatAmount(e.Amount),
 			"recipientHint": hex.EncodeToString(e.RecipientHint[:]),
@@ -81,7 +81,7 @@ func (e ClaimableCancelled) Event() *types.Event {
 		Type: TypeClaimableCancelled,
 		Attributes: map[string]string{
 			"id":     hex.EncodeToString(e.ID[:]),
-			"payer":  crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
+			"payer":  crypto.MustNewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
 			"token":  e.Token,
 			"amount": formatAmount(e.Amount),
 		},
@@ -102,7 +102,7 @@ func (e ClaimableExpired) Event() *types.Event {
 		Type: TypeClaimableExpired,
 		Attributes: map[string]string{
 			"id":     hex.EncodeToString(e.ID[:]),
-			"payer":  crypto.NewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
+			"payer":  crypto.MustNewAddress(crypto.NHBPrefix, e.Payer[:]).String(),
 			"token":  e.Token,
 			"amount": formatAmount(e.Amount),
 		},

--- a/core/events/engagement.go
+++ b/core/events/engagement.go
@@ -28,7 +28,7 @@ func (e EngagementHeartbeat) Event() *types.Event {
 	return &types.Event{
 		Type: TypeEngagementHeartbeat,
 		Attributes: map[string]string{
-			"address":   crypto.NewAddress(crypto.NHBPrefix, e.Address[:]).String(),
+			"address":   crypto.MustNewAddress(crypto.NHBPrefix, e.Address[:]).String(),
 			"device_id": e.DeviceID,
 			"minutes":   fmt.Sprintf("%d", e.Minutes),
 			"timestamp": fmt.Sprintf("%d", e.Timestamp),
@@ -53,7 +53,7 @@ func (e EngagementScoreUpdated) Event() *types.Event {
 	return &types.Event{
 		Type: TypeEngagementScoreUpdated,
 		Attributes: map[string]string{
-			"address":   crypto.NewAddress(crypto.NHBPrefix, e.Address[:]).String(),
+			"address":   crypto.MustNewAddress(crypto.NHBPrefix, e.Address[:]).String(),
 			"day":       e.Day,
 			"raw":       fmt.Sprintf("%d", e.RawScore),
 			"old_score": fmt.Sprintf("%d", e.OldScore),

--- a/core/events/identity.go
+++ b/core/events/identity.go
@@ -26,7 +26,7 @@ func (e IdentityAliasSet) Event() *types.Event {
 		Type: TypeIdentityAliasSet,
 		Attributes: map[string]string{
 			"alias":   e.Alias,
-			"address": crypto.NewAddress(crypto.NHBPrefix, e.Address[:]).String(),
+			"address": crypto.MustNewAddress(crypto.NHBPrefix, e.Address[:]).String(),
 		},
 	}
 }
@@ -48,7 +48,7 @@ func (e IdentityAliasRenamed) Event() *types.Event {
 		Attributes: map[string]string{
 			"old":     e.OldAlias,
 			"new":     e.NewAlias,
-			"address": crypto.NewAddress(crypto.NHBPrefix, e.Address[:]).String(),
+			"address": crypto.MustNewAddress(crypto.NHBPrefix, e.Address[:]).String(),
 		},
 	}
 }
@@ -69,7 +69,7 @@ func (e IdentityAliasAvatarUpdated) Event() *types.Event {
 		Type: TypeIdentityAliasAvatarUpdated,
 		Attributes: map[string]string{
 			"alias":     e.Alias,
-			"address":   crypto.NewAddress(crypto.NHBPrefix, e.Address[:]).String(),
+			"address":   crypto.MustNewAddress(crypto.NHBPrefix, e.Address[:]).String(),
 			"avatarRef": e.AvatarRef,
 		},
 	}

--- a/core/events/mint.go
+++ b/core/events/mint.go
@@ -40,7 +40,7 @@ func (e MintSettled) Event() *types.Event {
 		Type: TypeMintSettled,
 		Attributes: map[string]string{
 			"invoiceId":   e.InvoiceID,
-			"recipient":   crypto.NewAddress(crypto.NHBPrefix, e.Recipient[:]).String(),
+			"recipient":   crypto.MustNewAddress(crypto.NHBPrefix, e.Recipient[:]).String(),
 			"token":       e.Token,
 			"amount":      e.Amount.String(),
 			"txHash":      txHash,

--- a/core/events/potso.go
+++ b/core/events/potso.go
@@ -36,7 +36,7 @@ type PotsoHeartbeat struct {
 
 // Event converts the heartbeat into the generic event representation.
 func (h PotsoHeartbeat) Event() *types.Event {
-	addr := crypto.NewAddress(crypto.NHBPrefix, h.Address[:])
+	addr := crypto.MustNewAddress(crypto.NHBPrefix, h.Address[:])
 	return &types.Event{
 		Type: TypePotsoHeartbeat,
 		Attributes: map[string]string{
@@ -63,7 +63,7 @@ type PotsoStakeLocked struct {
 
 // Event converts the stake lock notification into a generic event.
 func (e PotsoStakeLocked) Event() *types.Event {
-	addr := crypto.NewAddress(crypto.NHBPrefix, e.Owner[:])
+	addr := crypto.MustNewAddress(crypto.NHBPrefix, e.Owner[:])
 	return &types.Event{
 		Type: TypePotsoStakeLocked,
 		Attributes: map[string]string{
@@ -82,7 +82,7 @@ type PotsoStakeUnbonded struct {
 
 // Event converts the unbond notification into the generic event representation.
 func (e PotsoStakeUnbonded) Event() *types.Event {
-	addr := crypto.NewAddress(crypto.NHBPrefix, e.Owner[:])
+	addr := crypto.MustNewAddress(crypto.NHBPrefix, e.Owner[:])
 	return &types.Event{
 		Type: TypePotsoStakeUnbonded,
 		Attributes: map[string]string{
@@ -101,7 +101,7 @@ type PotsoStakeWithdrawn struct {
 
 // Event converts the withdrawal notification into the generic event representation.
 func (e PotsoStakeWithdrawn) Event() *types.Event {
-	addr := crypto.NewAddress(crypto.NHBPrefix, e.Owner[:])
+	addr := crypto.MustNewAddress(crypto.NHBPrefix, e.Owner[:])
 	return &types.Event{
 		Type: TypePotsoStakeWithdrawn,
 		Attributes: map[string]string{
@@ -150,7 +150,7 @@ type PotsoRewardReady struct {
 
 // Event converts the ready notification into a generic event representation.
 func (e PotsoRewardReady) Event() *types.Event {
-	addr := crypto.NewAddress(crypto.NHBPrefix, e.Address[:])
+	addr := crypto.MustNewAddress(crypto.NHBPrefix, e.Address[:])
 	attrs := map[string]string{
 		"epoch":   fmt.Sprintf("%d", e.Epoch),
 		"address": addr.String(),
@@ -172,7 +172,7 @@ type PotsoRewardPaid struct {
 
 // Event converts the payout into a generic event representation.
 func (e PotsoRewardPaid) Event() *types.Event {
-	addr := crypto.NewAddress(crypto.NHBPrefix, e.Address[:])
+	addr := crypto.MustNewAddress(crypto.NHBPrefix, e.Address[:])
 	attrs := map[string]string{
 		"epoch":   fmt.Sprintf("%d", e.Epoch),
 		"address": addr.String(),

--- a/core/events/potso_evidence.go
+++ b/core/events/potso_evidence.go
@@ -22,8 +22,8 @@ type PotsoEvidenceAccepted struct {
 }
 
 func (e PotsoEvidenceAccepted) Event() *types.Event {
-	offender := crypto.NewAddress(crypto.NHBPrefix, e.Offender[:])
-	reporter := crypto.NewAddress(crypto.NHBPrefix, e.Reporter[:])
+	offender := crypto.MustNewAddress(crypto.NHBPrefix, e.Offender[:])
+	reporter := crypto.MustNewAddress(crypto.NHBPrefix, e.Reporter[:])
 	attrs := map[string]string{
 		"hash":     "0x" + hex.EncodeToString(e.Hash[:]),
 		"type":     e.EvidenceType,
@@ -40,7 +40,7 @@ type PotsoEvidenceRejected struct {
 }
 
 func (e PotsoEvidenceRejected) Event() *types.Event {
-	reporter := crypto.NewAddress(crypto.NHBPrefix, e.Reporter[:])
+	reporter := crypto.MustNewAddress(crypto.NHBPrefix, e.Reporter[:])
 	attrs := map[string]string{
 		"reporter": reporter.String(),
 	}

--- a/core/events/potso_penalty.go
+++ b/core/events/potso_penalty.go
@@ -28,7 +28,7 @@ func (e PotsoPenaltyApplied) Event() *types.Event {
 	attrs := map[string]string{
 		"hash":       "0x" + hex.EncodeToString(e.Hash[:]),
 		"type":       e.Type,
-		"offender":   crypto.NewAddress(crypto.NHBPrefix, e.Offender[:]).String(),
+		"offender":   crypto.MustNewAddress(crypto.NHBPrefix, e.Offender[:]).String(),
 		"decayPct":   formatBps(e.DecayBps),
 		"slashAmt":   amountString(e.SlashAmt),
 		"newWeight":  amountString(e.NewWeight),

--- a/core/events/sponsorship.go
+++ b/core/events/sponsorship.go
@@ -37,10 +37,10 @@ func (e TxSponsorshipApplied) Event() *types.Event {
 		"gasUsed": new(big.Int).SetUint64(e.GasUsed).String(),
 	}
 	if e.Sender != ([20]byte{}) {
-		attrs["sender"] = crypto.NewAddress(crypto.NHBPrefix, e.Sender[:]).String()
+		attrs["sender"] = crypto.MustNewAddress(crypto.NHBPrefix, e.Sender[:]).String()
 	}
 	if e.Sponsor != ([20]byte{}) {
-		attrs["sponsor"] = crypto.NewAddress(crypto.NHBPrefix, e.Sponsor[:]).String()
+		attrs["sponsor"] = crypto.MustNewAddress(crypto.NHBPrefix, e.Sponsor[:]).String()
 	}
 	if e.GasPrice != nil {
 		attrs["gasPriceWei"] = new(big.Int).Set(e.GasPrice).String()
@@ -76,10 +76,10 @@ func (e TxSponsorshipFailed) Event() *types.Event {
 		attrs["reason"] = strings.TrimSpace(e.Reason)
 	}
 	if e.Sender != ([20]byte{}) {
-		attrs["sender"] = crypto.NewAddress(crypto.NHBPrefix, e.Sender[:]).String()
+		attrs["sender"] = crypto.MustNewAddress(crypto.NHBPrefix, e.Sender[:]).String()
 	}
 	if e.Sponsor != ([20]byte{}) {
-		attrs["sponsor"] = crypto.NewAddress(crypto.NHBPrefix, e.Sponsor[:]).String()
+		attrs["sponsor"] = crypto.MustNewAddress(crypto.NHBPrefix, e.Sponsor[:]).String()
 	}
 	return &types.Event{Type: TypeTxSponsorshipFailed, Attributes: attrs}
 }

--- a/core/events/swap.go
+++ b/core/events/swap.go
@@ -46,7 +46,7 @@ func (e SwapMinted) Event() *types.Event {
 	}
 	recipient := ""
 	if e.Recipient != ([20]byte{}) {
-		recipient = crypto.NewAddress(crypto.NHBPrefix, e.Recipient[:]).String()
+		recipient = crypto.MustNewAddress(crypto.NHBPrefix, e.Recipient[:]).String()
 	}
 	return &types.Event{
 		Type: TypeSwapMinted,
@@ -144,7 +144,7 @@ func (a SwapLimitAlert) Event() *types.Event {
 		"limit":        strings.TrimSpace(a.Limit),
 	}
 	if a.Address != ([20]byte{}) {
-		attrs["address"] = crypto.NewAddress(crypto.NHBPrefix, a.Address[:]).String()
+		attrs["address"] = crypto.MustNewAddress(crypto.NHBPrefix, a.Address[:]).String()
 	}
 	amount := big.NewInt(0)
 	if a.Amount != nil {
@@ -177,7 +177,7 @@ func (a SwapSanctionAlert) Event() *types.Event {
 		"providerTxId": strings.TrimSpace(a.ProviderTxID),
 	}
 	if a.Address != ([20]byte{}) {
-		attrs["address"] = crypto.NewAddress(crypto.NHBPrefix, a.Address[:]).String()
+		attrs["address"] = crypto.MustNewAddress(crypto.NHBPrefix, a.Address[:]).String()
 	}
 	return &types.Event{Type: TypeSwapAlertSanction, Attributes: attrs}
 }
@@ -205,7 +205,7 @@ func (a SwapVelocityAlert) Event() *types.Event {
 		"observedCount": strconv.Itoa(a.ObservedCount),
 	}
 	if a.Address != ([20]byte{}) {
-		attrs["address"] = crypto.NewAddress(crypto.NHBPrefix, a.Address[:]).String()
+		attrs["address"] = crypto.MustNewAddress(crypto.NHBPrefix, a.Address[:]).String()
 	}
 	return &types.Event{Type: TypeSwapAlertVelocity, Attributes: attrs}
 }

--- a/core/genesis/spec_test.go
+++ b/core/genesis/spec_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 func TestLoadGenesisSpecAndBuildGenesis(t *testing.T) {
-	addr1 := crypto.NewAddress(crypto.NHBPrefix, bytes.Repeat([]byte{0x01}, 20)).String()
-	addr2 := crypto.NewAddress(crypto.ZNHBPrefix, bytes.Repeat([]byte{0x02}, 20)).String()
+	addr1 := crypto.MustNewAddress(crypto.NHBPrefix, bytes.Repeat([]byte{0x01}, 20)).String()
+	addr2 := crypto.MustNewAddress(crypto.ZNHBPrefix, bytes.Repeat([]byte{0x02}, 20)).String()
 
 	chainID := uint64(42)
 	paused := true

--- a/core/identity_integration_test.go
+++ b/core/identity_integration_test.go
@@ -65,7 +65,7 @@ func TestNodeIdentityAliasLifecycle(t *testing.T) {
 	if len(eventsList) != 2 {
 		t.Fatalf("expected 2 events, got %d", len(eventsList))
 	}
-	expectedAddr := crypto.NewAddress(crypto.NHBPrefix, addr[:]).String()
+	expectedAddr := crypto.MustNewAddress(crypto.NHBPrefix, addr[:]).String()
 	if eventsList[0].Type != events.TypeIdentityAliasSet {
 		t.Fatalf("unexpected first event type: %s", eventsList[0].Type)
 	}

--- a/core/node.go
+++ b/core/node.go
@@ -948,13 +948,13 @@ func cloneAddress(addr crypto.Address) crypto.Address {
 	if len(bytes) == 0 {
 		return crypto.Address{}
 	}
-	return crypto.NewAddress(addr.Prefix(), append([]byte(nil), bytes...))
+	return crypto.MustNewAddress(addr.Prefix(), append([]byte(nil), bytes...))
 }
 
 func deriveModuleAddress(seed string, prefix crypto.AddressPrefix) crypto.Address {
 	hash := ethcrypto.Keccak256([]byte(seed))
 	raw := append([]byte(nil), hash[len(hash)-20:]...)
-	return crypto.NewAddress(prefix, raw)
+	return crypto.MustNewAddress(prefix, raw)
 }
 
 func (n *Node) emitSwapLimitAlert(alert events.SwapLimitAlert) {

--- a/core/potso_rewards_integration_test.go
+++ b/core/potso_rewards_integration_test.go
@@ -377,8 +377,8 @@ func TestPotsoRewardClaimFlow(t *testing.T) {
 	if len(records) != 3 { // header + 2 rows
 		t.Fatalf("expected 3 CSV rows, got %d", len(records))
 	}
-	addrA := crypto.NewAddress(crypto.NHBPrefix, participantA[:]).String()
-	addrB := crypto.NewAddress(crypto.NHBPrefix, participantB[:]).String()
+	addrA := crypto.MustNewAddress(crypto.NHBPrefix, participantA[:]).String()
+	addrB := crypto.MustNewAddress(crypto.NHBPrefix, participantB[:]).String()
 	seenA := false
 	seenB := false
 	for _, row := range records[1:] {

--- a/core/rewards_logic.go
+++ b/core/rewards_logic.go
@@ -172,7 +172,7 @@ func (sp *StateProcessor) applyAccountRewards(epochNumber uint64, rewardMap map[
 		}
 		payouts = append(payouts, payout)
 
-		bech := crypto.NewAddress(crypto.NHBPrefix, reward.addr)
+		bech := crypto.MustNewAddress(crypto.NHBPrefix, reward.addr)
 		attrs := map[string]string{
 			"epoch":   strconv.FormatUint(epochNumber, 10),
 			"account": bech.String(),

--- a/core/state/governance_test.go
+++ b/core/state/governance_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestGovernanceEscrowAndProposalHelpers(t *testing.T) {
 	manager := newTestManager(t)
-	proposer := crypto.NewAddress(crypto.NHBPrefix, make([]byte, 20))
+	proposer := crypto.MustNewAddress(crypto.NHBPrefix, make([]byte, 20))
 	addrBytes := proposer.Bytes()
 	if balance, err := manager.GovernanceEscrowBalance(addrBytes); err != nil {
 		t.Fatalf("escrow balance: %v", err)
@@ -114,8 +114,8 @@ func TestGovernanceEscrowAndProposalHelpers(t *testing.T) {
 func TestGovernanceVoteIndexing(t *testing.T) {
 	manager := newTestManager(t)
 	proposalID := uint64(5)
-	voterA := crypto.NewAddress(crypto.NHBPrefix, append(make([]byte, 19), 1))
-	voterB := crypto.NewAddress(crypto.NHBPrefix, append(make([]byte, 19), 2))
+	voterA := crypto.MustNewAddress(crypto.NHBPrefix, append(make([]byte, 19), 1))
+	voterB := crypto.MustNewAddress(crypto.NHBPrefix, append(make([]byte, 19), 2))
 
 	voteA := &governance.Vote{
 		ProposalID: proposalID,

--- a/core/state/manager.go
+++ b/core/state/manager.go
@@ -261,7 +261,7 @@ func (s *storedGovernanceProposal) toGovernanceProposal() (*governance.Proposal,
 	if !validProposalStatus(status) {
 		return nil, fmt.Errorf("governance: invalid proposal status")
 	}
-	submitter := crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), s.Submitter[:]...))
+	submitter := crypto.MustNewAddress(crypto.NHBPrefix, append([]byte(nil), s.Submitter[:]...))
 	deposit := big.NewInt(0)
 	if s.Deposit != nil {
 		deposit = new(big.Int).Set(s.Deposit)
@@ -310,7 +310,7 @@ func (s *storedGovernanceVote) toGovernanceVote() (*governance.Vote, error) {
 	if !choice.Valid() {
 		return nil, fmt.Errorf("governance: invalid vote choice %q", s.Choice)
 	}
-	voter := crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), s.Voter[:]...))
+	voter := crypto.MustNewAddress(crypto.NHBPrefix, append([]byte(nil), s.Voter[:]...))
 	vote := &governance.Vote{
 		ProposalID: s.ProposalID,
 		Voter:      voter,
@@ -976,10 +976,10 @@ func (s *storedLendingMarket) toMarket() *lending.Market {
 	}
 	var zeroAddr [20]byte
 	if !bytes.Equal(s.DeveloperOwner[:], zeroAddr[:]) {
-		market.DeveloperOwner = crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), s.DeveloperOwner[:]...))
+		market.DeveloperOwner = crypto.MustNewAddress(crypto.NHBPrefix, append([]byte(nil), s.DeveloperOwner[:]...))
 	}
 	if !bytes.Equal(s.DeveloperCollector[:], zeroAddr[:]) {
-		market.DeveloperFeeCollector = crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), s.DeveloperCollector[:]...))
+		market.DeveloperFeeCollector = crypto.MustNewAddress(crypto.NHBPrefix, append([]byte(nil), s.DeveloperCollector[:]...))
 	}
 	if s.TotalNHBSupplied != nil {
 		market.TotalNHBSupplied = new(big.Int).Set(s.TotalNHBSupplied)
@@ -1061,7 +1061,7 @@ func (s *storedLendingUser) toUserAccount() *lending.UserAccount {
 		return nil
 	}
 	account := &lending.UserAccount{
-		Address: crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), s.Address[:]...)),
+		Address: crypto.MustNewAddress(crypto.NHBPrefix, append([]byte(nil), s.Address[:]...)),
 	}
 	if s.CollateralZNHB != nil {
 		account.CollateralZNHB = new(big.Int).Set(s.CollateralZNHB)
@@ -1994,7 +1994,7 @@ func (m *Manager) PotsoRewardsBuildCSV(epoch uint64) ([]byte, *big.Int, int, err
 			}
 		}
 		record := []string{
-			crypto.NewAddress(crypto.NHBPrefix, addr[:]).String(),
+			crypto.MustNewAddress(crypto.NHBPrefix, addr[:]).String(),
 			amount.String(),
 			strconv.FormatBool(claimed),
 			strconv.FormatUint(claimedAt, 10),

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -246,7 +246,7 @@ func (sp *StateProcessor) emitQuotaExceeded(module string, addr []byte, epoch ui
 	}
 	if len(addr) > 0 {
 		if len(addr) == common.AddressLength {
-			attrs["address"] = crypto.NewAddress(crypto.NHBPrefix, addr).String()
+			attrs["address"] = crypto.MustNewAddress(crypto.NHBPrefix, addr).String()
 		} else {
 			attrs["address"] = hex.EncodeToString(addr)
 		}
@@ -1371,7 +1371,7 @@ func (sp *StateProcessor) applyRegisterIdentity(tx *types.Transaction, sender []
 		return err
 	}
 	fmt.Printf("Identity processed: Username '%s' registered to %s.\n",
-		username, crypto.NewAddress(crypto.NHBPrefix, sender).String())
+		username, crypto.MustNewAddress(crypto.NHBPrefix, sender).String())
 	return nil
 }
 
@@ -1599,8 +1599,8 @@ func (sp *StateProcessor) StakeDelegate(delegator, validator []byte, amount *big
 		return nil, err
 	}
 
-	delegatorAddr := crypto.NewAddress(crypto.NHBPrefix, delegator)
-	validatorAddr := crypto.NewAddress(crypto.NHBPrefix, target)
+	delegatorAddr := crypto.MustNewAddress(crypto.NHBPrefix, delegator)
+	validatorAddr := crypto.MustNewAddress(crypto.NHBPrefix, target)
 	sp.AppendEvent(&types.Event{
 		Type: "stake.delegated",
 		Attributes: map[string]string{
@@ -1679,8 +1679,8 @@ func (sp *StateProcessor) StakeUndelegate(delegator []byte, amount *big.Int) (*t
 		return nil, err
 	}
 
-	delegatorAddr := crypto.NewAddress(crypto.NHBPrefix, delegator)
-	validatorAddr := crypto.NewAddress(crypto.NHBPrefix, validator)
+	delegatorAddr := crypto.MustNewAddress(crypto.NHBPrefix, delegator)
+	validatorAddr := crypto.MustNewAddress(crypto.NHBPrefix, validator)
 	sp.AppendEvent(&types.Event{
 		Type: "stake.undelegated",
 		Attributes: map[string]string{
@@ -1737,8 +1737,8 @@ func (sp *StateProcessor) StakeClaim(delegator []byte, unbondID uint64) (*types.
 		return nil, err
 	}
 
-	delegatorAddr := crypto.NewAddress(crypto.NHBPrefix, delegator)
-	validatorAddr := crypto.NewAddress(crypto.NHBPrefix, entry.Validator)
+	delegatorAddr := crypto.MustNewAddress(crypto.NHBPrefix, delegator)
+	validatorAddr := crypto.MustNewAddress(crypto.NHBPrefix, entry.Validator)
 	sp.AppendEvent(&types.Event{
 		Type: "stake.claimed",
 		Attributes: map[string]string{
@@ -1866,7 +1866,7 @@ func (sp *StateProcessor) applyHeartbeat(tx *types.Transaction, sender []byte, s
 	}
 
 	fmt.Printf("Heartbeat processed: %s recorded %d minute(s).\n",
-		crypto.NewAddress(crypto.NHBPrefix, sender).String(), minutes)
+		crypto.MustNewAddress(crypto.NHBPrefix, sender).String(), minutes)
 	return nil
 }
 

--- a/native/governance/engine.go
+++ b/native/governance/engine.go
@@ -649,7 +649,7 @@ func decodeAddress(addr string) ([20]byte, error) {
 }
 
 func formatAddress(addr [20]byte) string {
-	return crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), addr[:]...)).String()
+	return crypto.MustNewAddress(crypto.NHBPrefix, append([]byte(nil), addr[:]...)).String()
 }
 
 func parseSlashingPolicyPayload(payloadJSON string) (*parsedSlashingPolicy, error) {
@@ -738,7 +738,7 @@ func (e *Engine) parseTreasuryDirectivePayload(payloadJSON string) (*parsedTreas
 		return nil, fmt.Errorf("governance: invalid source address: %w", err)
 	}
 	if _, ok := e.treasuryAllow[src]; !ok {
-		return nil, fmt.Errorf("governance: source %s not in treasury allow-list", crypto.NewAddress(crypto.NHBPrefix, src[:]).String())
+		return nil, fmt.Errorf("governance: source %s not in treasury allow-list", crypto.MustNewAddress(crypto.NHBPrefix, src[:]).String())
 	}
 	if len(payload.Transfers) == 0 {
 		return nil, fmt.Errorf("governance: treasury directive must include at least one transfer")
@@ -1109,7 +1109,7 @@ func (e *Engine) SubmitProposal(proposer [20]byte, kind string, payloadJSON stri
 	votingEnd := now.Add(time.Duration(e.votingPeriodSeconds) * time.Second)
 	timelockEnd := votingEnd.Add(time.Duration(e.timelockSeconds) * time.Second)
 
-	submitter := crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), proposer[:]...))
+	submitter := crypto.MustNewAddress(crypto.NHBPrefix, append([]byte(nil), proposer[:]...))
 	depositCopy := new(big.Int).Set(lockAmount)
 	proposal := &Proposal{
 		ID:             proposalID,
@@ -1203,7 +1203,7 @@ func (e *Engine) CastVote(proposalID uint64, voter [20]byte, choice string) erro
 
 	vote := &Vote{
 		ProposalID: proposalID,
-		Voter:      crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), voter[:]...)),
+		Voter:      crypto.MustNewAddress(crypto.NHBPrefix, append([]byte(nil), voter[:]...)),
 		Choice:     voteChoice,
 		PowerBps:   uint32(power),
 		Timestamp:  now,

--- a/native/governance/engine_test.go
+++ b/native/governance/engine_test.go
@@ -719,7 +719,7 @@ func TestFinalizeRejectsBeforeVotingEnd(t *testing.T) {
 	state := newMockGovernanceState(map[[20]byte]*types.Account{
 		proposer: &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)},
 	})
-	submitter := crypto.NewAddress(crypto.NHBPrefix, proposer[:])
+	submitter := crypto.MustNewAddress(crypto.NHBPrefix, proposer[:])
 	state.proposals[1] = &Proposal{
 		ID:        1,
 		Submitter: submitter,
@@ -833,7 +833,7 @@ func TestFinalizeOutcomes(t *testing.T) {
 			state := newMockGovernanceState(map[[20]byte]*types.Account{
 				proposer: &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)},
 			})
-			submitter := crypto.NewAddress(crypto.NHBPrefix, proposer[:])
+			submitter := crypto.MustNewAddress(crypto.NHBPrefix, proposer[:])
 			proposalID := uint64(100 + idx)
 			state.proposals[proposalID] = &Proposal{
 				ID:        proposalID,
@@ -853,7 +853,7 @@ func TestFinalizeOutcomes(t *testing.T) {
 
 			for voteIdx, vote := range tc.votes {
 				voterBytes := append(make([]byte, 19), byte(voteIdx+1))
-				voter := crypto.NewAddress(crypto.NHBPrefix, voterBytes)
+				voter := crypto.MustNewAddress(crypto.NHBPrefix, voterBytes)
 				if err := state.GovernancePutVote(&Vote{ProposalID: proposalID, Voter: voter, Choice: vote.choice, PowerBps: vote.power}); err != nil {
 					t.Fatalf("store vote: %v", err)
 				}
@@ -1202,8 +1202,8 @@ func TestExecuteRoleAllowlistProposal(t *testing.T) {
 	engine.SetNowFunc(func() time.Time { return now })
 
 	payload := fmt.Sprintf(`{"grant":[{"role":"compliance","address":"%s"}],"revoke":[{"role":"compliance","address":"%s"}]}`,
-		crypto.NewAddress(crypto.NHBPrefix, grant[:]).String(),
-		crypto.NewAddress(crypto.NHBPrefix, revoke[:]).String(),
+		crypto.MustNewAddress(crypto.NHBPrefix, grant[:]).String(),
+		crypto.MustNewAddress(crypto.NHBPrefix, revoke[:]).String(),
 	)
 	proposalID, err := engine.SubmitProposal(proposer, ProposalKindRoleAllowlist, payload, big.NewInt(75))
 	if err != nil {
@@ -1257,8 +1257,8 @@ func TestExecuteTreasuryDirective(t *testing.T) {
 	engine.SetNowFunc(func() time.Time { return now })
 
 	payload := fmt.Sprintf(`{"source":"%s","transfers":[{"to":"%s","amountWei":"250"}]}`,
-		crypto.NewAddress(crypto.NHBPrefix, treasury[:]).String(),
-		crypto.NewAddress(crypto.NHBPrefix, recipient[:]).String(),
+		crypto.MustNewAddress(crypto.NHBPrefix, treasury[:]).String(),
+		crypto.MustNewAddress(crypto.NHBPrefix, recipient[:]).String(),
 	)
 	proposalID, err := engine.SubmitProposal(proposer, ProposalKindTreasuryDirective, payload, big.NewInt(10))
 	if err != nil {

--- a/native/lending/engine.go
+++ b/native/lending/engine.go
@@ -155,7 +155,7 @@ func (e *Engine) SetDeveloperFee(bps uint64, collector crypto.Address) {
 		return
 	}
 	cloned := append([]byte(nil), collector.Bytes()...)
-	e.developerFeeAddr = crypto.NewAddress(collector.Prefix(), cloned)
+	e.developerFeeAddr = crypto.MustNewAddress(collector.Prefix(), cloned)
 }
 
 // SetCollateralRouting configures the default collateral distribution applied
@@ -489,7 +489,7 @@ func (e *Engine) Borrow(borrower crypto.Address, amount *big.Int, feeRecipient c
 		}
 		feeBps = e.developerFeeBps
 		cloned := append([]byte(nil), e.developerFeeAddr.Bytes()...)
-		feeRecipient = crypto.NewAddress(e.developerFeeAddr.Prefix(), cloned)
+		feeRecipient = crypto.MustNewAddress(e.developerFeeAddr.Prefix(), cloned)
 	}
 
 	if feeBps > 0 {

--- a/native/lending/engine_accrual_test.go
+++ b/native/lending/engine_accrual_test.go
@@ -80,7 +80,7 @@ func (m *mockEngineState) PutFeeAccrual(_ string, fees *FeeAccrual) error {
 func makeAddress(prefix crypto.AddressPrefix, suffix byte) crypto.Address {
 	raw := make([]byte, 20)
 	raw[len(raw)-1] = suffix
-	return crypto.NewAddress(prefix, raw)
+	return crypto.MustNewAddress(prefix, raw)
 }
 
 func TestAccrueInterestUpdatesIndexesAndFees(t *testing.T) {

--- a/native/lending/types.go
+++ b/native/lending/types.go
@@ -79,10 +79,10 @@ func (r CollateralRouting) Clone() CollateralRouting {
 		ProtocolBps:   r.ProtocolBps,
 	}
 	if bytes := r.DeveloperTarget.Bytes(); len(bytes) != 0 {
-		clone.DeveloperTarget = crypto.NewAddress(r.DeveloperTarget.Prefix(), append([]byte(nil), bytes...))
+		clone.DeveloperTarget = crypto.MustNewAddress(r.DeveloperTarget.Prefix(), append([]byte(nil), bytes...))
 	}
 	if bytes := r.ProtocolTarget.Bytes(); len(bytes) != 0 {
-		clone.ProtocolTarget = crypto.NewAddress(r.ProtocolTarget.Prefix(), append([]byte(nil), bytes...))
+		clone.ProtocolTarget = crypto.MustNewAddress(r.ProtocolTarget.Prefix(), append([]byte(nil), bytes...))
 	}
 	return clone
 }

--- a/native/swap/sanctions_test.go
+++ b/native/swap/sanctions_test.go
@@ -10,7 +10,7 @@ import (
 func TestSanctionsCheckerDenyList(t *testing.T) {
 	var denied [20]byte
 	denied[0] = 1
-	addr := crypto.NewAddress(crypto.NHBPrefix, denied[:])
+	addr := crypto.MustNewAddress(crypto.NHBPrefix, denied[:])
 	cfg := SanctionsConfig{DenyList: []string{addr.String()}}
 	params, err := cfg.Parameters()
 	if err != nil {

--- a/native/swap/voucher.go
+++ b/native/swap/voucher.go
@@ -66,7 +66,7 @@ func (v VoucherV1) MarshalJSON() ([]byte, error) {
 	nonceHex := hex.EncodeToString(v.Nonce)
 	recipient := ""
 	if v.Recipient != ([20]byte{}) {
-		recipient = repoCrypto.NewAddress(repoCrypto.NHBPrefix, v.Recipient[:]).String()
+		recipient = repoCrypto.MustNewAddress(repoCrypto.NHBPrefix, v.Recipient[:]).String()
 	}
 	payload := voucherJSON{
 		Domain:     strings.TrimSpace(v.Domain),

--- a/rpc/claimable_handlers.go
+++ b/rpc/claimable_handlers.go
@@ -242,7 +242,7 @@ func formatClaimableJSON(record *claimable.Claimable) claimableJSON {
 	}
 	return claimableJSON{
 		ID:        formatClaimableID(record.ID),
-		Payer:     crypto.NewAddress(crypto.NHBPrefix, record.Payer[:]).String(),
+		Payer:     crypto.MustNewAddress(crypto.NHBPrefix, record.Payer[:]).String(),
 		Token:     record.Token,
 		Amount:    amount,
 		HashLock:  "0x" + hex.EncodeToString(record.HashLock[:]),

--- a/rpc/creator_handlers.go
+++ b/rpc/creator_handlers.go
@@ -125,7 +125,7 @@ func formatLedger(ledger *creator.PayoutLedger) (pending, totalTips, totalYield 
 }
 
 func formatAddress(addr [20]byte) string {
-	return crypto.NewAddress(crypto.NHBPrefix, addr[:]).String()
+	return crypto.MustNewAddress(crypto.NHBPrefix, addr[:]).String()
 }
 
 func (s *Server) handleCreatorPublish(w http.ResponseWriter, r *http.Request, req *RPCRequest) {

--- a/rpc/escrow_handlers.go
+++ b/rpc/escrow_handlers.go
@@ -384,11 +384,11 @@ func formatEscrowID(id [32]byte) string {
 }
 
 func formatEscrowJSON(esc *escrow.Escrow) escrowJSON {
-	payer := crypto.NewAddress(crypto.NHBPrefix, esc.Payer[:]).String()
-	payee := crypto.NewAddress(crypto.NHBPrefix, esc.Payee[:]).String()
+	payer := crypto.MustNewAddress(crypto.NHBPrefix, esc.Payer[:]).String()
+	payee := crypto.MustNewAddress(crypto.NHBPrefix, esc.Payee[:]).String()
 	var mediatorPtr *string
 	if esc.Mediator != ([20]byte{}) {
-		mediator := crypto.NewAddress(crypto.NHBPrefix, esc.Mediator[:]).String()
+		mediator := crypto.MustNewAddress(crypto.NHBPrefix, esc.Mediator[:]).String()
 		mediatorPtr = &mediator
 	}
 	amount := "0"
@@ -422,7 +422,7 @@ func formatEscrowJSON(esc *escrow.Escrow) escrowJSON {
 			if len(esc.FrozenArb.Members) > 0 {
 				arbitrators = make([]string, 0, len(esc.FrozenArb.Members))
 				for _, member := range esc.FrozenArb.Members {
-					arbitrators = append(arbitrators, crypto.NewAddress(crypto.NHBPrefix, member[:]).String())
+					arbitrators = append(arbitrators, crypto.MustNewAddress(crypto.NHBPrefix, member[:]).String())
 				}
 			}
 		}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -1286,14 +1286,14 @@ func balanceResponseFromAccount(addr string, account *types.Account) BalanceResp
 		resp.LockedZNHB = account.LockedZNHB
 	}
 	if len(account.DelegatedValidator) > 0 {
-		resp.DelegatedValidator = crypto.NewAddress(crypto.NHBPrefix, account.DelegatedValidator).String()
+		resp.DelegatedValidator = crypto.MustNewAddress(crypto.NHBPrefix, account.DelegatedValidator).String()
 	}
 	if len(account.PendingUnbonds) > 0 {
 		resp.PendingUnbonds = make([]StakeUnbondResponse, len(account.PendingUnbonds))
 		for i, entry := range account.PendingUnbonds {
 			validator := ""
 			if len(entry.Validator) > 0 {
-				validator = crypto.NewAddress(crypto.NHBPrefix, entry.Validator).String()
+				validator = crypto.MustNewAddress(crypto.NHBPrefix, entry.Validator).String()
 			}
 			amount := big.NewInt(0)
 			if entry.Amount != nil {

--- a/rpc/identity_handlers.go
+++ b/rpc/identity_handlers.go
@@ -176,10 +176,10 @@ func (s *Server) handleIdentityResolve(w http.ResponseWriter, _ *http.Request, r
 		writeError(w, http.StatusNotFound, req.ID, codeInvalidParams, "alias not found", normalized)
 		return
 	}
-	primary := crypto.NewAddress(crypto.NHBPrefix, record.Primary[:]).String()
+	primary := crypto.MustNewAddress(crypto.NHBPrefix, record.Primary[:]).String()
 	addresses := make([]string, 0, len(record.Addresses))
 	for _, addr := range record.Addresses {
-		addresses = append(addresses, crypto.NewAddress(crypto.NHBPrefix, addr[:]).String())
+		addresses = append(addresses, crypto.MustNewAddress(crypto.NHBPrefix, addr[:]).String())
 	}
 	aliasID := record.AliasID()
 	result := identityResolveResult{

--- a/rpc/loyalty_handlers.go
+++ b/rpc/loyalty_handlers.go
@@ -650,7 +650,7 @@ func (s *Server) handleLoyaltyResolveUsername(w http.ResponseWriter, _ *http.Req
 		writeError(w, http.StatusNotFound, req.ID, codeInvalidParams, "username not found", params.Username)
 		return
 	}
-	writeResult(w, req.ID, crypto.NewAddress(crypto.NHBPrefix, addr).String())
+	writeResult(w, req.ID, crypto.MustNewAddress(crypto.NHBPrefix, addr).String())
 }
 
 func (s *Server) handleLoyaltyUserQR(w http.ResponseWriter, _ *http.Request, req *RPCRequest) {
@@ -676,7 +676,7 @@ func (s *Server) handleLoyaltyUserQR(w http.ResponseWriter, _ *http.Request, req
 			writeError(w, http.StatusNotFound, req.ID, codeInvalidParams, "username not found", params.Username)
 			return
 		}
-		address = crypto.NewAddress(crypto.NHBPrefix, addr).String()
+		address = crypto.MustNewAddress(crypto.NHBPrefix, addr).String()
 	} else {
 		writeError(w, http.StatusBadRequest, req.ID, codeInvalidParams, "username or address required", nil)
 		return
@@ -752,16 +752,16 @@ func formatProgramID(id loyalty.ProgramID) string {
 func formatBusiness(business *loyalty.Business) businessResult {
 	merchants := make([]string, 0, len(business.Merchants))
 	for _, merchant := range business.Merchants {
-		merchants = append(merchants, crypto.NewAddress(crypto.NHBPrefix, merchant[:]).String())
+		merchants = append(merchants, crypto.MustNewAddress(crypto.NHBPrefix, merchant[:]).String())
 	}
 	sort.Strings(merchants)
 	paymaster := ""
 	if !isZeroAddress(business.Paymaster) {
-		paymaster = crypto.NewAddress(crypto.NHBPrefix, business.Paymaster[:]).String()
+		paymaster = crypto.MustNewAddress(crypto.NHBPrefix, business.Paymaster[:]).String()
 	}
 	return businessResult{
 		ID:        formatBusinessID(business.ID),
-		Owner:     crypto.NewAddress(crypto.NHBPrefix, business.Owner[:]).String(),
+		Owner:     crypto.MustNewAddress(crypto.NHBPrefix, business.Owner[:]).String(),
 		Name:      business.Name,
 		Paymaster: paymaster,
 		Merchants: merchants,
@@ -771,8 +771,8 @@ func formatBusiness(business *loyalty.Business) businessResult {
 func formatProgram(program *loyalty.Program) programResult {
 	return programResult{
 		ID:           formatProgramID(program.ID),
-		Owner:        crypto.NewAddress(crypto.NHBPrefix, program.Owner[:]).String(),
-		Pool:         crypto.NewAddress(crypto.NHBPrefix, program.Pool[:]).String(),
+		Owner:        crypto.MustNewAddress(crypto.NHBPrefix, program.Owner[:]).String(),
+		Pool:         crypto.MustNewAddress(crypto.NHBPrefix, program.Pool[:]).String(),
 		TokenSymbol:  program.TokenSymbol,
 		AccrualBps:   program.AccrualBps,
 		MinSpendWei:  bigIntToString(program.MinSpendWei),

--- a/rpc/loyalty_handlers_test.go
+++ b/rpc/loyalty_handlers_test.go
@@ -128,7 +128,7 @@ func TestHandleLoyaltyCreateBusinessSuccess(t *testing.T) {
 	if business.Name != "Acme Corp" {
 		t.Fatalf("unexpected business name: %s", business.Name)
 	}
-	if crypto.NewAddress(crypto.NHBPrefix, business.Owner[:]).String() != ownerAddr {
+	if crypto.MustNewAddress(crypto.NHBPrefix, business.Owner[:]).String() != ownerAddr {
 		t.Fatalf("owner mismatch")
 	}
 }

--- a/rpc/modules/escrow.go
+++ b/rpc/modules/escrow.go
@@ -233,8 +233,8 @@ func formatSnapshotResult(esc *escrow.Escrow) *EscrowSnapshotResult {
 	}
 	result := &EscrowSnapshotResult{
 		ID:        formatEscrowID(esc.ID),
-		Payer:     crypto.NewAddress(crypto.NHBPrefix, esc.Payer[:]).String(),
-		Payee:     crypto.NewAddress(crypto.NHBPrefix, esc.Payee[:]).String(),
+		Payer:     crypto.MustNewAddress(crypto.NHBPrefix, esc.Payer[:]).String(),
+		Payee:     crypto.MustNewAddress(crypto.NHBPrefix, esc.Payee[:]).String(),
 		Token:     esc.Token,
 		Amount:    amount,
 		FeeBps:    esc.FeeBps,
@@ -245,7 +245,7 @@ func formatSnapshotResult(esc *escrow.Escrow) *EscrowSnapshotResult {
 		Meta:      "0x" + hex.EncodeToString(esc.MetaHash[:]),
 	}
 	if esc.Mediator != ([20]byte{}) {
-		mediator := crypto.NewAddress(crypto.NHBPrefix, esc.Mediator[:]).String()
+		mediator := crypto.MustNewAddress(crypto.NHBPrefix, esc.Mediator[:]).String()
 		result.Mediator = &mediator
 	}
 	if trimmed := strings.TrimSpace(esc.RealmID); trimmed != "" {
@@ -290,7 +290,7 @@ func formatAddressList(members [][20]byte) []string {
 		if member == ([20]byte{}) {
 			continue
 		}
-		out = append(out, crypto.NewAddress(crypto.NHBPrefix, member[:]).String())
+		out = append(out, crypto.MustNewAddress(crypto.NHBPrefix, member[:]).String())
 	}
 	return out
 }

--- a/rpc/modules/lending.go
+++ b/rpc/modules/lending.go
@@ -377,7 +377,7 @@ func (m *LendingModule) wrapError(err error) *ModuleError {
 }
 
 func toCryptoAddress(raw [20]byte) crypto.Address {
-	return crypto.NewAddress(crypto.NHBPrefix, append([]byte(nil), raw[:]...))
+	return crypto.MustNewAddress(crypto.NHBPrefix, append([]byte(nil), raw[:]...))
 }
 
 func formatHexAddress(raw [20]byte) string {

--- a/rpc/modules/potso_evidence.go
+++ b/rpc/modules/potso_evidence.go
@@ -264,5 +264,5 @@ func formatHash(hash [32]byte) string {
 }
 
 func formatAddress(addr [20]byte) string {
-	return crypto.NewAddress(crypto.NHBPrefix, addr[:]).String()
+	return crypto.MustNewAddress(crypto.NHBPrefix, addr[:]).String()
 }

--- a/rpc/modules/transactions.go
+++ b/rpc/modules/transactions.go
@@ -66,7 +66,7 @@ func (m *TransactionsModule) PreviewSponsorship(raw json.RawMessage) (*Sponsorsh
 		result.Status = string(assessment.Status)
 		result.Reason = assessment.Reason
 		if assessment.Sponsor != (common.Address{}) {
-			result.Sponsor = crypto.NewAddress(crypto.NHBPrefix, assessment.Sponsor.Bytes()).String()
+			result.Sponsor = crypto.MustNewAddress(crypto.NHBPrefix, assessment.Sponsor.Bytes()).String()
 		}
 		if assessment.GasPrice != nil {
 			result.GasPriceWei = new(big.Int).Set(assessment.GasPrice).String()

--- a/rpc/p2p_handlers.go
+++ b/rpc/p2p_handlers.go
@@ -171,13 +171,13 @@ func (s *Server) handleP2PCreateTrade(w http.ResponseWriter, r *http.Request, re
 		EscrowQuoteID: formatEscrowID(escrowQuoteID),
 		PayIntents: map[string]p2pPayIntentResult{
 			"buyer": {
-				To:     crypto.NewAddress(crypto.NHBPrefix, buyerVault[:]).String(),
+				To:     crypto.MustNewAddress(crypto.NHBPrefix, buyerVault[:]).String(),
 				Token:  normalizedQuote,
 				Amount: quoteAmount.String(),
 				Memo:   "ESCROW:" + formatEscrowID(escrowQuoteID),
 			},
 			"seller": {
-				To:     crypto.NewAddress(crypto.NHBPrefix, sellerVault[:]).String(),
+				To:     crypto.MustNewAddress(crypto.NHBPrefix, sellerVault[:]).String(),
 				Token:  normalizedBase,
 				Amount: baseAmount.String(),
 				Memo:   "ESCROW:" + formatEscrowID(escrowBaseID),
@@ -342,8 +342,8 @@ func writeP2PError(w http.ResponseWriter, id interface{}, err error) {
 }
 
 func formatTradeJSON(trade *escrow.Trade) tradeJSON {
-	buyer := crypto.NewAddress(crypto.NHBPrefix, trade.Buyer[:]).String()
-	seller := crypto.NewAddress(crypto.NHBPrefix, trade.Seller[:]).String()
+	buyer := crypto.MustNewAddress(crypto.NHBPrefix, trade.Buyer[:]).String()
+	seller := crypto.MustNewAddress(crypto.NHBPrefix, trade.Seller[:]).String()
 	quoteAmt := "0"
 	if trade.QuoteAmount != nil {
 		quoteAmt = trade.QuoteAmount.String()

--- a/rpc/p2p_handlers_test.go
+++ b/rpc/p2p_handlers_test.go
@@ -186,14 +186,14 @@ func TestP2PCreateAndGetTrade(t *testing.T) {
 	if err != nil {
 		t.Fatalf("vault address: %v", err)
 	}
-	expectedBuyerTo := crypto.NewAddress(crypto.NHBPrefix, buyerVault[:]).String()
+	expectedBuyerTo := crypto.MustNewAddress(crypto.NHBPrefix, buyerVault[:]).String()
 	if buyerIntent.To != expectedBuyerTo {
 		t.Fatalf("unexpected buyer intent to: got %s want %s", buyerIntent.To, expectedBuyerTo)
 	}
 	if buyerIntent.Token != "ZNHB" || buyerIntent.Amount != "7" {
 		t.Fatalf("unexpected buyer intent payload: %+v", buyerIntent)
 	}
-	expectedSellerTo := crypto.NewAddress(crypto.NHBPrefix, sellerVault[:]).String()
+	expectedSellerTo := crypto.MustNewAddress(crypto.NHBPrefix, sellerVault[:]).String()
 	if sellerIntent.To != expectedSellerTo {
 		t.Fatalf("unexpected seller intent to: got %s want %s", sellerIntent.To, expectedSellerTo)
 	}

--- a/rpc/potso_handlers.go
+++ b/rpc/potso_handlers.go
@@ -157,7 +157,7 @@ func (s *Server) handlePotsoTop(w http.ResponseWriter, _ *http.Request, req *RPC
 	}
 	result := make([]potsoTopEntry, len(entries))
 	for i, entry := range entries {
-		user := crypto.NewAddress(crypto.NHBPrefix, entry.Address[:]).String()
+		user := crypto.MustNewAddress(crypto.NHBPrefix, entry.Address[:]).String()
 		result[i] = potsoTopEntry{User: user, Meter: entry.Meter}
 	}
 	writeResult(w, req.ID, result)

--- a/rpc/potso_query_handlers.go
+++ b/rpc/potso_query_handlers.go
@@ -62,7 +62,7 @@ func (s *Server) handlePotsoLeaderboard(w http.ResponseWriter, _ *http.Request, 
 		Items: make([]potsoLeaderboardItem, len(entries)),
 	}
 	for i, entry := range entries {
-		addr := crypto.NewAddress(crypto.NHBPrefix, entry.Address[:]).String()
+		addr := crypto.MustNewAddress(crypto.NHBPrefix, entry.Address[:]).String()
 		result.Items[i] = potsoLeaderboardItem{
 			Address:            addr,
 			WeightBps:          entry.WeightBps,

--- a/rpc/potso_query_handlers_test.go
+++ b/rpc/potso_query_handlers_test.go
@@ -116,7 +116,7 @@ func TestHandlePotsoLeaderboard(t *testing.T) {
 	if len(resp.Items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(resp.Items))
 	}
-	expectedAddr := crypto.NewAddress(crypto.NHBPrefix, snapshot.Entries[1].Address[:]).String()
+	expectedAddr := crypto.MustNewAddress(crypto.NHBPrefix, snapshot.Entries[1].Address[:]).String()
 	if resp.Items[0].Address != expectedAddr {
 		t.Fatalf("unexpected address %s", resp.Items[0].Address)
 	}

--- a/rpc/potso_reward_handlers.go
+++ b/rpc/potso_reward_handlers.go
@@ -181,7 +181,7 @@ func (s *Server) handlePotsoEpochPayouts(w http.ResponseWriter, _ *http.Request,
 		Payouts: make([]potsoEpochPayoutEntry, len(payouts)),
 	}
 	for i, payout := range payouts {
-		user := crypto.NewAddress(crypto.NHBPrefix, payout.Address[:]).String()
+		user := crypto.MustNewAddress(crypto.NHBPrefix, payout.Address[:]).String()
 		result.Payouts[i] = potsoEpochPayoutEntry{
 			User:   user,
 			Amount: bigIntString(payout.Amount),

--- a/rpc/stake_handlers.go
+++ b/rpc/stake_handlers.go
@@ -114,7 +114,7 @@ func (s *Server) handleStakeUndelegate(w http.ResponseWriter, r *http.Request, r
 	}
 	validator := ""
 	if len(unbond.Validator) > 0 {
-		validator = crypto.NewAddress(crypto.NHBPrefix, unbond.Validator).String()
+		validator = crypto.MustNewAddress(crypto.NHBPrefix, unbond.Validator).String()
 	}
 	amountCopy := big.NewInt(0)
 	if unbond.Amount != nil {
@@ -155,7 +155,7 @@ func (s *Server) handleStakeClaim(w http.ResponseWriter, r *http.Request, req *R
 	}
 	validator := ""
 	if len(claimed.Validator) > 0 {
-		validator = crypto.NewAddress(crypto.NHBPrefix, claimed.Validator).String()
+		validator = crypto.MustNewAddress(crypto.NHBPrefix, claimed.Validator).String()
 	}
 	amountCopy := big.NewInt(0)
 	if claimed.Amount != nil {

--- a/rpc/swap_admin_handlers.go
+++ b/rpc/swap_admin_handlers.go
@@ -219,7 +219,7 @@ func formatBurnReceipt(receipt *swap.BurnReceipt) map[string]interface{} {
 		"observedAt":   receipt.ObservedAt,
 	}
 	if receipt.Burner != ([20]byte{}) {
-		payload["burner"] = crypto.NewAddress(crypto.NHBPrefix, receipt.Burner[:]).String()
+		payload["burner"] = crypto.MustNewAddress(crypto.NHBPrefix, receipt.Burner[:]).String()
 	}
 	if strings.TrimSpace(receipt.RedeemReference) != "" {
 		payload["redeemRef"] = strings.TrimSpace(receipt.RedeemReference)

--- a/rpc/swap_handlers.go
+++ b/rpc/swap_handlers.go
@@ -285,7 +285,7 @@ func formatVoucherRecord(record *swap.VoucherRecord) map[string]interface{} {
 		response["twapEnd"] = record.TwapEnd
 	}
 	if record.Recipient != ([20]byte{}) {
-		response["recipient"] = crypto.NewAddress(crypto.NHBPrefix, record.Recipient[:]).String()
+		response["recipient"] = crypto.MustNewAddress(crypto.NHBPrefix, record.Recipient[:]).String()
 	}
 	return response
 }

--- a/services/escrow-gateway/payintent.go
+++ b/services/escrow-gateway/payintent.go
@@ -55,7 +55,7 @@ func computeVaultAddress(token string) (string, error) {
 	hash := ethcrypto.Keccak256([]byte(seed))
 	var addrBytes [20]byte
 	copy(addrBytes[:], hash[len(hash)-20:])
-	return crypto.NewAddress(crypto.NHBPrefix, addrBytes[:]).String(), nil
+	return crypto.MustNewAddress(crypto.NHBPrefix, addrBytes[:]).String(), nil
 }
 
 func buildQRString(vaultAddr, token, amount, memo string) string {

--- a/services/escrow-gateway/server_test.go
+++ b/services/escrow-gateway/server_test.go
@@ -189,7 +189,7 @@ func newWallet(t *testing.T) (*ecdsa.PrivateKey, string) {
 		t.Fatalf("generate key: %v", err)
 	}
 	addr := ethcrypto.PubkeyToAddress(priv.PublicKey).Bytes()
-	bech := nhbcrypto.NewAddress(nhbcrypto.NHBPrefix, addr).String()
+	bech := nhbcrypto.MustNewAddress(nhbcrypto.NHBPrefix, addr).String()
 	return priv, bech
 }
 

--- a/services/swap-gateway/voucher.go
+++ b/services/swap-gateway/voucher.go
@@ -83,7 +83,11 @@ func RecoverVoucherSignerAddress(v VoucherV1, sig []byte) (string, error) {
 		return "", fmt.Errorf("recover pubkey: %w", err)
 	}
 	addrBytes := ethcrypto.PubkeyToAddress(*pub).Bytes()
-	return repoCrypto.NewAddress(repoCrypto.NHBPrefix, addrBytes).String(), nil
+	addr, err := repoCrypto.NewAddress(repoCrypto.NHBPrefix, addrBytes)
+	if err != nil {
+		return "", err
+	}
+	return addr.String(), nil
 }
 
 func decodeBech32Address(addr string) ([]byte, error) {

--- a/services/swap-gateway/voucher_test.go
+++ b/services/swap-gateway/voucher_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestVoucherHashDeterministic(t *testing.T) {
 	recipientBytes := bytes.Repeat([]byte{0x11}, 20)
-	recipient := repoCrypto.NewAddress(repoCrypto.NHBPrefix, recipientBytes).String()
+	recipient := repoCrypto.MustNewAddress(repoCrypto.NHBPrefix, recipientBytes).String()
 	voucher := VoucherV1{
 		Domain:     "NHB_SWAP_VOUCHER_V1",
 		ChainID:    187001,
@@ -45,10 +45,10 @@ func TestSignVoucherRecoverAddress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hex to ecdsa: %v", err)
 	}
-	minterAddr := repoCrypto.NewAddress(repoCrypto.NHBPrefix, ethcrypto.PubkeyToAddress(key.PublicKey).Bytes()).String()
+	minterAddr := repoCrypto.MustNewAddress(repoCrypto.NHBPrefix, ethcrypto.PubkeyToAddress(key.PublicKey).Bytes()).String()
 
 	recipientBytes := bytes.Repeat([]byte{0x22}, 20)
-	recipient := repoCrypto.NewAddress(repoCrypto.NHBPrefix, recipientBytes).String()
+	recipient := repoCrypto.MustNewAddress(repoCrypto.NHBPrefix, recipientBytes).String()
 
 	voucher := VoucherV1{
 		Domain:     "NHB_SWAP_VOUCHER_V1",

--- a/services/swap-gateway/webhook_test.go
+++ b/services/swap-gateway/webhook_test.go
@@ -38,10 +38,10 @@ func TestHandlePaymentWebhook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("hex to ecdsa: %v", err)
 	}
-	minterAddr := repoCrypto.NewAddress(repoCrypto.NHBPrefix, ethcrypto.PubkeyToAddress(key.PublicKey).Bytes()).String()
+	minterAddr := repoCrypto.MustNewAddress(repoCrypto.NHBPrefix, ethcrypto.PubkeyToAddress(key.PublicKey).Bytes()).String()
 
 	recipientBytes := bytes.Repeat([]byte{0x33}, 20)
-	recipient := repoCrypto.NewAddress(repoCrypto.NHBPrefix, recipientBytes).String()
+	recipient := repoCrypto.MustNewAddress(repoCrypto.NHBPrefix, recipientBytes).String()
 
 	ord := &order{
 		OrderID:    "SWP_1",

--- a/tests/fuzz/lending_amounts_fuzz.go
+++ b/tests/fuzz/lending_amounts_fuzz.go
@@ -169,7 +169,7 @@ func FuzzLendingSupplyWithdrawAmounts(f *testing.F) {
 func makeAddress(prefix crypto.AddressPrefix, suffix byte) crypto.Address {
 	raw := make([]byte, 20)
 	raw[len(raw)-1] = suffix
-	return crypto.NewAddress(prefix, raw)
+	return crypto.MustNewAddress(prefix, raw)
 }
 
 func mustBig(value string) *big.Int {

--- a/tests/lending/rounding_attack_test.go
+++ b/tests/lending/rounding_attack_test.go
@@ -82,7 +82,7 @@ func (m *mockEngineState) PutFeeAccrual(_ string, fees *lending.FeeAccrual) erro
 func makeAddress(prefix crypto.AddressPrefix, suffix byte) crypto.Address {
 	raw := make([]byte, 20)
 	raw[len(raw)-1] = suffix
-	return crypto.NewAddress(prefix, raw)
+	return crypto.MustNewAddress(prefix, raw)
 }
 
 func mustBig(value string) *big.Int {


### PR DESCRIPTION
## Summary
- make `crypto.NewAddress` and `DecodeAddress` validate address lengths, clone input bytes, and return errors, adding a `MustNewAddress` helper for internal use
- update RPC modules, native config parsers, and gateway helpers to propagate Bech32 decode failures instead of panicking
- cover malformed address inputs with new RPC and governance config tests

## Testing
- go test ./crypto ./rpc ./config ./native/swap ./services/swap-gateway

------
https://chatgpt.com/codex/tasks/task_e_68defe396658832d8de85250be64680f