### PR TITLE
Implement bounded nonce cache with capacity controls

### DIFF
--- a/gateway/auth/auth_test.go
+++ b/gateway/auth/auth_test.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestNonceStoreCapacityEviction(t *testing.T) {
+	store := newNonceStore(5*time.Minute, 3)
+	base := time.Unix(1700000000, 0).UTC()
+
+	for i := 0; i < 3; i++ {
+		key := fmt.Sprintf("nonce-%d", i)
+		if seen := store.Seen(key, base); seen {
+			t.Fatalf("expected first observation of %s to be false", key)
+		}
+	}
+	if got := len(store.entries); got != 3 {
+		t.Fatalf("expected 3 entries after initial fill, got %d", got)
+	}
+
+	if seen := store.Seen("nonce-3", base); seen {
+		t.Fatalf("expected new key to be accepted after capacity eviction")
+	}
+	if got := len(store.entries); got != 3 {
+		t.Fatalf("expected capacity to remain at 3, got %d", got)
+	}
+	if _, exists := store.entries["nonce-0"]; exists {
+		t.Fatalf("expected oldest nonce to be evicted when capacity exceeded")
+	}
+	if seen := store.Seen("nonce-1", base); !seen {
+		t.Fatalf("expected recently seen nonce to be reported as duplicate")
+	}
+
+	if seen := store.Seen("nonce-4", base); seen {
+		t.Fatalf("expected new key to be accepted after second eviction")
+	}
+	if got := len(store.entries); got != 3 {
+		t.Fatalf("expected capacity to remain bounded at 3, got %d", got)
+	}
+}
+
+func TestNonceStoreExpiresOldEntries(t *testing.T) {
+	store := newNonceStore(30*time.Second, 5)
+	base := time.Unix(1700000000, 0).UTC()
+
+	if store.Seen("nonce-a", base) {
+		t.Fatalf("expected first nonce to be new")
+	}
+	if store.Seen("nonce-b", base.Add(5*time.Second)) {
+		t.Fatalf("expected second nonce to be new")
+	}
+
+	future := base.Add(1 * time.Minute)
+	if store.Seen("nonce-c", future) {
+		t.Fatalf("expected new nonce to be accepted after expiration window")
+	}
+	if _, exists := store.entries["nonce-a"]; exists {
+		t.Fatalf("expected expired nonce-a to be pruned")
+	}
+	if _, exists := store.entries["nonce-b"]; exists {
+		t.Fatalf("expected expired nonce-b to be pruned")
+	}
+
+	if store.Seen("nonce-b", future) {
+		t.Fatalf("expected nonce-b to be treated as new after expiration")
+	}
+}

--- a/services/escrow-gateway/auth.go
+++ b/services/escrow-gateway/auth.go
@@ -22,12 +22,12 @@ type Principal = gatewayauth.Principal
 // Authenticator verifies API key + HMAC signatures on incoming requests.
 type Authenticator = gatewayauth.Authenticator
 
-func NewAuthenticator(keys []APIKeyConfig, skew, nonceTTL time.Duration, nowFn func() time.Time) *Authenticator {
+func NewAuthenticator(keys []APIKeyConfig, skew, nonceTTL time.Duration, nonceCap int, nowFn func() time.Time) *Authenticator {
 	secrets := make(map[string]string, len(keys))
 	for _, key := range keys {
 		secrets[key.Key] = key.Secret
 	}
-	auth := gatewayauth.NewAuthenticator(secrets, skew, nonceTTL, nowFn)
+	auth := gatewayauth.NewAuthenticator(secrets, skew, nonceTTL, nonceCap, nowFn)
 	return auth
 }
 

--- a/services/escrow-gateway/main.go
+++ b/services/escrow-gateway/main.go
@@ -57,7 +57,7 @@ func main() {
 	}
 	defer store.Close()
 
-	auth := NewAuthenticator(cfg.APIKeys, cfg.AllowedTimestampSkew, cfg.NonceTTL, nil)
+	auth := NewAuthenticator(cfg.APIKeys, cfg.AllowedTimestampSkew, cfg.NonceTTL, cfg.NonceCapacity, nil)
 	node := NewRPCNodeClient(cfg.NodeURL, cfg.NodeAuthToken)
 	queue := NewWebhookQueue(
 		WithWebhookTaskCapacity(cfg.WebhookQueueCapacity),

--- a/services/escrow-gateway/server_test.go
+++ b/services/escrow-gateway/server_test.go
@@ -168,7 +168,7 @@ func newTestServer(t *testing.T, node NodeClient) (*Server, *SQLiteStore, *Webho
 	if err != nil {
 		t.Fatalf("new store: %v", err)
 	}
-	auth := NewAuthenticator([]APIKeyConfig{{Key: "test", Secret: "secret"}}, time.Minute, 2*time.Minute, func() time.Time {
+	auth := NewAuthenticator([]APIKeyConfig{{Key: "test", Secret: "secret"}}, time.Minute, 2*time.Minute, 4, func() time.Time {
 		return time.Unix(1700000000, 0).UTC()
 	})
 	queue := NewWebhookQueue()

--- a/tests/gateway/auth_replay_test.go
+++ b/tests/gateway/auth_replay_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestHMACReplayRejected(t *testing.T) {
 	now := time.Unix(1700000000, 0).UTC()
-	auth := gatewayauth.NewAuthenticator(map[string]string{"test": "secret"}, 2*time.Minute, 0, func() time.Time {
+	auth := gatewayauth.NewAuthenticator(map[string]string{"test": "secret"}, 2*time.Minute, 0, 0, func() time.Time {
 		return now
 	})
 

--- a/tests/gateway/skew_test.go
+++ b/tests/gateway/skew_test.go
@@ -15,7 +15,7 @@ import (
 func TestAuthenticatorRejectsOlderTimestamp(t *testing.T) {
 	base := time.Unix(1700000000, 0).UTC()
 	current := base
-	auth := gatewayauth.NewAuthenticator(map[string]string{"test": "secret"}, 0, 0, func() time.Time {
+	auth := gatewayauth.NewAuthenticator(map[string]string{"test": "secret"}, 0, 0, 0, func() time.Time {
 		return current
 	})
 
@@ -51,7 +51,7 @@ func TestAuthenticatorRejectsOlderTimestamp(t *testing.T) {
 func TestAuthenticatorAcceptsNewerTimestamp(t *testing.T) {
 	base := time.Unix(1700000000, 0).UTC()
 	current := base
-	auth := gatewayauth.NewAuthenticator(map[string]string{"test": "secret"}, 0, 0, func() time.Time {
+	auth := gatewayauth.NewAuthenticator(map[string]string{"test": "secret"}, 0, 0, 0, func() time.Time {
 		return current
 	})
 


### PR DESCRIPTION
## Summary
- replace nonce cache map with ordered structure supporting TTL pruning and capacity limits
- expose a configurable per-key nonce capacity through escrow gateway configuration
- add nonce eviction unit tests and update call sites for the new authenticator signature

## Testing
- go test ./gateway/auth
- go test ./tests/gateway
- go test ./services/escrow-gateway -run TestAuthenticateRejectsInvalidSignature -count=1


------
https://chatgpt.com/codex/tasks/task_e_68e25137c12c832da1b9923f69e59bcc