### PR TITLE
Add Linux bugcheck workflow job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,47 @@ jobs:
       - name: Test
         run: go test ./...
 
+  bugcheck-linux:
+    runs-on: ubuntu-latest
+    needs: build-test
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.0'
+          check-latest: true
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+      - name: Verify Docker availability
+        run: |
+          docker version
+          docker compose version
+      - name: Install npm dependencies
+        run: npm ci
+      - name: Run bugcheck pipeline
+        env:
+          GOFLAGS: -buildvcs=false
+        run: bash scripts/bugcheck.sh
+      - name: Upload bugcheck artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bugcheck-artifacts
+          path: |
+            logs/
+            artifacts/bugcheck-*
+          if-no-files-found: ignore
+
   audit-endpoints:
     runs-on: ubuntu-latest
     needs: build-test


### PR DESCRIPTION
## Summary
- add a dedicated ubuntu bugcheck job that runs the full scripts/bugcheck.sh pipeline on CI
- provision the required Go, Node, protobuf, and docker tooling for the bugcheck harness
- capture and upload bugcheck logs and artifacts for post-run inspection

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2fbbcf854832dbd233ecff13f776c