### PR TITLE
Refine network SDK dial defaults

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,17 @@
+# NHB Chain Go SDK
+
+The Go SDK provides typed clients for interacting with NHB Chain services such as
+consensus and network daemons. By default, all SDK gRPC clients attempt to
+establish TLS connections using the host operating system's certificate pool to
+mirror production security settings.
+
+## Network client defaults
+
+The `sdk/network` client now mirrors the consensus client behaviour by choosing
+TLS transport credentials when no explicit dial options are supplied. Local
+development that relies on plaintext gRPC endpoints must opt in by passing
+`network.WithInsecure()` (or the shared `dial.WithInsecure()` helper) when
+calling `network.Dial`.
+
+Explicitly specifying TLS material via `WithTLSConfig`, `WithTLSFromFiles`, or
+`WithSystemCertPool` continues to be supported.

--- a/sdk/network/client.go
+++ b/sdk/network/client.go
@@ -5,9 +5,31 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
 	networkv1 "nhbchain/proto/network/v1"
+	"nhbchain/sdk/internal/dial"
+)
+
+// DialOption configures the underlying gRPC dial behaviour.
+type DialOption = dial.DialOption
+
+var (
+	// WithTransportCredentials configures the client to use the provided gRPC transport credentials.
+	WithTransportCredentials = dial.WithTransportCredentials
+	// WithTLSConfig configures the client to use the provided TLS configuration.
+	WithTLSConfig = dial.WithTLSConfig
+	// WithTLSFromFiles loads TLS credentials from certificate files.
+	WithTLSFromFiles = dial.WithTLSFromFiles
+	// WithSystemCertPool trusts the system certificate pool for TLS connections.
+	WithSystemCertPool = dial.WithSystemCertPool
+	// WithInsecure enables plaintext gRPC connections and should only be used for development.
+	WithInsecure = dial.WithInsecure
+	// WithContextDialer attaches a custom context-based dialer.
+	WithContextDialer = dial.WithContextDialer
+	// WithPerRPCCredentials attaches per-RPC credential authenticators.
+	WithPerRPCCredentials = dial.WithPerRPCCredentials
+	// WithDialOptions forwards arbitrary gRPC dial options to the connector.
+	WithDialOptions = dial.WithDialOptions
 )
 
 // Client is a thin wrapper around the generated Network gRPC client.
@@ -16,16 +38,19 @@ type Client struct {
 	raw  networkv1.NetworkServiceClient
 }
 
-// Dial initialises a client connection to the network daemon.
-func Dial(ctx context.Context, target string, opts ...grpc.DialOption) (*Client, error) {
-	if len(opts) == 0 {
-		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+// Dial initialises a client connection to the network daemon. When no dial
+// options are provided the connector defaults to TLS credentials using the host
+// certificate pool.
+func Dial(ctx context.Context, target string, opts ...DialOption) (*Client, error) {
+	dialOpts, err := dial.Resolve(opts...)
+	if err != nil {
+		return nil, err
 	}
-	opts = append(opts,
+	dialOpts = append(dialOpts,
 		grpc.WithChainUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
 		grpc.WithChainStreamInterceptor(otelgrpc.StreamClientInterceptor()),
 	)
-	conn, err := grpc.DialContext(ctx, target, opts...)
+	conn, err := grpc.DialContext(ctx, target, dialOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/network/client_test.go
+++ b/sdk/network/client_test.go
@@ -1,0 +1,129 @@
+package network
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+
+	networkv1 "nhbchain/proto/network/v1"
+)
+
+type noopNetworkServer struct {
+	networkv1.UnimplementedNetworkServiceServer
+}
+
+func (noopNetworkServer) ListPeers(context.Context, *networkv1.ListPeersRequest) (*networkv1.ListPeersResponse, error) {
+	return &networkv1.ListPeersResponse{}, nil
+}
+
+func (noopNetworkServer) GetView(context.Context, *networkv1.GetViewRequest) (*networkv1.GetViewResponse, error) {
+	return &networkv1.GetViewResponse{View: &networkv1.NetworkView{}}, nil
+}
+
+func startInsecureServer(t *testing.T) (string, func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	server := grpc.NewServer()
+	networkv1.RegisterNetworkServiceServer(server, &noopNetworkServer{})
+
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	cleanup := func() {
+		server.Stop()
+		_ = lis.Close()
+	}
+
+	return lis.Addr().String(), cleanup
+}
+
+func startProbeListener(t *testing.T) (string, <-chan []byte, func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	data := make(chan []byte, 1)
+
+	go func() {
+		defer close(data)
+
+		conn, err := lis.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+		buf := make([]byte, 3)
+		if n, err := conn.Read(buf); err == nil && n > 0 {
+			data <- append([]byte{}, buf[:n]...)
+		}
+	}()
+
+	cleanup := func() {
+		_ = lis.Close()
+	}
+
+	return lis.Addr().String(), data, cleanup
+}
+
+func TestDialDefaultsToTLS(t *testing.T) {
+	addr, handshake, cleanup := startProbeListener(t)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	client, err := Dial(ctx, addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	select {
+	case data := <-handshake:
+		if len(data) == 0 || data[0] != 0x16 {
+			t.Fatalf("expected TLS client hello, got %x", data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for TLS handshake data")
+	}
+}
+
+func TestDialWithInsecureOptIn(t *testing.T) {
+	addr, cleanup := startInsecureServer(t)
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	client, err := Dial(ctx, addr, WithInsecure())
+	if err != nil {
+		t.Fatalf("dial with insecure opt-in: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	if _, err := client.ListPeers(ctx); err != nil {
+		t.Fatalf("list peers: %v", err)
+	}
+
+	if _, err := client.GetView(ctx); err != nil {
+		t.Fatalf("get view: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- update the SDK network client to resolve dial options via the shared TLS-first helper and expose convenience wrappers for callers
- add unit tests that capture the TLS client hello by default and require an explicit insecure opt-in for plaintext servers
- document the TLS default for SDK clients in a new README

## Testing
- go test ./network


------
https://chatgpt.com/codex/tasks/task_e_68e30141d3cc832d948b51ac3ad257fc