### PR TITLE
Add eviction to IP rate limiter

### DIFF
--- a/p2p/ratelimit.go
+++ b/p2p/ratelimit.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"container/list"
 	"math"
 	"sync"
 	"time"
@@ -11,6 +12,7 @@ type tokenBucket struct {
 	tokens   float64
 	rate     float64
 	last     time.Time
+	lastSeen time.Time
 	mu       sync.Mutex
 }
 
@@ -30,6 +32,7 @@ func newTokenBucket(rate float64, burst float64) *tokenBucket {
 		tokens:   burst,
 		rate:     rate,
 		last:     now,
+		lastSeen: now,
 	}
 }
 
@@ -41,6 +44,9 @@ func (b *tokenBucket) allow(now time.Time) bool {
 	defer b.mu.Unlock()
 
 	b.refillLocked(now)
+	if now.After(b.lastSeen) {
+		b.lastSeen = now
+	}
 	if b.tokens >= 1 {
 		b.tokens -= 1
 		return true
@@ -83,25 +89,67 @@ func (b *tokenBucket) setRate(rate float64, burst float64) {
 }
 
 type ipRateLimiter struct {
-	rate  float64
-	burst float64
+	rate        float64
+	burst       float64
+	idleTimeout time.Duration
+	maxEntries  int
 
 	mu     sync.Mutex
-	limits map[string]*tokenBucket
+	limits map[string]*bucketEntry
+	order  *list.List
 }
 
-func newIPRateLimiter(rate float64, burst float64) *ipRateLimiter {
+type bucketEntry struct {
+	bucket   *tokenBucket
+	lastSeen time.Time
+	element  *list.Element
+}
+
+type ipRateLimiterOption func(*ipRateLimiter)
+
+const (
+	defaultIPBucketIdleTimeout = 15 * time.Minute
+)
+
+// WithIPRateLimiterIdleTimeout sets the duration after which idle token buckets are evicted.
+func WithIPRateLimiterIdleTimeout(timeout time.Duration) ipRateLimiterOption {
+	return func(l *ipRateLimiter) {
+		l.idleTimeout = timeout
+	}
+}
+
+// WithIPRateLimiterMaxEntries bounds the number of token buckets retained at once.
+// A value <= 0 disables the cap.
+func WithIPRateLimiterMaxEntries(max int) ipRateLimiterOption {
+	return func(l *ipRateLimiter) {
+		l.maxEntries = max
+	}
+}
+
+func newIPRateLimiter(rate float64, burst float64, opts ...ipRateLimiterOption) *ipRateLimiter {
 	if rate <= 0 {
 		return nil
 	}
 	if burst < 1 {
 		burst = 1
 	}
-	return &ipRateLimiter{
-		rate:   rate,
-		burst:  burst,
-		limits: make(map[string]*tokenBucket),
+	limiter := &ipRateLimiter{
+		rate:        rate,
+		burst:       burst,
+		idleTimeout: defaultIPBucketIdleTimeout,
+		limits:      make(map[string]*bucketEntry),
+		order:       list.New(),
 	}
+	for _, opt := range opts {
+		opt(limiter)
+	}
+	if limiter.idleTimeout < 0 {
+		limiter.idleTimeout = 0
+	}
+	if limiter.maxEntries < 0 {
+		limiter.maxEntries = 0
+	}
+	return limiter
 }
 
 func (l *ipRateLimiter) allow(ip string, now time.Time) bool {
@@ -113,12 +161,71 @@ func (l *ipRateLimiter) allow(ip string, now time.Time) bool {
 	}
 
 	l.mu.Lock()
-	bucket := l.limits[ip]
-	if bucket == nil {
-		bucket = newTokenBucket(l.rate, l.burst)
-		l.limits[ip] = bucket
+	l.evictIdleLocked(now)
+
+	entry := l.limits[ip]
+	if entry == nil {
+		l.evictLRULocked()
+		bucket := newTokenBucket(l.rate, l.burst)
+		entry = &bucketEntry{bucket: bucket}
+		entry.element = l.order.PushBack(ip)
+		l.limits[ip] = entry
 	}
+	entry.lastSeen = now
+	if entry.element != nil {
+		l.order.MoveToBack(entry.element)
+	}
+	bucket := entry.bucket
 	l.mu.Unlock()
 
 	return bucket.allow(now)
+}
+
+func (l *ipRateLimiter) evictIdleLocked(now time.Time) {
+	if l == nil || l.idleTimeout <= 0 {
+		return
+	}
+	cutoff := now.Add(-l.idleTimeout)
+	for {
+		front := l.order.Front()
+		if front == nil {
+			return
+		}
+		ip, _ := front.Value.(string)
+		entry, ok := l.limits[ip]
+		if !ok {
+			l.order.Remove(front)
+			continue
+		}
+		if !entry.lastSeen.Before(cutoff) {
+			return
+		}
+		l.removeEntryLocked(ip)
+	}
+}
+
+func (l *ipRateLimiter) evictLRULocked() {
+	if l == nil || l.maxEntries <= 0 {
+		return
+	}
+	for len(l.limits) >= l.maxEntries {
+		front := l.order.Front()
+		if front == nil {
+			return
+		}
+		ip, _ := front.Value.(string)
+		l.removeEntryLocked(ip)
+	}
+}
+
+func (l *ipRateLimiter) removeEntryLocked(ip string) {
+	entry, ok := l.limits[ip]
+	if !ok {
+		return
+	}
+	if entry.element != nil {
+		l.order.Remove(entry.element)
+		entry.element = nil
+	}
+	delete(l.limits, ip)
 }

--- a/p2p/ratelimit_test.go
+++ b/p2p/ratelimit_test.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -25,6 +26,24 @@ func TestTokenBucketAllowance(t *testing.T) {
 	}
 }
 
+func TestTokenBucketLastSeen(t *testing.T) {
+	bucket := newTokenBucket(1, 1)
+	now := bucket.lastSeen
+	if !bucket.allow(now) {
+		t.Fatalf("token should be available at start")
+	}
+	if bucket.lastSeen != now {
+		t.Fatalf("lastSeen not updated, got %v want %v", bucket.lastSeen, now)
+	}
+	later := now.Add(time.Second)
+	if !bucket.allow(later) {
+		t.Fatalf("token should refill after a second")
+	}
+	if bucket.lastSeen != later {
+		t.Fatalf("lastSeen should advance, got %v want %v", bucket.lastSeen, later)
+	}
+}
+
 func TestIPRateLimiter(t *testing.T) {
 	limiter := newIPRateLimiter(1, 1)
 	now := time.Now()
@@ -39,5 +58,93 @@ func TestIPRateLimiter(t *testing.T) {
 	}
 	if !limiter.allow("1.2.3.4", now.Add(time.Second)) {
 		t.Fatalf("token should refill after rate interval")
+	}
+}
+
+func TestIPRateLimiterIdleEviction(t *testing.T) {
+	limiter := newIPRateLimiter(1, 1, WithIPRateLimiterIdleTimeout(time.Second))
+	now := time.Unix(0, 0)
+
+	if !limiter.allow("1.1.1.1", now) {
+		t.Fatalf("expected allow for first IP")
+	}
+	if !limiter.allow("2.2.2.2", now.Add(500*time.Millisecond)) {
+		t.Fatalf("expected allow for second IP")
+	}
+	if !limiter.allow("3.3.3.3", now.Add(1500*time.Millisecond)) {
+		t.Fatalf("expected allow for third IP after idle eviction")
+	}
+
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+
+	if _, ok := limiter.limits["1.1.1.1"]; ok {
+		t.Fatalf("idle IP should have been evicted")
+	}
+	if _, ok := limiter.limits["2.2.2.2"]; !ok {
+		t.Fatalf("recent IP should remain in limiter")
+	}
+	if _, ok := limiter.limits["3.3.3.3"]; !ok {
+		t.Fatalf("new IP should be present")
+	}
+}
+
+func TestIPRateLimiterMaxEntries(t *testing.T) {
+	const maxEntries = 10
+	limiter := newIPRateLimiter(1, 1, WithIPRateLimiterMaxEntries(maxEntries))
+	now := time.Unix(0, 0)
+
+	for i := 0; i < 100; i++ {
+		ip := fmt.Sprintf("192.0.2.%d", i)
+		if !limiter.allow(ip, now.Add(time.Duration(i)*time.Millisecond)) {
+			t.Fatalf("unexpected denial for ip %s", ip)
+		}
+	}
+
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+
+	if len(limiter.limits) > maxEntries {
+		t.Fatalf("limiter should cap entries to %d, got %d", maxEntries, len(limiter.limits))
+	}
+	if limiter.order.Len() > maxEntries {
+		t.Fatalf("order list should not exceed max entries, got %d", limiter.order.Len())
+	}
+}
+
+func TestIPRateLimiterLRUEviction(t *testing.T) {
+        limiter := newIPRateLimiter(10, 10, WithIPRateLimiterMaxEntries(3))
+        now := time.Unix(0, 0)
+
+        ips := []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"}
+        for i, ip := range ips {
+                if !limiter.allow(ip, now.Add(time.Duration(i)*time.Millisecond)) {
+			t.Fatalf("unexpected denial for %s", ip)
+		}
+	}
+
+	// Touch the first IP so it becomes the most recently used.
+	if !limiter.allow("1.1.1.1", now.Add(100*time.Millisecond)) {
+		t.Fatalf("expected allow for refreshed IP")
+	}
+
+	if !limiter.allow("4.4.4.4", now.Add(200*time.Millisecond)) {
+		t.Fatalf("expected allow for new IP")
+	}
+
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+
+	if _, ok := limiter.limits["2.2.2.2"]; ok {
+		t.Fatalf("least recently used IP should have been evicted")
+	}
+	if _, ok := limiter.limits["1.1.1.1"]; !ok {
+		t.Fatalf("recently refreshed IP should remain")
+	}
+	if _, ok := limiter.limits["3.3.3.3"]; !ok {
+		t.Fatalf("existing IP should remain")
+	}
+	if _, ok := limiter.limits["4.4.4.4"]; !ok {
+		t.Fatalf("new IP should be present")
 	}
 }


### PR DESCRIPTION
## Summary
- track last-seen timestamps for IP rate-limit buckets and evict entries once they are idle for a configurable window
- add an optional maximum bucket count with LRU eviction to bound rate limiter memory growth under churn
- expand the rate limiter tests to cover idle and LRU eviction behaviour

## Testing
- ./p2p.test -test.run TestIPRateLimiter -test.v

------
https://chatgpt.com/codex/tasks/task_e_68e2e3a469f8832dbd60abebb25bb658