### PR TITLE
Handle swap module envelopes

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -208,7 +208,7 @@ func TestBlockchainPersistenceAcrossRestart(t *testing.T) {
 
 func TestTipReturnsCopy(t *testing.T) {
 	db := storage.NewMemDB()
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() { db.Close() })
 
 	bc, err := NewBlockchain(db, "", true)
 	if err != nil {

--- a/core/node.go
+++ b/core/node.go
@@ -1084,7 +1084,7 @@ func (n *Node) validateTransaction(tx *types.Transaction) error {
 	if !types.IsValidChainID(tx.ChainID) {
 		return fmt.Errorf("%w: unexpected chain id %s", ErrInvalidTransaction, tx.ChainID.String())
 	}
-	if tx.Type != types.TxTypeMint {
+	if types.RequiresSignature(tx.Type) {
 		if _, err := tx.From(); err != nil {
 			return fmt.Errorf("%w: recover sender: %w", ErrInvalidTransaction, err)
 		}
@@ -1131,7 +1131,7 @@ func (n *Node) SubmitTxEnvelope(envelope *consensusv1.SignedTxEnvelope) error {
 	}
 	tx, err := codec.TransactionFromEnvelope(envelope)
 	if err != nil {
-		return err
+		return fmt.Errorf("submit envelope: %w", err)
 	}
 	return n.AddTransaction(tx)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -31,21 +31,34 @@ func IsValidChainID(chainID *big.Int) bool {
 type TxType byte
 
 const (
-	TxTypeTransfer         TxType = 0x01 // A standard transfer of NHB
-	TxTypeRegisterIdentity TxType = 0x02 // A transaction to claim a username
-	TxTypeCreateEscrow     TxType = 0x03 // Create escrow
-	TxTypeReleaseEscrow    TxType = 0x04 // NEW: Buyer releases funds to seller
-	TxTypeRefundEscrow     TxType = 0x05 // NEW: Seller refunds funds to buyer
-	TxTypeStake            TxType = 0x06 // Implenting stake
-	TxTypeUnstake          TxType = 0x07 // NEW: A transaction to un-stake ZapNHB
-	TxTypeHeartbeat        TxType = 0x08 // Heartbeat from users device
-	TxTypeLockEscrow       TxType = 0x09 // NEW: Buyer commits to a purchase
-	TxTypeDisputeEscrow    TxType = 0x0A // NEW: Buyer raises a dispute
-	TxTypeArbitrateRelease TxType = 0x0B // NEW: Admin-only action to release to buyer
-	TxTypeArbitrateRefund  TxType = 0x0C // NEW: Admin-only action to refund seller
-	TxTypeStakeClaim       TxType = 0x0D // NEW: Claim matured unbonded ZapNHB
-	TxTypeMint             TxType = 0x0E // NEW: Execute a signed mint voucher on-chain
+	TxTypeTransfer          TxType = 0x01 // A standard transfer of NHB
+	TxTypeRegisterIdentity  TxType = 0x02 // A transaction to claim a username
+	TxTypeCreateEscrow      TxType = 0x03 // Create escrow
+	TxTypeReleaseEscrow     TxType = 0x04 // NEW: Buyer releases funds to seller
+	TxTypeRefundEscrow      TxType = 0x05 // NEW: Seller refunds funds to buyer
+	TxTypeStake             TxType = 0x06 // Implenting stake
+	TxTypeUnstake           TxType = 0x07 // NEW: A transaction to un-stake ZapNHB
+	TxTypeHeartbeat         TxType = 0x08 // Heartbeat from users device
+	TxTypeLockEscrow        TxType = 0x09 // NEW: Buyer commits to a purchase
+	TxTypeDisputeEscrow     TxType = 0x0A // NEW: Buyer raises a dispute
+	TxTypeArbitrateRelease  TxType = 0x0B // NEW: Admin-only action to release to buyer
+	TxTypeArbitrateRefund   TxType = 0x0C // NEW: Admin-only action to refund seller
+	TxTypeStakeClaim        TxType = 0x0D // NEW: Claim matured unbonded ZapNHB
+	TxTypeMint              TxType = 0x0E // NEW: Execute a signed mint voucher on-chain
+	TxTypeSwapPayoutReceipt TxType = 0x0F // NEW: Record a swap payout receipt attested by the treasury
 )
+
+// RequiresSignature reports whether the transaction type must carry an
+// originator signature that can be recovered via From(). Types that originate
+// from module attestations rely on their envelope signatures instead.
+func RequiresSignature(t TxType) bool {
+	switch t {
+	case TxTypeMint, TxTypeSwapPayoutReceipt:
+		return false
+	default:
+		return true
+	}
+}
 
 // Transaction now has a Type field to distinguish its intent.
 // Transaction now supports gas fees and a paymaster.


### PR DESCRIPTION
## Summary
- branch signed envelope decoding to support swap module payloads by type URL
- add a swap payout receipt transaction type and state processor handler that records receipts
- exercise the consensus gRPC server with swap module payloads and unsupported module coverage

## Testing
- go test ./consensus/...
- go test ./core/... *(fails: core/blockchain_test.go expects db.Close return value)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d92ea2e4832da3cfd664418f22d7