### PR TITLE
Add Buf lint and breaking checks to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,57 @@ permissions:
   packages: write
 
 jobs:
+  proto-compatibility:
+    name: Validate protobuf compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.0'
+          check-latest: true
+          cache: true
+
+      - name: Install Buf
+        run: go install github.com/bufbuild/buf/cmd/buf@latest
+
+      - name: Fetch main branch
+        run: git fetch origin main:refs/remotes/origin/main
+
+      - name: Run buf lint
+        id: buf_lint
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          buf lint | tee artifacts/buf-lint.log
+
+      - name: Run buf breaking
+        id: buf_breaking
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          buf breaking --against '.git#branch=main' | tee artifacts/buf-breaking.log
+
+      - name: Evaluate buf results
+        if: steps.buf_lint.outcome == 'failure' || steps.buf_breaking.outcome == 'failure'
+        run: exit 1
+
+      - name: Upload buf artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: buf-validation-logs
+          path: artifacts
+
   build-images:
     name: Build and publish images
+    needs: proto-compatibility
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- add a proto compatibility job that installs buf using the existing Go toolchain and runs lint and breaking checks before releases
- require the new job before building images and upload buf logs as workflow artifacts for troubleshooting

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2fc8aac60832da09bac5a7ed32a7b