### PR TITLE
HSK-2: Bound nonce guard (TTL + LRU cap + janitor)

### DIFF
--- a/p2p/nonce.go
+++ b/p2p/nonce.go
@@ -1,11 +1,8 @@
 package p2p
 
 import (
-	"container/list"
-	"crypto/sha256"
 	"encoding/hex"
 	"strings"
-	"sync"
 	"time"
 	"unicode"
 
@@ -20,143 +17,6 @@ type NonceReplayGuard interface {
 // NewNonceReplayGuard constructs a nonce replay guard with the supplied retention window.
 func NewNonceReplayGuard(window time.Duration) NonceReplayGuard {
 	return newNonceGuard(window)
-}
-
-type nonceGuard struct {
-	window     time.Duration
-	mu         sync.Mutex
-	entries    map[string]*list.Element
-	order      *list.List
-	seen       map[string]struct{}
-	maxEntries int
-}
-
-type nonceRecord struct {
-	key  string
-	seen time.Time
-}
-
-func newNonceGuard(window time.Duration) *nonceGuard {
-	if window <= 0 {
-		window = 10 * time.Minute
-	}
-	return &nonceGuard{
-		window:     window,
-		entries:    make(map[string]*list.Element),
-		order:      list.New(),
-		seen:       make(map[string]struct{}),
-		maxEntries: defaultNonceGuardMaxEntries,
-	}
-}
-
-// Remember returns false if the nonce was already observed within the guard's
-// retention policies. The guard keeps a time-ordered window for eviction
-// heuristics while storing cryptographic fingerprints for recent (nodeID,
-// nonce) pairs. Entries are expired after the window elapses or when the
-// capacity limit is exceeded.
-func (g *nonceGuard) Remember(nodeID, nonce string, observedAt time.Time) bool {
-	if nonce == "" {
-		return false
-	}
-	if observedAt.IsZero() {
-		observedAt = time.Now()
-	}
-
-	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	fingerprint := g.fingerprint(nodeID, nonce)
-	if fingerprint == "" {
-		return false
-	}
-	g.pruneLocked(observedAt)
-	if _, exists := g.seen[fingerprint]; exists {
-		if elem, ok := g.entries[fingerprint]; ok {
-			if elem != nil {
-				if record, ok := elem.Value.(*nonceRecord); ok && record != nil {
-					record.seen = observedAt
-				}
-				g.order.MoveToFront(elem)
-			}
-		} else {
-			record := &nonceRecord{key: fingerprint, seen: observedAt}
-			elem := g.order.PushFront(record)
-			g.entries[fingerprint] = elem
-		}
-		g.enforceLimitLocked()
-		return false
-	}
-	g.seen[fingerprint] = struct{}{}
-	record := &nonceRecord{key: fingerprint, seen: observedAt}
-	elem := g.order.PushFront(record)
-	g.entries[fingerprint] = elem
-	g.enforceLimitLocked()
-	return true
-}
-
-func (g *nonceGuard) pruneLocked(now time.Time) {
-	if g.order == nil {
-		return
-	}
-	threshold := now.Add(-g.window)
-	for elem := g.order.Back(); elem != nil; {
-		record, _ := elem.Value.(*nonceRecord)
-		if record == nil {
-			prev := elem.Prev()
-			g.order.Remove(elem)
-			elem = prev
-			continue
-		}
-		if !record.seen.Before(threshold) {
-			break
-		}
-		prev := elem.Prev()
-		g.order.Remove(elem)
-		delete(g.entries, record.key)
-		delete(g.seen, record.key)
-		elem = prev
-	}
-	g.enforceLimitLocked()
-}
-
-func (g *nonceGuard) enforceLimitLocked() {
-	if g.order == nil {
-		return
-	}
-	if g.maxEntries <= 0 {
-		return
-	}
-	for len(g.seen) > g.maxEntries {
-		elem := g.order.Back()
-		if elem == nil {
-			break
-		}
-		record, _ := elem.Value.(*nonceRecord)
-		g.order.Remove(elem)
-		if record != nil {
-			delete(g.entries, record.key)
-			delete(g.seen, record.key)
-		}
-	}
-}
-
-const defaultNonceGuardMaxEntries = 64 * 1024
-
-func (g *nonceGuard) fingerprint(nodeID, nonce string) string {
-	canonicalNonce, ok := canonicalizeNonce(nonce)
-	if !ok {
-		return ""
-	}
-	normalized := normalizeHex(nodeID)
-	if normalized == "" {
-		normalized = strings.ToLower(strings.TrimSpace(nodeID))
-	}
-	if normalized == "" {
-		return ""
-	}
-	payload := normalized + ":" + canonicalNonce
-	sum := sha256.Sum256([]byte(payload))
-	return hex.EncodeToString(sum[:])
 }
 
 func canonicalizeNonce(nonce string) (string, bool) {

--- a/p2p/nonce_guard.go
+++ b/p2p/nonce_guard.go
@@ -1,0 +1,261 @@
+package p2p
+
+import (
+	"container/list"
+	"crypto/sha256"
+	"encoding/hex"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type nonceGuard struct {
+	ttl        time.Duration
+	mu         sync.Mutex
+	entries    map[string]*list.Element
+	order      *list.List
+	maxEntries int
+	now        func() time.Time
+
+	janitorStop chan struct{}
+	stopOnce    sync.Once
+	janitorWG   sync.WaitGroup
+
+	metrics *nonceGuardMetrics
+}
+
+type nonceRecord struct {
+	key    string
+	seen   time.Time
+	expiry time.Time
+}
+
+func newNonceGuard(window time.Duration) *nonceGuard {
+	ttl := window
+	if ttl <= 0 {
+		ttl = defaultNonceGuardTTL
+	}
+	guard := &nonceGuard{
+		ttl:         ttl,
+		entries:     make(map[string]*list.Element),
+		order:       list.New(),
+		maxEntries:  defaultNonceGuardMaxEntries,
+		now:         time.Now,
+		janitorStop: make(chan struct{}),
+		metrics:     getNonceGuardMetrics(),
+	}
+	guard.metrics.observeSize(0)
+	guard.janitorWG.Add(1)
+	go guard.runJanitor()
+	runtime.SetFinalizer(guard, func(g *nonceGuard) {
+		g.stopJanitor()
+	})
+	return guard
+}
+
+func (g *nonceGuard) Remember(nodeID, nonce string, observedAt time.Time) bool {
+	if nonce == "" {
+		return false
+	}
+	if observedAt.IsZero() {
+		observedAt = g.now()
+	}
+
+	fingerprint := g.fingerprint(nodeID, nonce)
+	if fingerprint == "" {
+		return false
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if elem := g.entries[fingerprint]; elem != nil {
+		if record, _ := elem.Value.(*nonceRecord); record != nil {
+			record.seen = observedAt
+		}
+		return false
+	}
+
+	record := &nonceRecord{
+		key:    fingerprint,
+		seen:   observedAt,
+		expiry: observedAt.Add(g.ttl),
+	}
+	elem := g.order.PushFront(record)
+	g.entries[fingerprint] = elem
+	g.metrics.observeSize(len(g.entries))
+	g.evictOverflowLocked()
+	return true
+}
+
+func (g *nonceGuard) evictOverflowLocked() {
+	if g.maxEntries <= 0 {
+		return
+	}
+	for len(g.entries) > g.maxEntries {
+		elem := g.order.Back()
+		if elem == nil {
+			break
+		}
+		g.removeElementLocked(elem, true)
+	}
+}
+
+func (g *nonceGuard) removeExpiredLocked(now time.Time) {
+	for {
+		elem := g.order.Back()
+		if elem == nil {
+			break
+		}
+		record, _ := elem.Value.(*nonceRecord)
+		if record == nil {
+			g.removeElementLocked(elem, false)
+			continue
+		}
+		if now.Before(record.expiry) {
+			break
+		}
+		g.removeElementLocked(elem, true)
+	}
+}
+
+func (g *nonceGuard) removeElementLocked(elem *list.Element, count bool) {
+	if elem == nil {
+		return
+	}
+	record, _ := elem.Value.(*nonceRecord)
+	g.order.Remove(elem)
+	if record != nil {
+		delete(g.entries, record.key)
+		if count {
+			g.metrics.observeEvicted(1)
+		}
+	}
+	g.metrics.observeSize(len(g.entries))
+}
+
+func (g *nonceGuard) runJanitor() {
+	defer g.janitorWG.Done()
+	ticker := time.NewTicker(nonceGuardJanitorInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			g.sweep()
+		case <-g.janitorStop:
+			return
+		}
+	}
+}
+
+func (g *nonceGuard) sweep() {
+	now := g.now()
+	g.mu.Lock()
+	g.removeExpiredLocked(now)
+	g.evictOverflowLocked()
+	g.mu.Unlock()
+}
+
+func (g *nonceGuard) stopJanitor() {
+	g.stopOnce.Do(func() {
+		close(g.janitorStop)
+		g.janitorWG.Wait()
+	})
+}
+
+func (g *nonceGuard) Close() {
+	if g == nil {
+		return
+	}
+	g.stopJanitor()
+}
+
+func (g *nonceGuard) fingerprint(nodeID, nonce string) string {
+	canonicalNonce, ok := canonicalizeNonce(nonce)
+	if !ok {
+		return ""
+	}
+	normalized := normalizeHex(nodeID)
+	if normalized == "" {
+		normalized = strings.ToLower(strings.TrimSpace(nodeID))
+	}
+	if normalized == "" {
+		return ""
+	}
+	payload := normalized + ":" + canonicalNonce
+	sum := sha256.Sum256([]byte(payload))
+	return hex.EncodeToString(sum[:])
+}
+
+func (g *nonceGuard) Size() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.entries)
+}
+
+func (g *nonceGuard) SetMaxEntries(max int) {
+	if max <= 0 {
+		return
+	}
+	g.mu.Lock()
+	g.maxEntries = max
+	g.evictOverflowLocked()
+	g.mu.Unlock()
+}
+
+func (g *nonceGuard) RunJanitorSweep(now time.Time) {
+	g.mu.Lock()
+	g.removeExpiredLocked(now)
+	g.evictOverflowLocked()
+	g.mu.Unlock()
+}
+
+const (
+	defaultNonceGuardMaxEntries = 100_000
+	defaultNonceGuardTTL        = 15 * time.Minute
+	nonceGuardJanitorInterval   = time.Minute
+)
+
+type nonceGuardMetrics struct {
+	size    prometheus.Gauge
+	evicted prometheus.Counter
+}
+
+var (
+	nonceGuardMetricsOnce sync.Once
+	nonceGuardMetricsInst *nonceGuardMetrics
+)
+
+func getNonceGuardMetrics() *nonceGuardMetrics {
+	nonceGuardMetricsOnce.Do(func() {
+		nonceGuardMetricsInst = &nonceGuardMetrics{
+			size: prometheus.NewGauge(prometheus.GaugeOpts{
+				Name: "nhb_p2p_nonce_guard_size",
+				Help: "Number of entries tracked by the handshake nonce guard.",
+			}),
+			evicted: prometheus.NewCounter(prometheus.CounterOpts{
+				Name: "nhb_p2p_nonce_guard_evicted_total",
+				Help: "Number of nonce guard entries evicted due to TTL or capacity.",
+			}),
+		}
+		prometheus.MustRegister(nonceGuardMetricsInst.size, nonceGuardMetricsInst.evicted)
+	})
+	return nonceGuardMetricsInst
+}
+
+func (m *nonceGuardMetrics) observeSize(size int) {
+	if m == nil {
+		return
+	}
+	m.size.Set(float64(size))
+}
+
+func (m *nonceGuardMetrics) observeEvicted(delta int) {
+	if m == nil || delta <= 0 {
+		return
+	}
+	m.evicted.Add(float64(delta))
+}

--- a/tests/netsec/nonce_guard_test.go
+++ b/tests/netsec/nonce_guard_test.go
@@ -1,0 +1,64 @@
+package netsec
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"nhbchain/p2p"
+)
+
+func TestNonceGuardBoundedUnderFlood(t *testing.T) {
+	guard := p2p.NewNonceReplayGuard(time.Minute)
+	if closable, ok := guard.(interface{ Close() }); ok {
+		t.Cleanup(closable.Close)
+	}
+
+	const limit = 512
+	if adjustable, ok := guard.(interface{ SetMaxEntries(int) }); ok {
+		adjustable.SetMaxEntries(limit)
+	} else {
+		t.Fatalf("nonce guard does not expose SetMaxEntries for testing")
+	}
+
+	nodeID := "0x1234567890abcdef1234567890abcdef12345678"
+	now := time.Now()
+	for i := 0; i < limit*4; i++ {
+		nonce := fmt.Sprintf("0x%08x", i)
+		if !guard.Remember(nodeID, nonce, now.Add(time.Duration(i))) {
+			t.Fatalf("expected nonce %d to be accepted", i)
+		}
+	}
+
+	sized, ok := guard.(interface{ Size() int })
+	if !ok {
+		t.Fatalf("nonce guard does not expose Size for testing")
+	}
+	if size := sized.Size(); size > limit {
+		t.Fatalf("expected guard size to stay <= %d, got %d", limit, size)
+	}
+
+	if !guard.Remember(nodeID, "0x00000000", now.Add(time.Hour)) {
+		t.Fatalf("expected oldest nonce to be accepted after eviction")
+	}
+}
+
+func TestNonceGuardRejectsExpiredReuse(t *testing.T) {
+	guard := p2p.NewNonceReplayGuard(10 * time.Millisecond)
+	if closable, ok := guard.(interface{ Close() }); ok {
+		t.Cleanup(closable.Close)
+	}
+
+	nodeID := "0xabcdef0123456789abcdef0123456789abcdef01"
+	nonce := "0xfeedc0de"
+
+	start := time.Now()
+	if !guard.Remember(nodeID, nonce, start) {
+		t.Fatalf("expected nonce to be accepted initially")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	if guard.Remember(nodeID, nonce, time.Now()) {
+		t.Fatalf("expected replay to be rejected even after ttl expiration")
+	}
+}


### PR DESCRIPTION
## Summary
- replace the nonce replay guard with an LRU-based structure that enforces a TTL, hard capacity, and background janitor while exporting size/eviction metrics
- expose testing hooks and adjust unit tests to cover eviction, TTL expiry, and rejection semantics across the handshake stack
- add netsec regression tests to ensure large nonce floods remain bounded and expired nonces are still rejected

## Testing
- go test ./p2p ./tests/netsec

------
https://chatgpt.com/codex/tasks/task_e_68e227ed1534832d986a0016a0fa63a3