### PR TITLE
Harden p2pd network security validation

### DIFF
--- a/config-local.toml
+++ b/config-local.toml
@@ -45,8 +45,10 @@ ClientVersion = "nhbchain/node"
 # to an empty secret. Production deployments should supply the secret via
 # SharedSecretFile or SharedSecretEnv and/or enable mutual TLS.
 SharedSecret = "local-dev-shared-secret"
-# Local development defaults to plaintext; production operators must provision TLS
-# and set AllowInsecure = false.
+# Local development defaults to plaintext. Keep this at true only for throwaway
+# labs and always pair it with a shared secret. Production operators must
+# provision TLS and set AllowInsecure = false; the daemon now fails fast when TLS
+# material is absent.
 AllowInsecure = true
 # ServerTLSCertFile = "./tls/p2pd.crt"
 # ServerTLSKeyFile = "./tls/p2pd.key"

--- a/config-peer.toml
+++ b/config-peer.toml
@@ -42,8 +42,10 @@ SharedSecretEnv = "NHB_NETWORK_SHARED_SECRET"
 SharedSecretFile = "/etc/nhb/network.token"
 SharedSecret = ""
 AllowInsecure = false
-# Leave the TLS paths commented until certificates are provisioned. Production
-# clusters should enable mutual TLS and keep AllowInsecure = false.
+# Leave the TLS paths commented until certificates are provisioned. The daemon
+# now fails fast when TLS material is missing unless AllowInsecure is explicitly
+# set to true, so production clusters should enable mutual TLS and keep
+# AllowInsecure = false.
 # ServerTLSCertFile = "/etc/nhb/tls/p2pd.crt"
 # ServerTLSKeyFile = "/etc/nhb/tls/p2pd.key"
 # ClientTLSCertFile = "/etc/nhb/tls/consensus.crt"

--- a/config.toml
+++ b/config.toml
@@ -41,8 +41,10 @@ SharedSecretEnv = "NHB_NETWORK_SHARED_SECRET"
 SharedSecretFile = "/etc/nhb/network.token"
 SharedSecret = ""
 # Production deployments must disable plaintext by leaving AllowInsecure=false
-# and provisioning TLS certificates. Local lab setups can flip this to true
-# temporarily when TLS is not available.
+# and provisioning TLS certificates. The daemon will now fail fast when TLS is
+# missing unless this flag is explicitly set to true. Local lab setups can flip
+# it temporarily when TLS is not available, but must still provide a shared
+# secret or client certificates.
 AllowInsecure = false
 AuthorizationHeader = "x-nhb-network-token"
 AllowUnauthenticatedReads = false

--- a/docs/networking/ops.md
+++ b/docs/networking/ops.md
@@ -83,9 +83,11 @@ service enforces it on `Gossip`, `DialPeer`, `BanPeer`, `GetView`, and
 `AllowedClientCommonNames` allowlist when provided. `consensusd` consumes the
 same block to dial with `grpc.WithTransportCredentials` and per-RPC metadata so
 authenticated traffic continues to flow while unauthenticated requests are
-rejected. Beginning with this release, `consensusd` refuses to fall back to
-plaintext; operators must ship valid TLS material or explicitly set
-`AllowInsecure = true` for short-lived lab environments.
+rejected. Beginning with this release, both `consensusd` and `p2pd` refuse to
+fall back to plaintext; the server now fails fast when TLS material is missing
+unless `AllowInsecure = true` is explicitly set for a short-lived lab
+environment, and at least one authenticator (shared secret or client
+certificate) must be configured before either service will start.
 
 Setting `AllowUnauthenticatedReads = true` re-opens `GetView` and `ListPeers` to
 anonymous callers for debugging or observability tooling. This opt-in bypasses

--- a/docs/runbooks/p2pd-failover.md
+++ b/docs/runbooks/p2pd-failover.md
@@ -35,7 +35,8 @@ If a warm standby is available:
 * Confirm `consensusd` reports height progression.
 * Run `grpcurl <p2pd>:9091 network.v1.NetworkService/ListPeers` with the issued TLS
   material to verify active peers. Use `-plaintext` only when the deployment has
-  explicitly set `AllowInsecure = true` for a lab environment.
+  explicitly set `AllowInsecure = true` for a lab environment and paired it with
+  a shared secret or mutual TLS.
 * Ensure rate limits and scoring metrics reset as expected.
 * Inspect relay queue health:
   - `nhb_network_relay_queue_enqueued_total` vs `nhb_network_relay_queue_dropped_total` to confirm drop ratio is below the configured threshold.

--- a/network/security.go
+++ b/network/security.go
@@ -1,0 +1,103 @@
+package network
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"nhbchain/config"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// BuildServerSecurity constructs transport credentials and authenticators for the
+// p2pd gRPC server based on the provided network security configuration. When
+// AllowUnauthenticatedReads is false the returned read authenticator matches the
+// write authenticator so callers must pass the returned values directly into
+// network.NewService.
+func BuildServerSecurity(sec *config.NetworkSecurity, baseDir string, lookup func(string) (string, bool)) (credentials.TransportCredentials, Authenticator, Authenticator, error) {
+	if sec == nil {
+		return nil, nil, nil, fmt.Errorf("network security configuration is missing")
+	}
+
+	secret, err := sec.ResolveSharedSecret(baseDir, lookup)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("resolve shared secret: %w", err)
+	}
+
+	var auths []Authenticator
+	if secret != "" {
+		auths = append(auths, NewTokenAuthenticator(sec.AuthorizationHeaderName(), secret))
+	}
+
+	certPath := resolveSecurityPath(baseDir, sec.ServerTLSCertFile)
+	keyPath := resolveSecurityPath(baseDir, sec.ServerTLSKeyFile)
+
+	var tlsConfig *tls.Config
+	if certPath != "" || keyPath != "" {
+		if certPath == "" || keyPath == "" {
+			return nil, nil, nil, fmt.Errorf("network security requires both ServerTLSCertFile and ServerTLSKeyFile when enabling TLS")
+		}
+		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("load network TLS keypair: %w", err)
+		}
+		tlsConfig = &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{cert},
+		}
+	}
+
+	if caPath := resolveSecurityPath(baseDir, sec.ClientCAFile); caPath != "" {
+		if tlsConfig == nil {
+			return nil, nil, nil, fmt.Errorf("ClientCAFile requires ServerTLSCertFile and ServerTLSKeyFile to be configured")
+		}
+		pem, err := os.ReadFile(caPath)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("read client CA file: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, nil, nil, fmt.Errorf("failed to parse client CA certificates from %s", caPath)
+		}
+		tlsConfig.ClientCAs = pool
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+		auths = append(auths, NewTLSAuthorizer(sec.AllowedClientCommonNames))
+	}
+
+	if len(auths) == 0 {
+		return nil, nil, nil, fmt.Errorf("network security requires a shared secret or client certificate authentication")
+	}
+
+	var creds credentials.TransportCredentials
+	switch {
+	case tlsConfig != nil:
+		creds = credentials.NewTLS(tlsConfig)
+	case sec.AllowInsecure:
+		creds = insecure.NewCredentials()
+	default:
+		return nil, nil, nil, fmt.Errorf("network security configuration is missing TLS material; set AllowInsecure=true only for development")
+	}
+
+	writeAuth := ChainAuthenticators(auths...)
+	readAuth := writeAuth
+	if sec.AllowUnauthenticatedReads {
+		readAuth = nil
+	}
+	return creds, writeAuth, readAuth, nil
+}
+
+func resolveSecurityPath(baseDir, path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return ""
+	}
+	if baseDir != "" && !filepath.IsAbs(trimmed) {
+		return filepath.Join(baseDir, trimmed)
+	}
+	return trimmed
+}


### PR DESCRIPTION
## Summary
- centralize the p2pd server security construction in network.BuildServerSecurity so startup now fails when TLS material is missing without AllowInsecure and when no shared secret or client CA is configured
- extend the system tests to assert the new failure modes and adjust the anonymous read test to focus on authentication behavior
- update the sample configs and operator docs to document the stricter plaintext opt-in requirements

## Testing
- go test ./network
- go test ./cmd/p2pd ./tests/system


------
https://chatgpt.com/codex/tasks/task_e_68df870312b8832da332b94cc8f1b840