### PR TITLE
Persist governd nonce across restarts

### DIFF
--- a/deploy/compose/config/governd.yaml
+++ b/deploy/compose/config/governd.yaml
@@ -3,6 +3,7 @@ consensus: "consensusd:9090"
 chain_id: "nhb-local"
 signer_key: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 nonce_start: 1
+nonce_store_path: "/var/lib/nhb/governd/nonce"
 fee:
   amount: "0"
   denom: ""

--- a/deploy/helm/governd/values.yaml
+++ b/deploy/helm/governd/values.yaml
@@ -22,6 +22,7 @@ config:
   chainID: nhb-staging
   consensusEndpoint: consensusd:9090
   nonceStart: 1
+  nonceStorePath: /var/lib/nhb/governd/nonce
   fee:
     amount: "0"
     denom: ""
@@ -32,6 +33,7 @@ config:
     chain_id: "{{ .Values.config.chainID }}"
     signer_key: "{{ .Values.secrets.signerKey }}"
     nonce_start: {{ .Values.config.nonceStart }}
+    nonce_store_path: "{{ .Values.config.nonceStorePath }}"
     fee:
       amount: "{{ .Values.config.fee.amount }}"
       denom: "{{ .Values.config.fee.denom }}"

--- a/deploy/helm/values/dev/governd.yaml
+++ b/deploy/helm/values/dev/governd.yaml
@@ -9,12 +9,14 @@ config:
   chainID: nhb-dev
   consensusEndpoint: consensusd:9090
   nonceStart: 1
+  nonceStorePath: /var/lib/nhb/governd/nonce
   content: |
     listen: ":50061"
     consensus: "{{ .Values.config.consensusEndpoint }}"
     chain_id: "{{ .Values.config.chainID }}"
     signer_key: "{{ .Values.secrets.signerKey }}"
     nonce_start: {{ .Values.config.nonceStart }}
+    nonce_store_path: "{{ .Values.config.nonceStorePath }}"
     fee:
       amount: "0"
       denom: ""

--- a/deploy/helm/values/prod/governd.yaml
+++ b/deploy/helm/values/prod/governd.yaml
@@ -9,6 +9,7 @@ config:
   chainID: nhb-mainnet
   consensusEndpoint: consensusd:9090
   nonceStart: 1000
+  nonceStorePath: /var/lib/nhb/governd/nonce
   fee:
     amount: "5000"
     denom: ZNHB
@@ -19,6 +20,7 @@ config:
     chain_id: "{{ .Values.config.chainID }}"
     signer_key: "{{ .Values.secrets.signerKey }}"
     nonce_start: {{ .Values.config.nonceStart }}
+    nonce_store_path: "{{ .Values.config.nonceStorePath }}"
     fee:
       amount: "{{ .Values.config.fee.amount }}"
       denom: "{{ .Values.config.fee.denom }}"

--- a/deploy/helm/values/staging/governd.yaml
+++ b/deploy/helm/values/staging/governd.yaml
@@ -9,6 +9,7 @@ config:
   chainID: nhb-staging
   consensusEndpoint: consensusd:9090
   nonceStart: 100
+  nonceStorePath: /var/lib/nhb/governd/nonce
   fee:
     amount: "1000"
     denom: ZNHB
@@ -19,6 +20,7 @@ config:
     chain_id: "{{ .Values.config.chainID }}"
     signer_key: "{{ .Values.secrets.signerKey }}"
     nonce_start: {{ .Values.config.nonceStart }}
+    nonce_store_path: "{{ .Values.config.nonceStorePath }}"
     fee:
       amount: "{{ .Values.config.fee.amount }}"
       denom: "{{ .Values.config.fee.denom }}"

--- a/services/governd/config.yaml
+++ b/services/governd/config.yaml
@@ -3,6 +3,7 @@ consensus: "localhost:9090"
 chain_id: "localnet"
 signer_key: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 nonce_start: 1
+nonce_store_path: "services/governd/data/nonce"
 fee:
   amount: ""
   denom: ""

--- a/services/governd/config/config.go
+++ b/services/governd/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	ChainID           string       `yaml:"chain_id"`
 	SignerKey         string       `yaml:"signer_key"`
 	NonceStart        uint64       `yaml:"nonce_start"`
+	NonceStorePath    string       `yaml:"nonce_store_path"`
 	Fee               FeeConfig    `yaml:"fee"`
 	TLS               TLSConfig    `yaml:"tls"`
 	Auth              AuthConfig   `yaml:"auth"`
@@ -74,6 +75,7 @@ func Load(path string) (Config, error) {
 		ConsensusEndpoint: "localhost:9090",
 		ChainID:           "localnet",
 		NonceStart:        1,
+		NonceStorePath:    "/var/lib/nhb/governd-nonce",
 	}
 	if path == "" {
 		return cfg, fmt.Errorf("config path required")
@@ -98,6 +100,10 @@ func Load(path string) (Config, error) {
 	}
 	if cfg.NonceStart == 0 {
 		cfg.NonceStart = 1
+	}
+	cfg.NonceStorePath = strings.TrimSpace(cfg.NonceStorePath)
+	if cfg.NonceStorePath == "" {
+		return cfg, fmt.Errorf("nonce_store_path is required")
 	}
 	if cfg.SignerKey == "" {
 		return cfg, fmt.Errorf("signer_key is required")

--- a/services/governd/config/config_test.go
+++ b/services/governd/config/config_test.go
@@ -26,14 +26,15 @@ func writeTempConfig(t *testing.T, contents string) string {
 }
 
 func baseConfig(prefix string) string {
-	return "listen: \"" + prefix + "\"\n" +
-		"consensus: \"localhost:9090\"\n" +
-		"chain_id: \"localnet\"\n" +
-		"signer_key: \"" + sampleSignerKey + "\"\n" +
-		"nonce_start: 1\n" +
-		"fee:\n" +
-		"  amount: \"\"\n" +
-		"  denom: \"\"\n" +
+        return "listen: \"" + prefix + "\"\n" +
+                "consensus: \"localhost:9090\"\n" +
+                "chain_id: \"localnet\"\n" +
+                "signer_key: \"" + sampleSignerKey + "\"\n" +
+                "nonce_start: 1\n" +
+                "nonce_store_path: \"" + filepath.ToSlash(filepath.Join("var", "lib", "nhb", "governd-nonce")) + "\"\n" +
+                "fee:\n" +
+                "  amount: \"\"\n" +
+                "  denom: \"\"\n" +
 		"  payer: \"\"\n" +
 		"tls:\n" +
 		"  cert: \"" + filepath.ToSlash(filepath.Join("services", "governd", "config", "server.crt")) + "\"\n" +

--- a/services/governd/server/nonce_store.go
+++ b/services/governd/server/nonce_store.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// NonceStore persists the next nonce value across service restarts.
+type NonceStore interface {
+	Load() (uint64, error)
+	Save(uint64) error
+}
+
+// FileNonceStore stores the next nonce value in a filesystem path.
+type FileNonceStore struct {
+	path string
+}
+
+// NewFileNonceStore constructs a filesystem-backed nonce store rooted at the provided path.
+func NewFileNonceStore(path string) (*FileNonceStore, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return nil, fmt.Errorf("nonce store path required")
+	}
+	dir := filepath.Dir(trimmed)
+	if dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("create nonce store directory: %w", err)
+		}
+	}
+	return &FileNonceStore{path: trimmed}, nil
+}
+
+// Load retrieves the persisted nonce value. A zero return indicates no prior state exists.
+func (s *FileNonceStore) Load() (uint64, error) {
+	if s == nil {
+		return 0, fmt.Errorf("nonce store not initialised")
+	}
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read nonce store: %w", err)
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return 0, nil
+	}
+	value, err := strconv.ParseUint(trimmed, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse nonce value: %w", err)
+	}
+	return value, nil
+}
+
+// Save writes the provided nonce value to disk atomically.
+func (s *FileNonceStore) Save(value uint64) error {
+	if s == nil {
+		return fmt.Errorf("nonce store not initialised")
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), "nonce-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp nonce file: %w", err)
+	}
+	cleanup := func() {
+		_ = os.Remove(tmp.Name())
+	}
+	if _, err := tmp.WriteString(strconv.FormatUint(value, 10)); err != nil {
+		cleanup()
+		tmp.Close()
+		return fmt.Errorf("write nonce value: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		cleanup()
+		tmp.Close()
+		return fmt.Errorf("chmod nonce file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close nonce file: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), s.path); err != nil {
+		cleanup()
+		return fmt.Errorf("replace nonce file: %w", err)
+	}
+	return nil
+}
+
+// RestoreNonce determines the initial nonce to use based on the persisted state and configured baseline.
+func RestoreNonce(store NonceStore, baseline uint64) (uint64, error) {
+	if baseline == 0 {
+		baseline = 1
+	}
+	if store == nil {
+		return baseline, nil
+	}
+	persisted, err := store.Load()
+	if err != nil {
+		return 0, err
+	}
+	if persisted == 0 {
+		return baseline, nil
+	}
+	if persisted < baseline {
+		return baseline, nil
+	}
+	if persisted > baseline {
+		// Avoid decreasing the nonce below the persisted value.
+		return persisted, nil
+	}
+	return baseline, nil
+}

--- a/services/governd/server/server_restart_test.go
+++ b/services/governd/server/server_restart_test.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"nhbchain/crypto"
+	consensusv1 "nhbchain/proto/consensus/v1"
+	govv1 "nhbchain/proto/gov/v1"
+	"nhbchain/services/governd/config"
+)
+
+type fakeConsensusClient struct {
+	submitted []*consensusv1.SignedTxEnvelope
+	lastNonce uint64
+}
+
+func (f *fakeConsensusClient) QueryState(ctx context.Context, namespace, key string) ([]byte, []byte, error) {
+	return nil, nil, nil
+}
+
+func (f *fakeConsensusClient) SubmitEnvelope(ctx context.Context, tx *consensusv1.SignedTxEnvelope) error {
+	if tx == nil {
+		return nil
+	}
+	f.submitted = append(f.submitted, tx)
+	if env := tx.GetEnvelope(); env != nil {
+		f.lastNonce = env.GetNonce()
+	}
+	return nil
+}
+
+func TestServicePersistsNonceAcrossRestarts(t *testing.T) {
+	t.Parallel()
+
+	signer, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	voter := signer.PubKey().Address().String()
+
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "nonce.store")
+	store, err := NewFileNonceStore(storePath)
+	if err != nil {
+		t.Fatalf("create nonce store: %v", err)
+	}
+
+	const baseline uint64 = 7
+	restored, err := RestoreNonce(store, baseline)
+	if err != nil {
+		t.Fatalf("restore nonce: %v", err)
+	}
+	if restored != baseline {
+		t.Fatalf("unexpected initial nonce: want %d, got %d", baseline, restored)
+	}
+
+	cfg := config.Config{
+		ChainID:        "localnet",
+		NonceStart:     restored,
+		NonceStorePath: storePath,
+	}
+
+	ctx := markAuthenticated(context.Background())
+	msg := &govv1.MsgVote{Voter: voter, ProposalId: 1, Option: "yes"}
+
+	// First service run uses the baseline nonce and persists the incremented value.
+	consensus1 := &fakeConsensusClient{}
+	svc1, err := New(consensus1, signer, cfg, store)
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	if _, err := svc1.Vote(ctx, msg); err != nil {
+		t.Fatalf("first vote: %v", err)
+	}
+	if consensus1.lastNonce != baseline {
+		t.Fatalf("unexpected first nonce: want %d, got %d", baseline, consensus1.lastNonce)
+	}
+	persisted, err := store.Load()
+	if err != nil {
+		t.Fatalf("load persisted nonce: %v", err)
+	}
+	if persisted != baseline+1 {
+		t.Fatalf("unexpected persisted nonce: want %d, got %d", baseline+1, persisted)
+	}
+
+	// Simulate restart: reload the store and ensure the persisted nonce is used.
+	store2, err := NewFileNonceStore(storePath)
+	if err != nil {
+		t.Fatalf("reopen nonce store: %v", err)
+	}
+	restored2, err := RestoreNonce(store2, baseline)
+	if err != nil {
+		t.Fatalf("restore nonce after restart: %v", err)
+	}
+	if restored2 != baseline+1 {
+		t.Fatalf("unexpected restored nonce: want %d, got %d", baseline+1, restored2)
+	}
+	cfg.NonceStart = restored2
+
+	consensus2 := &fakeConsensusClient{}
+	svc2, err := New(consensus2, signer, cfg, store2)
+	if err != nil {
+		t.Fatalf("restart service: %v", err)
+	}
+	if _, err := svc2.Vote(ctx, msg); err != nil {
+		t.Fatalf("second vote: %v", err)
+	}
+	if consensus2.lastNonce != baseline+1 {
+		t.Fatalf("unexpected nonce after restart: want %d, got %d", baseline+1, consensus2.lastNonce)
+	}
+	persisted2, err := store2.Load()
+	if err != nil {
+		t.Fatalf("load persisted nonce after restart: %v", err)
+	}
+	if persisted2 != baseline+2 {
+		t.Fatalf("unexpected persisted nonce after restart: want %d, got %d", baseline+2, persisted2)
+	}
+}


### PR DESCRIPTION
## Summary
- add a filesystem-backed nonce store for governd and load persisted values during startup
- persist the next nonce after successful broadcasts while preventing regressions
- add a restart test and update configuration/docs to cover the new nonce_store_path setting


------
https://chatgpt.com/codex/tasks/task_e_68e2f4509278832d8c595031286054b4