### PR TITLE
API-REPLAY-1: Enforce timestamp skew and nonce replay protection

### DIFF
--- a/docs/security/api-auth.md
+++ b/docs/security/api-auth.md
@@ -1,0 +1,40 @@
+# API Replay Protection
+
+The escrow and OTC gateways accept requests that are authenticated via an HMAC-SHA256 signature. Each request **must** include the following headers:
+
+| Header | Description |
+| --- | --- |
+| `X-Api-Key` | Identifies the client credential used to sign the request. |
+| `X-Timestamp` | Unix timestamp (seconds) at the time of signing. The gateway rejects requests older than ±2 minutes by default (configurable via `ESCROW_GATEWAY_TIMESTAMP_SKEW`). |
+| `X-Nonce` | Unique, client-chosen string used once per timestamp. Nonces are tracked per API key for twice the skew window (configurable via `ESCROW_GATEWAY_NONCE_TTL`). Reusing a nonce causes the request to be rejected. |
+| `X-Signature` | Hex-encoded HMAC-SHA256 signature computed with the shared secret. |
+
+The canonical payload used for signing is the newline-delimited concatenation of:
+
+1. The string value of `X-Timestamp`.
+2. The exact `X-Nonce` header value.
+3. The uppercase HTTP method.
+4. The canonical request path (path plus query parameters sorted lexicographically).
+5. The UTF-8 request body (empty string when there is no body).
+
+```text
+payload = join([timestamp, nonce, strings.ToUpper(method), canonicalPath, body], "\n")
+signature = hex.EncodeToString(HMAC_SHA256(secret, payload))
+```
+
+Signatures are compared using constant-time `hmac.Equal` after decoding from hex, eliminating early-exit timing leaks. A per-key nonce cache prevents captured signatures from being replayed within the TTL window, while still permitting legitimate retries signed with a fresh nonce.
+
+Wallet co-signatures (`X-Sig` / `X-Sig-Addr`) are bound to the same timestamp and nonce. The signed payload is:
+
+```text
+payload = strings.Join([]string{
+    strings.ToUpper(method),
+    canonicalPath,
+    body,
+    timestamp,
+    nonce,
+    strings.ToLower(resourceID),
+}, "|")
+```
+
+Requests missing any header, using stale timestamps, reusing a nonce, or providing malformed signatures now fail with `401 Unauthorized` before hitting business logic.

--- a/gateway/auth/auth.go
+++ b/gateway/auth/auth.go
@@ -1,0 +1,212 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// HeaderAPIKey is the header containing the caller's API key identifier.
+	HeaderAPIKey = "X-Api-Key"
+	// HeaderTimestamp is the unix timestamp (seconds) used when signing the request.
+	HeaderTimestamp = "X-Timestamp"
+	// HeaderNonce provides replay protection when combined with the timestamp.
+	HeaderNonce = "X-Nonce"
+	// HeaderSignature carries the hex-encoded HMAC-SHA256 signature for the request.
+	HeaderSignature = "X-Signature"
+	// MaxBodyForSignature is the maximum body size we will hash when authenticating.
+	MaxBodyForSignature int = 1 << 20 // 1 MiB
+)
+
+// Principal represents an authenticated API client.
+type Principal struct {
+	APIKey string
+}
+
+// Authenticator verifies API key + HMAC signatures on incoming requests.
+type Authenticator struct {
+	secrets              map[string]string
+	allowedTimestampSkew time.Duration
+	nonceTTL             time.Duration
+	nowFn                func() time.Time
+
+	nonceMu sync.Mutex
+	nonces  map[string]*nonceStore
+}
+
+// NewAuthenticator builds an Authenticator keyed by the provided secrets. The map
+// should contain API key identifiers mapped to their shared secret.
+func NewAuthenticator(secrets map[string]string, skew time.Duration, nonceTTL time.Duration, nowFn func() time.Time) *Authenticator {
+	cloned := make(map[string]string, len(secrets))
+	for k, v := range secrets {
+		cloned[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	if nonceTTL <= 0 {
+		// Default to twice the skew window, falling back to two minutes if skew is unset.
+		if skew > 0 {
+			nonceTTL = 2 * skew
+		} else {
+			nonceTTL = 2 * time.Minute
+		}
+	}
+	return &Authenticator{
+		secrets:              cloned,
+		allowedTimestampSkew: skew,
+		nonceTTL:             nonceTTL,
+		nowFn:                nowFn,
+		nonces:               make(map[string]*nonceStore),
+	}
+}
+
+// Authenticate validates headers and signature, returning the caller principal.
+func (a *Authenticator) Authenticate(r *http.Request, body []byte) (*Principal, error) {
+	if len(body) > MaxBodyForSignature {
+		return nil, fmt.Errorf("request body exceeds %d bytes", MaxBodyForSignature)
+	}
+	apiKey := strings.TrimSpace(r.Header.Get(HeaderAPIKey))
+	if apiKey == "" {
+		return nil, errors.New("missing X-Api-Key header")
+	}
+	secret, ok := a.secrets[apiKey]
+	if !ok || secret == "" {
+		return nil, errors.New("unknown API key")
+	}
+	timestampHeader := strings.TrimSpace(r.Header.Get(HeaderTimestamp))
+	if timestampHeader == "" {
+		return nil, errors.New("missing X-Timestamp header")
+	}
+	ts, err := parseUnixTimestamp(timestampHeader)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timestamp: %w", err)
+	}
+	now := a.nowFn().UTC()
+	skew := now.Sub(ts)
+	if skew < 0 {
+		skew = -skew
+	}
+	if a.allowedTimestampSkew > 0 && skew > a.allowedTimestampSkew {
+		return nil, fmt.Errorf("timestamp outside allowed skew of %s", a.allowedTimestampSkew)
+	}
+	nonce := strings.TrimSpace(r.Header.Get(HeaderNonce))
+	if nonce == "" {
+		return nil, errors.New("missing X-Nonce header")
+	}
+	providedSig := strings.TrimSpace(r.Header.Get(HeaderSignature))
+	if providedSig == "" {
+		return nil, errors.New("missing X-Signature header")
+	}
+	expected := ComputeSignature(secret, timestampHeader, nonce, r.Method, CanonicalRequestPath(r), body)
+	providedBytes, err := hex.DecodeString(providedSig)
+	if err != nil {
+		return nil, fmt.Errorf("invalid signature encoding: %w", err)
+	}
+	if !hmac.Equal(providedBytes, expected) {
+		return nil, errors.New("invalid signature")
+	}
+	if a.isReplay(apiKey, timestampHeader, nonce, now) {
+		return nil, errors.New("nonce already used")
+	}
+	return &Principal{APIKey: apiKey}, nil
+}
+
+func (a *Authenticator) isReplay(apiKey, timestamp, nonce string, now time.Time) bool {
+	cache := a.nonceStore(apiKey)
+	composite := timestamp + "|" + nonce
+	return cache.Seen(composite, now)
+}
+
+func (a *Authenticator) nonceStore(apiKey string) *nonceStore {
+	a.nonceMu.Lock()
+	defer a.nonceMu.Unlock()
+	cache, ok := a.nonces[apiKey]
+	if ok {
+		return cache
+	}
+	cache = newNonceStore(a.nonceTTL)
+	a.nonces[apiKey] = cache
+	return cache
+}
+
+// CanonicalRequestPath normalises URL paths and query ordering for signing.
+func CanonicalRequestPath(r *http.Request) string {
+	path := r.URL.Path
+	if path == "" {
+		path = "/"
+	}
+	if r.URL.RawQuery != "" {
+		path += "?" + CanonicalQuery(r.URL.RawQuery)
+	}
+	return path
+}
+
+// CanonicalQuery normalises raw query strings for stable HMAC signing.
+func CanonicalQuery(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, "&")
+	sort.Strings(parts)
+	return strings.Join(parts, "&")
+}
+
+// ComputeSignature builds the HMAC-SHA256 signature bytes for the request metadata.
+func ComputeSignature(secret, timestamp, nonce, method, path string, body []byte) []byte {
+	payload := strings.Join([]string{timestamp, nonce, strings.ToUpper(method), path, string(body)}, "\n")
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return mac.Sum(nil)
+}
+
+func parseUnixTimestamp(v string) (time.Time, error) {
+	secs, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(secs, 0).UTC(), nil
+}
+
+type nonceStore struct {
+	ttl time.Duration
+
+	mu      sync.Mutex
+	entries map[string]time.Time
+}
+
+func newNonceStore(ttl time.Duration) *nonceStore {
+	if ttl <= 0 {
+		ttl = 2 * time.Minute
+	}
+	return &nonceStore{
+		ttl:     ttl,
+		entries: make(map[string]time.Time),
+	}
+}
+
+// Seen returns true if the provided nonce has already been observed within the TTL window.
+func (n *nonceStore) Seen(key string, now time.Time) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	cutoff := now.Add(-n.ttl)
+	for k, ts := range n.entries {
+		if ts.Before(cutoff) {
+			delete(n.entries, k)
+		}
+	}
+	if _, exists := n.entries[key]; exists {
+		return true
+	}
+	n.entries[key] = now
+	return false
+}

--- a/services/escrow-gateway/auth.go
+++ b/services/escrow-gateway/auth.go
@@ -1,111 +1,45 @@
 package main
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
 	"encoding/hex"
-	"errors"
-	"fmt"
 	"net/http"
-	"sort"
-	"strings"
 	"time"
+
+	gatewayauth "nhbchain/gateway/auth"
 )
 
 const (
-	headerAPIKey        = "X-Api-Key"
-	headerTimestamp     = "X-Timestamp"
-	headerSignature     = "X-Signature"
-	maxBodyForSig   int = 1 << 20 // 1 MiB
+	headerAPIKey    = gatewayauth.HeaderAPIKey
+	headerTimestamp = gatewayauth.HeaderTimestamp
+	headerNonce     = gatewayauth.HeaderNonce
+	headerSignature = gatewayauth.HeaderSignature
+	maxBodyForSig   = gatewayauth.MaxBodyForSignature
 )
 
 // Principal represents an authenticated API client.
-type Principal struct {
-	APIKey string
-}
+type Principal = gatewayauth.Principal
 
 // Authenticator verifies API key + HMAC signatures on incoming requests.
-type Authenticator struct {
-	secrets              map[string]string
-	allowedTimestampSkew time.Duration
-	nowFn                func() time.Time
-}
+type Authenticator = gatewayauth.Authenticator
 
-func NewAuthenticator(keys []APIKeyConfig, skew time.Duration, nowFn func() time.Time) *Authenticator {
+func NewAuthenticator(keys []APIKeyConfig, skew, nonceTTL time.Duration, nowFn func() time.Time) *Authenticator {
 	secrets := make(map[string]string, len(keys))
 	for _, key := range keys {
 		secrets[key.Key] = key.Secret
 	}
-	if nowFn == nil {
-		nowFn = time.Now
-	}
-	return &Authenticator{secrets: secrets, allowedTimestampSkew: skew, nowFn: nowFn}
-}
-
-// Authenticate validates headers and signature, returning the caller principal.
-func (a *Authenticator) Authenticate(r *http.Request, body []byte) (*Principal, error) {
-	if len(body) > maxBodyForSig {
-		return nil, fmt.Errorf("request body exceeds %d bytes", maxBodyForSig)
-	}
-	apiKey := strings.TrimSpace(r.Header.Get(headerAPIKey))
-	if apiKey == "" {
-		return nil, errors.New("missing X-Api-Key header")
-	}
-	secret, ok := a.secrets[apiKey]
-	if !ok {
-		return nil, errors.New("unknown API key")
-	}
-	timestampHeader := strings.TrimSpace(r.Header.Get(headerTimestamp))
-	if timestampHeader == "" {
-		return nil, errors.New("missing X-Timestamp header")
-	}
-	ts, err := parseUnixTimestamp(timestampHeader)
-	if err != nil {
-		return nil, fmt.Errorf("invalid timestamp: %w", err)
-	}
-	now := a.nowFn().UTC()
-	skew := now.Sub(ts)
-	if skew < 0 {
-		skew = -skew
-	}
-	if skew > a.allowedTimestampSkew {
-		return nil, fmt.Errorf("timestamp outside allowed skew of %s", a.allowedTimestampSkew)
-	}
-	providedSig := strings.TrimSpace(r.Header.Get(headerSignature))
-	if providedSig == "" {
-		return nil, errors.New("missing X-Signature header")
-	}
-	expected := computeSignature(secret, timestampHeader, r.Method, canonicalRequestPath(r), body)
-	if !hmac.Equal([]byte(strings.ToLower(providedSig)), []byte(expected)) {
-		return nil, errors.New("invalid signature")
-	}
-	return &Principal{APIKey: apiKey}, nil
+	auth := gatewayauth.NewAuthenticator(secrets, skew, nonceTTL, nowFn)
+	return auth
 }
 
 func canonicalRequestPath(r *http.Request) string {
-	path := r.URL.Path
-	if path == "" {
-		path = "/"
-	}
-	if r.URL.RawQuery != "" {
-		// Ensure consistent ordering of query params
-		path += "?" + canonicalQuery(r.URL.RawQuery)
-	}
-	return path
+	return gatewayauth.CanonicalRequestPath(r)
 }
 
 func canonicalQuery(raw string) string {
-	if raw == "" {
-		return ""
-	}
-	parts := strings.Split(raw, "&")
-	sort.Strings(parts)
-	return strings.Join(parts, "&")
+	return gatewayauth.CanonicalQuery(raw)
 }
 
-func computeSignature(secret, timestamp, method, path string, body []byte) string {
-	payload := strings.Join([]string{timestamp, strings.ToUpper(method), path, string(body)}, "\n")
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(payload))
-	return hex.EncodeToString(mac.Sum(nil))
+func computeSignature(secret, timestamp, nonce, method, path string, body []byte) string {
+	sig := gatewayauth.ComputeSignature(secret, timestamp, nonce, method, path, body)
+	return hex.EncodeToString(sig)
 }

--- a/services/escrow-gateway/main.go
+++ b/services/escrow-gateway/main.go
@@ -57,7 +57,7 @@ func main() {
 	}
 	defer store.Close()
 
-	auth := NewAuthenticator(cfg.APIKeys, cfg.AllowedTimestampSkew, nil)
+	auth := NewAuthenticator(cfg.APIKeys, cfg.AllowedTimestampSkew, cfg.NonceTTL, nil)
 	node := NewRPCNodeClient(cfg.NodeURL, cfg.NodeAuthToken)
 	queue := NewWebhookQueue(
 		WithWebhookTaskCapacity(cfg.WebhookQueueCapacity),

--- a/services/escrow-gateway/server.go
+++ b/services/escrow-gateway/server.go
@@ -463,7 +463,11 @@ func (s *Server) verifyWalletSignature(r *http.Request, body []byte, resourceID 
 	if timestamp == "" {
 		return "", errors.New("missing X-Timestamp header")
 	}
-	payload := strings.Join([]string{strings.ToUpper(r.Method), canonicalRequestPath(r), string(body), timestamp, strings.ToLower(strings.TrimSpace(resourceID))}, "|")
+	nonce := strings.TrimSpace(r.Header.Get(headerNonce))
+	if nonce == "" {
+		return "", errors.New("missing X-Nonce header")
+	}
+	payload := strings.Join([]string{strings.ToUpper(r.Method), canonicalRequestPath(r), string(body), timestamp, nonce, strings.ToLower(strings.TrimSpace(resourceID))}, "|")
 	msgHash := ethcrypto.Keccak256([]byte(payload))
 	digest := accounts.TextHash(msgHash)
 

--- a/tests/gateway/auth_replay_test.go
+++ b/tests/gateway/auth_replay_test.go
@@ -1,0 +1,58 @@
+package gateway_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	gatewayauth "nhbchain/gateway/auth"
+)
+
+func TestHMACReplayRejected(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	auth := gatewayauth.NewAuthenticator(map[string]string{"test": "secret"}, 2*time.Minute, 0, func() time.Time {
+		return now
+	})
+
+	body := []byte(`{"payload":"example"}`)
+	req := httptest.NewRequest(http.MethodPost, "/payments?id=1&sort=desc", bytes.NewReader(body))
+	timestamp := strconv.FormatInt(now.Unix(), 10)
+	nonce := "nonce-original"
+	sig := hex.EncodeToString(gatewayauth.ComputeSignature("secret", timestamp, nonce, http.MethodPost, gatewayauth.CanonicalRequestPath(req), body))
+
+	req.Header.Set(gatewayauth.HeaderAPIKey, "test")
+	req.Header.Set(gatewayauth.HeaderTimestamp, timestamp)
+	req.Header.Set(gatewayauth.HeaderNonce, nonce)
+	req.Header.Set(gatewayauth.HeaderSignature, sig)
+
+	principal, err := auth.Authenticate(req, body)
+	if err != nil {
+		t.Fatalf("authenticate first request: %v", err)
+	}
+	if principal.APIKey != "test" {
+		t.Fatalf("unexpected principal: %+v", principal)
+	}
+
+	replay := httptest.NewRequest(http.MethodPost, "/payments?sort=desc&id=1", bytes.NewReader(body))
+	replay.Header = req.Header.Clone()
+	if _, err := auth.Authenticate(replay, body); err == nil || !strings.Contains(err.Error(), "nonce") {
+		t.Fatalf("expected nonce replay rejection, got %v", err)
+	}
+
+	newNonce := "nonce-retry"
+	sig2 := hex.EncodeToString(gatewayauth.ComputeSignature("secret", timestamp, newNonce, http.MethodPost, gatewayauth.CanonicalRequestPath(replay), body))
+	retry := httptest.NewRequest(http.MethodPost, "/payments?sort=desc&id=1", bytes.NewReader(body))
+	retry.Header.Set(gatewayauth.HeaderAPIKey, "test")
+	retry.Header.Set(gatewayauth.HeaderTimestamp, timestamp)
+	retry.Header.Set(gatewayauth.HeaderNonce, newNonce)
+	retry.Header.Set(gatewayauth.HeaderSignature, sig2)
+
+	if _, err := auth.Authenticate(retry, body); err != nil {
+		t.Fatalf("authenticate retried request: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- move escrow gateway HMAC validation into a shared `gateway/auth` package with nonce tracking and constant-time signature checks
- require `X-Nonce` alongside a tighter ±2m timestamp skew and bind wallet signatures to the same nonce
- document the signing rules and add a replay regression test covering duplicate nonce rejection

## Testing
- go test ./gateway/auth ./services/escrow-gateway ./tests/gateway

------
https://chatgpt.com/codex/tasks/task_e_68e23aceecbc832db817adfe3789a47d