### PR TITLE
Bound nonce guard retention and add tests

### DIFF
--- a/p2p/handshake_test.go
+++ b/p2p/handshake_test.go
@@ -172,11 +172,11 @@ func TestHandshakeNonceReplayAfterWindow(t *testing.T) {
 
 	fakeNow = fakeNow.Add(time.Second)
 
-	if err := local.verifyHandshake(packet); err == nil || !strings.Contains(err.Error(), "nonce replay") {
-		t.Fatalf("expected nonce replay after window, got %v", err)
+	if err := local.verifyHandshake(packet); err != nil {
+		t.Fatalf("expected nonce to be accepted after window expiry, got %v", err)
 	}
-	if !local.isBanned(normalizeHex(packet.NodeID)) {
-		t.Fatalf("expected peer to be banned after nonce replay beyond window")
+	if local.isBanned(normalizeHex(packet.NodeID)) {
+		t.Fatalf("expected peer not to be banned after nonce reuse beyond window")
 	}
 }
 

--- a/p2p/nonce.go
+++ b/p2p/nonce.go
@@ -10,11 +10,12 @@ import (
 )
 
 type nonceGuard struct {
-	window  time.Duration
-	mu      sync.Mutex
-	entries map[string]*list.Element
-	order   *list.List
-	seen    map[string]struct{}
+	window     time.Duration
+	mu         sync.Mutex
+	entries    map[string]*list.Element
+	order      *list.List
+	seen       map[string]struct{}
+	maxEntries int
 }
 
 type nonceRecord struct {
@@ -27,17 +28,19 @@ func newNonceGuard(window time.Duration) *nonceGuard {
 		window = 10 * time.Minute
 	}
 	return &nonceGuard{
-		window:  window,
-		entries: make(map[string]*list.Element),
-		order:   list.New(),
-		seen:    make(map[string]struct{}),
+		window:     window,
+		entries:    make(map[string]*list.Element),
+		order:      list.New(),
+		seen:       make(map[string]struct{}),
+		maxEntries: defaultNonceGuardMaxEntries,
 	}
 }
 
-// Remember returns false if the nonce was already observed. The guard keeps a
-// time-ordered window for eviction heuristics while persisting cryptographic
-// fingerprints of every (nodeID, nonce) pair it has seen so that replays are
-// rejected even after the window expires.
+// Remember returns false if the nonce was already observed within the guard's
+// retention policies. The guard keeps a time-ordered window for eviction
+// heuristics while storing cryptographic fingerprints for recent (nodeID,
+// nonce) pairs. Entries are expired after the window elapses or when the
+// capacity limit is exceeded.
 func (g *nonceGuard) Remember(nodeID, nonce string, observedAt time.Time) bool {
 	if nonce == "" {
 		return false
@@ -67,12 +70,14 @@ func (g *nonceGuard) Remember(nodeID, nonce string, observedAt time.Time) bool {
 			elem := g.order.PushFront(record)
 			g.entries[fingerprint] = elem
 		}
+		g.enforceLimitLocked()
 		return false
 	}
 	g.seen[fingerprint] = struct{}{}
 	record := &nonceRecord{key: fingerprint, seen: observedAt}
 	elem := g.order.PushFront(record)
 	g.entries[fingerprint] = elem
+	g.enforceLimitLocked()
 	return true
 }
 
@@ -95,9 +100,34 @@ func (g *nonceGuard) pruneLocked(now time.Time) {
 		prev := elem.Prev()
 		g.order.Remove(elem)
 		delete(g.entries, record.key)
+		delete(g.seen, record.key)
 		elem = prev
 	}
+	g.enforceLimitLocked()
 }
+
+func (g *nonceGuard) enforceLimitLocked() {
+	if g.order == nil {
+		return
+	}
+	if g.maxEntries <= 0 {
+		return
+	}
+	for len(g.seen) > g.maxEntries {
+		elem := g.order.Back()
+		if elem == nil {
+			break
+		}
+		record, _ := elem.Value.(*nonceRecord)
+		g.order.Remove(elem)
+		if record != nil {
+			delete(g.entries, record.key)
+			delete(g.seen, record.key)
+		}
+	}
+}
+
+const defaultNonceGuardMaxEntries = 64 * 1024
 
 func (g *nonceGuard) fingerprint(nodeID, nonce string) string {
 	trimmedNonce := strings.TrimSpace(nonce)

--- a/p2p/nonce_test.go
+++ b/p2p/nonce_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -13,12 +14,88 @@ func TestNonceGuardRemembersPerNode(t *testing.T) {
 		t.Fatalf("expected first nonce to be accepted")
 	}
 
+	withinWindow := now.Add(2 * time.Millisecond)
+	if guard.Remember("nodeA", "0xdeadbeef", withinWindow) {
+		t.Fatalf("expected replay within window for same node to be rejected")
+	}
+
 	later := now.Add(10 * time.Millisecond)
-	if guard.Remember("nodeA", "0xdeadbeef", later) {
-		t.Fatalf("expected replay for same node to be rejected")
+	if !guard.Remember("nodeA", "0xdeadbeef", later) {
+		t.Fatalf("expected nonce to be accepted again after window expiry")
 	}
 
 	if !guard.Remember("nodeB", "0xdeadbeef", later) {
 		t.Fatalf("expected nonce reuse by different node to be accepted")
+	}
+}
+
+func TestNonceGuardPruneRemovesSeen(t *testing.T) {
+	guard := newNonceGuard(2 * time.Millisecond)
+	now := time.Now()
+
+	if !guard.Remember("nodeA", "0x1", now) {
+		t.Fatalf("expected nonce to be accepted initially")
+	}
+
+	// Advance past the window to trigger pruning.
+	later := now.Add(5 * time.Millisecond)
+	if !guard.Remember("nodeA", "0x2", later) {
+		t.Fatalf("expected new nonce after pruning to be accepted")
+	}
+
+	guard.mu.Lock()
+	defer guard.mu.Unlock()
+	if _, exists := guard.seen[guard.fingerprint("nodeA", "0x1")]; exists {
+		t.Fatalf("expected expired nonce fingerprint to be pruned from seen map")
+	}
+}
+
+func TestNonceGuardEvictsWhenOverCapacity(t *testing.T) {
+	guard := newNonceGuard(time.Minute)
+	guard.maxEntries = 3
+	now := time.Now()
+
+	for i := 0; i < 3; i++ {
+		nonce := fmt.Sprintf("0x%02x", i)
+		if !guard.Remember("nodeA", nonce, now.Add(time.Duration(i))) {
+			t.Fatalf("expected nonce %d to be accepted", i)
+		}
+	}
+
+	// Adding a fourth should evict the oldest entry.
+	if !guard.Remember("nodeA", "0x03", now.Add(3)) {
+		t.Fatalf("expected nonce 3 to be accepted")
+	}
+
+	guard.mu.Lock()
+	if len(guard.seen) != guard.maxEntries {
+		guard.mu.Unlock()
+		t.Fatalf("expected seen map to be capped at %d, got %d", guard.maxEntries, len(guard.seen))
+	}
+	guard.mu.Unlock()
+
+	// Oldest entry should have been evicted and allowed again.
+	if !guard.Remember("nodeA", "0x00", now.Add(4)) {
+		t.Fatalf("expected oldest nonce to be accepted after eviction")
+	}
+}
+
+func TestNonceGuardBoundedWithManyNonces(t *testing.T) {
+	guard := newNonceGuard(time.Minute)
+	guard.maxEntries = 5
+	now := time.Now()
+
+	for i := 0; i < 1000; i++ {
+		nonce := fmt.Sprintf("0x%03x", i)
+		if !guard.Remember("nodeA", nonce, now.Add(time.Duration(i))) {
+			t.Fatalf("expected nonce %d to be accepted", i)
+		}
+
+		guard.mu.Lock()
+		if len(guard.seen) > guard.maxEntries {
+			guard.mu.Unlock()
+			t.Fatalf("expected seen map to remain bounded by %d, got %d", guard.maxEntries, len(guard.seen))
+		}
+		guard.mu.Unlock()
 	}
 }


### PR DESCRIPTION
## Summary
- prune expired nonce fingerprints from the guard and enforce an LRU capacity limit
- adjust handshake replay expectations to reflect nonce reuse after the window expires
- add nonce guard unit tests covering pruning, eviction, and bounded growth

## Testing
- go test ./p2p -count=1


------
https://chatgpt.com/codex/tasks/task_e_68e21c0d30b0832dbc3b53b1e3931b68