### PR TITLE
NET-HTTPS-1: Enforce HTTPS/TLS for gateway→node RPC

### DIFF
--- a/docs/ops/security.md
+++ b/docs/ops/security.md
@@ -1,0 +1,16 @@
+# Gateway TLS Enforcement
+
+The gateway refuses to connect to plaintext JSON-RPC endpoints outside of the
+`dev` environment. When `NHB_ENV` is set to any other value, service endpoints
+must use `https://` URLs.
+
+For operators that are in the process of migrating endpoints, set one of the
+following configuration options to automatically upgrade existing `http://`
+values to HTTPS:
+
+- Set `security.autoUpgradeHTTP: true` in the gateway configuration file.
+- Export `NHB_GATEWAY_AUTO_HTTPS=true` in the gateway environment.
+
+When auto-upgrade is enabled the gateway will transparently rewrite the scheme
+before proxying requests. This keeps production safe by enforcing TLS while
+avoiding downtime during transition periods.

--- a/tests/gateway/https_enforce_test.go
+++ b/tests/gateway/https_enforce_test.go
@@ -1,0 +1,69 @@
+package gateway_test
+
+import (
+	"net/url"
+	"testing"
+
+	gatewayconfig "nhbchain/gateway/config"
+)
+
+func TestEnforceSecureSchemeRejectsHTTPInProd(t *testing.T) {
+	raw, err := url.Parse("http://node.internal:26657")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if _, _, err := gatewayconfig.EnforceSecureScheme("prod", raw, false); err == nil {
+		t.Fatalf("expected rejection for plaintext endpoint in prod")
+	}
+}
+
+func TestEnforceSecureSchemeAllowsDevHTTP(t *testing.T) {
+	raw, err := url.Parse("http://localhost:26657")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	secured, upgraded, err := gatewayconfig.EnforceSecureScheme("dev", raw, false)
+	if err != nil {
+		t.Fatalf("enforce scheme: %v", err)
+	}
+	if upgraded {
+		t.Fatalf("expected no upgrade in dev environment")
+	}
+	if secured.Scheme != "http" {
+		t.Fatalf("expected http scheme, got %s", secured.Scheme)
+	}
+}
+
+func TestEnforceSecureSchemeUpgradesWhenEnabled(t *testing.T) {
+	raw, err := url.Parse("http://node.internal:26657")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	secured, upgraded, err := gatewayconfig.EnforceSecureScheme("prod", raw, true)
+	if err != nil {
+		t.Fatalf("enforce scheme: %v", err)
+	}
+	if !upgraded {
+		t.Fatalf("expected upgrade flag")
+	}
+	if secured.Scheme != "https" {
+		t.Fatalf("expected https scheme, got %s", secured.Scheme)
+	}
+}
+
+func TestEnforceSecureSchemeAcceptsHTTPS(t *testing.T) {
+	raw, err := url.Parse("https://rpc.nhbchain.com")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	secured, upgraded, err := gatewayconfig.EnforceSecureScheme("prod", raw, false)
+	if err != nil {
+		t.Fatalf("enforce scheme: %v", err)
+	}
+	if upgraded {
+		t.Fatalf("did not expect upgrade for HTTPS endpoint")
+	}
+	if secured.String() != raw.String() {
+		t.Fatalf("expected same URL, got %s", secured.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add a security section to the gateway configuration with HTTPS enforcement helpers
- require HTTPS service endpoints in the gateway, with optional env-driven auto-upgrade logging
- document the TLS requirement and add regression tests covering rejection, allowance, and upgrade paths

## Testing
- go test ./tests/gateway -run EnforceSecureScheme -count=1

------
https://chatgpt.com/codex/tasks/task_e_68e24c83a520832d93d533f62b43ba42