### PR TITLE
Add secure consensus client options to governd

### DIFF
--- a/docs/gov/service.md
+++ b/docs/gov/service.md
@@ -28,6 +28,15 @@ auth:
   api_tokens: []               # list of accepted bearer tokens for Msg RPCs
   mtls:
     allowed_common_names: []   # optional set of authorised client certificate common names
+consensus_client:              # security settings for the outbound consensus client
+  allow_insecure: true         # development override for plaintext consensus connections
+  tls:
+    cert: ""                   # optional client certificate for mutual TLS
+    key: ""
+    ca: ""                    # optional PEM bundle of trusted consensus server roots
+  shared_secret:
+    header: "authorization"   # metadata key for the shared-secret token
+    token: ""                 # optional static shared secret sent to consensus
 ```
 
 * **`signer_key`** is required and must be the lowercase hexadecimal encoding of
@@ -47,6 +56,11 @@ auth:
 * **`auth.mtls.allowed_common_names`** lists the client certificate subjects
   permitted to call the `gov.v1.Msg` RPCs when mTLS is enabled. Leave the list
   empty to disable subject filtering.
+* **`consensus_client`** controls how the service authenticates to the
+  consensus endpoint. Production deployments should provision TLS material and
+  optionally set a shared-secret token enforced by the validator. Leave
+  `allow_insecure` disabled outside of throwaway lab environments; the process
+  now fails fast if neither TLS nor a shared secret are configured.
 
 ## Running the service
 

--- a/services/governd/config.yaml
+++ b/services/governd/config.yaml
@@ -15,3 +15,12 @@ auth:
   api_tokens: []
   mtls:
     allowed_common_names: []
+consensus_client:
+  allow_insecure: true
+  tls:
+    cert: ""
+    key: ""
+    ca: ""
+  shared_secret:
+    header: "authorization"
+    token: ""

--- a/services/governd/config/config.go
+++ b/services/governd/config/config.go
@@ -3,20 +3,22 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 // Config captures the runtime settings for the governance service.
 type Config struct {
-	ListenAddress     string     `yaml:"listen"`
-	ConsensusEndpoint string     `yaml:"consensus"`
-	ChainID           string     `yaml:"chain_id"`
-	SignerKey         string     `yaml:"signer_key"`
-	NonceStart        uint64     `yaml:"nonce_start"`
-	Fee               FeeConfig  `yaml:"fee"`
-	TLS               TLSConfig  `yaml:"tls"`
-	Auth              AuthConfig `yaml:"auth"`
+	ListenAddress     string       `yaml:"listen"`
+	ConsensusEndpoint string       `yaml:"consensus"`
+	ChainID           string       `yaml:"chain_id"`
+	SignerKey         string       `yaml:"signer_key"`
+	NonceStart        uint64       `yaml:"nonce_start"`
+	Fee               FeeConfig    `yaml:"fee"`
+	TLS               TLSConfig    `yaml:"tls"`
+	Auth              AuthConfig   `yaml:"auth"`
+	ConsensusClient   ClientConfig `yaml:"consensus_client"`
 }
 
 // FeeConfig describes the optional transaction fee metadata attached to
@@ -32,6 +34,26 @@ type TLSConfig struct {
 	CertPath     string `yaml:"cert"`
 	KeyPath      string `yaml:"key"`
 	ClientCAPath string `yaml:"client_ca"`
+}
+
+// ClientConfig describes the security configuration for the consensus client.
+type ClientConfig struct {
+	AllowInsecure bool               `yaml:"allow_insecure"`
+	TLS           ClientTLSConfig    `yaml:"tls"`
+	SharedSecret  SharedSecretConfig `yaml:"shared_secret"`
+}
+
+// ClientTLSConfig captures optional TLS material for the consensus client.
+type ClientTLSConfig struct {
+	CertPath string `yaml:"cert"`
+	KeyPath  string `yaml:"key"`
+	CAPath   string `yaml:"ca"`
+}
+
+// SharedSecretConfig provides metadata for shared-secret authentication.
+type SharedSecretConfig struct {
+	Header string `yaml:"header"`
+	Token  string `yaml:"token"`
 }
 
 // AuthConfig describes the authentication mechanisms accepted by the service.
@@ -86,5 +108,32 @@ func Load(path string) (Config, error) {
 	if cfg.TLS.KeyPath == "" {
 		return cfg, fmt.Errorf("tls.key is required")
 	}
+	if err := cfg.ConsensusClient.Validate(); err != nil {
+		return cfg, fmt.Errorf("consensus client security: %w", err)
+	}
 	return cfg, nil
+}
+
+// Validate ensures the consensus client security configuration is well formed.
+func (cfg *ClientConfig) Validate() error {
+	if cfg == nil {
+		return fmt.Errorf("configuration is missing")
+	}
+	cfg.SharedSecret.Header = strings.TrimSpace(cfg.SharedSecret.Header)
+	cfg.SharedSecret.Token = strings.TrimSpace(cfg.SharedSecret.Token)
+
+	hasTLSCert := strings.TrimSpace(cfg.TLS.CertPath) != ""
+	hasTLSKey := strings.TrimSpace(cfg.TLS.KeyPath) != ""
+	if hasTLSCert != hasTLSKey {
+		return fmt.Errorf("tls cert and key must both be provided when enabling client mTLS")
+	}
+
+	hasTLS := strings.TrimSpace(cfg.TLS.CAPath) != "" || (hasTLSCert && hasTLSKey)
+	hasSharedSecret := cfg.SharedSecret.Token != ""
+
+	if !cfg.AllowInsecure && !hasTLS && !hasSharedSecret {
+		return fmt.Errorf("requires tls material or shared-secret authentication unless allow_insecure=true")
+	}
+
+	return nil
 }

--- a/services/governd/config/config_test.go
+++ b/services/governd/config/config_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	sampleSignerKey = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+)
+
+func writeTempConfig(t *testing.T, contents string) string {
+	t.Helper()
+	file, err := os.CreateTemp(t.TempDir(), "governd-config-*.yaml")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	if _, err := file.WriteString(contents); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close config: %v", err)
+	}
+	return file.Name()
+}
+
+func baseConfig(prefix string) string {
+	return "listen: \"" + prefix + "\"\n" +
+		"consensus: \"localhost:9090\"\n" +
+		"chain_id: \"localnet\"\n" +
+		"signer_key: \"" + sampleSignerKey + "\"\n" +
+		"nonce_start: 1\n" +
+		"fee:\n" +
+		"  amount: \"\"\n" +
+		"  denom: \"\"\n" +
+		"  payer: \"\"\n" +
+		"tls:\n" +
+		"  cert: \"" + filepath.ToSlash(filepath.Join("services", "governd", "config", "server.crt")) + "\"\n" +
+		"  key: \"" + filepath.ToSlash(filepath.Join("services", "governd", "config", "server.key")) + "\"\n" +
+		"  client_ca: \"\"\n" +
+		"auth:\n" +
+		"  api_tokens: []\n" +
+		"  mtls:\n" +
+		"    allowed_common_names: []\n"
+}
+
+func TestLoadRequiresConsensusClientSecurity(t *testing.T) {
+	path := writeTempConfig(t, baseConfig(":50061"))
+	if _, err := Load(path); err == nil {
+		t.Fatalf("expected load to fail when consensus client security is missing")
+	}
+}
+
+func TestLoadAllowsExplicitInsecureConsensus(t *testing.T) {
+	cfg := baseConfig(":50062") +
+		"consensus_client:\n" +
+		"  allow_insecure: true\n" +
+		"  tls:\n" +
+		"    cert: \"\"\n" +
+		"    key: \"\"\n" +
+		"    ca: \"\"\n" +
+		"  shared_secret:\n" +
+		"    header: \"authorization\"\n" +
+		"    token: \"\"\n"
+	path := writeTempConfig(t, cfg)
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if !loaded.ConsensusClient.AllowInsecure {
+		t.Fatalf("expected AllowInsecure to remain true")
+	}
+}
+
+func TestLoadRejectsIncompleteClientTLS(t *testing.T) {
+	cfg := baseConfig(":50063") +
+		"consensus_client:\n" +
+		"  allow_insecure: false\n" +
+		"  tls:\n" +
+		"    cert: \"/tmp/test-cert.pem\"\n" +
+		"    key: \"\"\n" +
+		"    ca: \"\"\n" +
+		"  shared_secret:\n" +
+		"    header: \"authorization\"\n" +
+		"    token: \"token\"\n"
+	path := writeTempConfig(t, cfg)
+	if _, err := Load(path); err == nil {
+		t.Fatalf("expected load to reject missing client key")
+	}
+}

--- a/services/governd/dial.go
+++ b/services/governd/dial.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"nhbchain/network"
+	"nhbchain/services/governd/config"
+)
+
+func consensusDialOptions(cfg config.ClientConfig) ([]grpc.DialOption, error) {
+	creds, hasTLS, err := loadConsensusCredentials(cfg.TLS)
+	if err != nil {
+		return nil, err
+	}
+	hasSharedSecret := strings.TrimSpace(cfg.SharedSecret.Token) != ""
+	if !cfg.AllowInsecure && !hasTLS && !hasSharedSecret {
+		return nil, fmt.Errorf("consensus client security requires tls material or shared-secret authentication; set allow_insecure=true for development")
+	}
+
+	var opts []grpc.DialOption
+	if hasTLS {
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	if hasSharedSecret {
+		header := cfg.SharedSecret.Header
+		token := cfg.SharedSecret.Token
+		if hasTLS {
+			opts = append(opts, grpc.WithPerRPCCredentials(network.NewStaticTokenCredentials(header, token)))
+		} else {
+			opts = append(opts, grpc.WithPerRPCCredentials(network.NewStaticTokenCredentialsAllowInsecure(header, token)))
+		}
+	}
+	return opts, nil
+}
+
+func loadConsensusCredentials(cfg config.ClientTLSConfig) (credentials.TransportCredentials, bool, error) {
+	certPath := strings.TrimSpace(cfg.CertPath)
+	keyPath := strings.TrimSpace(cfg.KeyPath)
+	caPath := strings.TrimSpace(cfg.CAPath)
+
+	hasCert := certPath != ""
+	hasKey := keyPath != ""
+	if hasCert != hasKey {
+		return nil, false, fmt.Errorf("consensus client tls requires both cert and key when enabling mTLS")
+	}
+
+	if !hasCert && !hasKey && caPath == "" {
+		return nil, false, nil
+	}
+
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if hasCert {
+		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+		if err != nil {
+			return nil, false, fmt.Errorf("load consensus client certificate: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	if caPath != "" {
+		pem, err := os.ReadFile(caPath)
+		if err != nil {
+			return nil, false, fmt.Errorf("read consensus client ca: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, false, fmt.Errorf("parse consensus client ca: invalid pem data")
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	return credentials.NewTLS(tlsCfg), true, nil
+}

--- a/services/governd/dial_test.go
+++ b/services/governd/dial_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"nhbchain/services/governd/config"
+)
+
+func TestConsensusDialOptionsRequireSecurity(t *testing.T) {
+	if _, err := consensusDialOptions(config.ClientConfig{}); err == nil {
+		t.Fatalf("expected consensus dial configuration to fail without security settings")
+	}
+}
+
+func TestConsensusDialOptionsAllowInsecureOverride(t *testing.T) {
+	opts, err := consensusDialOptions(config.ClientConfig{AllowInsecure: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(opts) == 0 {
+		t.Fatalf("expected insecure dial option to be returned")
+	}
+}
+
+func TestConsensusDialOptionsWithTLS(t *testing.T) {
+	caPath := filepath.Join("config", "server.crt")
+	opts, err := consensusDialOptions(config.ClientConfig{
+		TLS: config.ClientTLSConfig{CAPath: caPath},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(opts) == 0 {
+		t.Fatalf("expected tls dial option to be returned")
+	}
+}
+
+func TestConsensusDialOptionsWithSharedSecret(t *testing.T) {
+	opts, err := consensusDialOptions(config.ClientConfig{
+		SharedSecret: config.SharedSecretConfig{Header: "x-test", Token: "value"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(opts) == 0 {
+		t.Fatalf("expected dial options to include shared-secret credentials")
+	}
+}

--- a/services/governd/main.go
+++ b/services/governd/main.go
@@ -75,8 +75,12 @@ func main() {
 		log.Fatalf("load signer key: %v", err)
 	}
 
+	dialOpts, err := consensusDialOptions(cfg.ConsensusClient)
+	if err != nil {
+		log.Fatalf("configure consensus client: %v", err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	client, err := cons.Dial(ctx, cfg.ConsensusEndpoint)
+	client, err := cons.Dial(ctx, cfg.ConsensusEndpoint, dialOpts...)
 	cancel()
 	if err != nil {
 		log.Fatalf("dial consensus: %v", err)


### PR DESCRIPTION
## Summary
- add consensus client security configuration to governd config supporting TLS assets and shared-secret headers
- wire governd to build the appropriate gRPC dial options before connecting to consensus
- document the new configuration and add regression tests for validation and dial behaviour

## Testing
- go test ./services/governd/...


------
https://chatgpt.com/codex/tasks/task_e_68e2e9a55c24832db9107e6339667c64