### PR TITLE
Add TLS/auth configuration for lendingd

### DIFF
--- a/services/lending/server/auth.go
+++ b/services/lending/server/auth.go
@@ -1,0 +1,216 @@
+package server
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	lendingv1 "nhbchain/proto/lending/v1"
+	"nhbchain/services/lendingd/config"
+)
+
+type authContextKey struct{}
+
+// NewAuthInterceptors constructs unary and stream interceptors that enforce
+// authentication on Msg RPCs. Requests must present either a configured API
+// token or an mTLS client certificate with an allowed common name.
+func NewAuthInterceptors(cfg config.AuthConfig) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+	authenticator := newAuthenticator(cfg)
+	return authenticator.unaryInterceptor(), authenticator.streamInterceptor()
+}
+
+func markAuthenticated(ctx context.Context) context.Context {
+	return context.WithValue(ctx, authContextKey{}, true)
+}
+
+func isAuthenticated(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	value, ok := ctx.Value(authContextKey{}).(bool)
+	return ok && value
+}
+
+type authenticator struct {
+	tokens       map[string]struct{}
+	commonNames  map[string]struct{}
+	allowByToken bool
+	allowByMTLS  bool
+}
+
+func newAuthenticator(cfg config.AuthConfig) *authenticator {
+	tokens := make(map[string]struct{})
+	for _, token := range cfg.APITokens {
+		trimmed := strings.TrimSpace(token)
+		if trimmed == "" {
+			continue
+		}
+		tokens[trimmed] = struct{}{}
+	}
+	commonNames := make(map[string]struct{})
+	for _, name := range cfg.MTLS.AllowedCommonNames {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+		commonNames[trimmed] = struct{}{}
+	}
+	return &authenticator{
+		tokens:       tokens,
+		commonNames:  commonNames,
+		allowByToken: len(tokens) > 0,
+		allowByMTLS:  len(commonNames) > 0,
+	}
+}
+
+func (a *authenticator) unaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if !isMsgMethod(info.FullMethod) {
+			return handler(ctx, req)
+		}
+		ctx, err := a.authenticate(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+func (a *authenticator) streamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if !isMsgMethod(info.FullMethod) {
+			return handler(srv, ss)
+		}
+		ctx, err := a.authenticate(ss.Context())
+		if err != nil {
+			return err
+		}
+		wrapped := &authStream{ServerStream: ss, ctx: ctx}
+		return handler(srv, wrapped)
+	}
+}
+
+func (a *authenticator) authenticate(ctx context.Context) (context.Context, error) {
+	if a == nil {
+		return ctx, status.Error(codes.Internal, "authenticator unavailable")
+	}
+	if !a.allowByToken && !a.allowByMTLS {
+		return ctx, status.Error(codes.PermissionDenied, "authentication is not configured")
+	}
+	if a.allowByToken && a.authenticateByToken(ctx) {
+		return markAuthenticated(ctx), nil
+	}
+	if a.allowByMTLS && a.authenticateByMTLS(ctx) {
+		return markAuthenticated(ctx), nil
+	}
+	return ctx, status.Error(codes.Unauthenticated, "authentication required")
+}
+
+func (a *authenticator) authenticateByToken(ctx context.Context) bool {
+	if ctx == nil || len(a.tokens) == 0 {
+		return false
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return false
+	}
+	for _, header := range md.Get("authorization") {
+		if token := parseBearerToken(header); token != "" {
+			if _, exists := a.tokens[token]; exists {
+				return true
+			}
+		}
+	}
+	for _, token := range md.Get("x-api-token") {
+		trimmed := strings.TrimSpace(token)
+		if trimmed == "" {
+			continue
+		}
+		if _, exists := a.tokens[trimmed]; exists {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *authenticator) authenticateByMTLS(ctx context.Context) bool {
+	if ctx == nil || len(a.commonNames) == 0 {
+		return false
+	}
+	pr, ok := peer.FromContext(ctx)
+	if !ok {
+		return false
+	}
+	info, ok := pr.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return false
+	}
+	state := info.State
+	for _, chain := range state.VerifiedChains {
+		if len(chain) == 0 {
+			continue
+		}
+		if a.commonNameAllowed(chain[0].Subject.CommonName) {
+			return true
+		}
+	}
+	for _, cert := range state.PeerCertificates {
+		if a.commonNameAllowed(cert.Subject.CommonName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *authenticator) commonNameAllowed(name string) bool {
+	_, ok := a.commonNames[strings.TrimSpace(name)]
+	return ok
+}
+
+func parseBearerToken(header string) string {
+	trimmed := strings.TrimSpace(header)
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.SplitN(trimmed, " ", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	if !strings.EqualFold(strings.TrimSpace(parts[0]), "bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+func isMsgMethod(fullMethod string) bool {
+	switch fullMethod {
+	case lendingv1.LendingService_SupplyAsset_FullMethodName,
+		lendingv1.LendingService_WithdrawAsset_FullMethodName,
+		lendingv1.LendingService_BorrowAsset_FullMethodName,
+		lendingv1.LendingService_RepayAsset_FullMethodName:
+		return true
+	default:
+		return false
+	}
+}
+
+type authStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *authStream) Context() context.Context {
+	if s == nil {
+		return nil
+	}
+	if s.ctx != nil {
+		return s.ctx
+	}
+	return s.ServerStream.Context()
+}

--- a/services/lending/server/auth_test.go
+++ b/services/lending/server/auth_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	lendingv1 "nhbchain/proto/lending/v1"
+	"nhbchain/services/lendingd/config"
+)
+
+func TestMsgRPCAuthentication(t *testing.T) {
+	cfg := config.AuthConfig{APITokens: []string{"secret-token"}}
+	unaryAuth, streamAuth := NewAuthInterceptors(cfg)
+
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(unaryAuth),
+		grpc.ChainStreamInterceptor(streamAuth),
+	)
+	lendingv1.RegisterLendingServiceServer(grpcServer, New())
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer lis.Close()
+
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+	defer grpcServer.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	client := lendingv1.NewLendingServiceClient(conn)
+
+	// Unauthenticated Msg RPCs should be rejected.
+	_, err = client.SupplyAsset(ctx, &lendingv1.SupplyAssetRequest{})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected unauthenticated error, got %v", err)
+	}
+
+	// Query-style RPCs remain accessible.
+	_, err = client.GetMarket(ctx, &lendingv1.GetMarketRequest{})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("expected query RPC to reach handler, got %v", err)
+	}
+
+	// Authenticated requests should pass through to the handler.
+	authCtx := metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer secret-token")
+	_, err = client.SupplyAsset(authCtx, &lendingv1.SupplyAssetRequest{})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("expected authenticated Msg RPC to reach handler, got %v", err)
+	}
+}

--- a/services/lendingd/config/config.go
+++ b/services/lendingd/config/config.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config captures the runtime settings for the lending service daemon.
+type Config struct {
+	ListenAddress string     `yaml:"listen"`
+	TLS           TLSConfig  `yaml:"tls"`
+	Auth          AuthConfig `yaml:"auth"`
+}
+
+// TLSConfig describes the TLS material for the gRPC server.
+type TLSConfig struct {
+	CertPath      string `yaml:"cert"`
+	KeyPath       string `yaml:"key"`
+	ClientCAPath  string `yaml:"client_ca"`
+	AllowInsecure bool   `yaml:"allow_insecure"`
+}
+
+// AuthConfig lists the authenticators accepted by the service.
+type AuthConfig struct {
+	APITokens []string       `yaml:"api_tokens"`
+	MTLS      MTLSAuthConfig `yaml:"mtls"`
+}
+
+// MTLSAuthConfig enumerates the allowed client certificate identities.
+type MTLSAuthConfig struct {
+	AllowedCommonNames []string `yaml:"allowed_common_names"`
+}
+
+// Load reads the YAML configuration from disk and validates the result.
+func Load(path string) (Config, error) {
+	cfg := Config{
+		ListenAddress: ":50053",
+	}
+	if path == "" {
+		return cfg, fmt.Errorf("config path required")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return cfg, fmt.Errorf("open config: %w", err)
+	}
+	defer file.Close()
+
+	decoder := yaml.NewDecoder(file)
+	if err := decoder.Decode(&cfg); err != nil {
+		return Config{}, fmt.Errorf("decode config: %w", err)
+	}
+
+	cfg.normalize()
+	if err := cfg.validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func (cfg *Config) normalize() {
+	if cfg == nil {
+		return
+	}
+	cfg.ListenAddress = strings.TrimSpace(cfg.ListenAddress)
+	if cfg.ListenAddress == "" {
+		cfg.ListenAddress = ":50053"
+	}
+	cfg.TLS.normalize()
+	cfg.Auth.normalize()
+}
+
+func (cfg *Config) validate() error {
+	if cfg == nil {
+		return fmt.Errorf("configuration is missing")
+	}
+	if err := cfg.TLS.validate(); err != nil {
+		return fmt.Errorf("tls: %w", err)
+	}
+	if err := cfg.Auth.validate(cfg.TLS); err != nil {
+		return fmt.Errorf("auth: %w", err)
+	}
+	return nil
+}
+
+func (cfg *TLSConfig) normalize() {
+	if cfg == nil {
+		return
+	}
+	cfg.CertPath = strings.TrimSpace(cfg.CertPath)
+	cfg.KeyPath = strings.TrimSpace(cfg.KeyPath)
+	cfg.ClientCAPath = strings.TrimSpace(cfg.ClientCAPath)
+}
+
+func (cfg TLSConfig) validate() error {
+	hasCert := cfg.CertPath != ""
+	hasKey := cfg.KeyPath != ""
+	if hasCert != hasKey {
+		return fmt.Errorf("cert and key must either both be provided or both be empty")
+	}
+	if !cfg.AllowInsecure && !hasCert {
+		return fmt.Errorf("cert and key are required unless allow_insecure=true")
+	}
+	if cfg.ClientCAPath != "" && !hasCert {
+		return fmt.Errorf("client_ca requires a server certificate and key")
+	}
+	return nil
+}
+
+// MTLSEnabled reports whether mutual TLS verification is configured.
+func (cfg TLSConfig) MTLSEnabled() bool {
+	return strings.TrimSpace(cfg.ClientCAPath) != ""
+}
+
+func (cfg *AuthConfig) normalize() {
+	if cfg == nil {
+		return
+	}
+	tokens := make([]string, 0, len(cfg.APITokens))
+	for _, token := range cfg.APITokens {
+		if trimmed := strings.TrimSpace(token); trimmed != "" {
+			tokens = append(tokens, trimmed)
+		}
+	}
+	cfg.APITokens = tokens
+
+	names := make([]string, 0, len(cfg.MTLS.AllowedCommonNames))
+	for _, name := range cfg.MTLS.AllowedCommonNames {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			names = append(names, trimmed)
+		}
+	}
+	cfg.MTLS.AllowedCommonNames = names
+}
+
+func (cfg AuthConfig) validate(tls TLSConfig) error {
+	hasTokens := len(cfg.APITokens) > 0
+	hasMTLS := len(cfg.MTLS.AllowedCommonNames) > 0
+	if !hasTokens && !hasMTLS {
+		return fmt.Errorf("at least one api token or mTLS common name must be configured")
+	}
+	if hasMTLS && strings.TrimSpace(tls.ClientCAPath) == "" {
+		return fmt.Errorf("mtls.allowed_common_names requires tls.client_ca to be configured")
+	}
+	return nil
+}

--- a/services/lendingd/config/config_test.go
+++ b/services/lendingd/config/config_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeConfig(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestLoadConfigDefaults(t *testing.T) {
+	path := writeConfig(t, `
+listen: " :6000 "
+tls:
+  allow_insecure: true
+auth:
+  api_tokens:
+    - " token-one "
+    - " "
+    - "token-two"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.ListenAddress != ":6000" {
+		t.Fatalf("unexpected listen address: %q", cfg.ListenAddress)
+	}
+	if !cfg.TLS.AllowInsecure {
+		t.Fatalf("expected allow_insecure to propagate")
+	}
+	if len(cfg.Auth.APITokens) != 2 {
+		t.Fatalf("expected 2 trimmed api tokens, got %d", len(cfg.Auth.APITokens))
+	}
+}
+
+func TestLoadConfigRequiresAuthenticators(t *testing.T) {
+	path := writeConfig(t, `
+listen: ":50053"
+tls:
+  cert: "server.crt"
+  key: "server.key"
+auth: {}
+`)
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error when no authenticators are configured")
+	}
+}
+
+func TestLoadConfigValidatesTLS(t *testing.T) {
+	path := writeConfig(t, `
+listen: ":50053"
+tls:
+  cert: "server.crt"
+auth:
+  api_tokens:
+    - token
+`)
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error when tls key is missing")
+	}
+}
+
+func TestLoadConfigValidatesMTLSDependencies(t *testing.T) {
+	path := writeConfig(t, `
+listen: ":50053"
+tls:
+  cert: "server.crt"
+  key: "server.key"
+auth:
+  mtls:
+    allowed_common_names: [client]
+`)
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error when mtls is configured without api tokens or client ca")
+	}
+}
+
+func TestLoadConfigRequiresTLSMaterialUnlessInsecure(t *testing.T) {
+	path := writeConfig(t, `
+listen: ":50053"
+auth:
+  api_tokens: [token]
+`)
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error when tls material missing without allow_insecure")
+	}
+}


### PR DESCRIPTION
## Summary
- load lendingd configuration via a dedicated package with TLS/auth validation
- enforce authentication on lending Msg RPCs via new server interceptors and tests
- wire TLS credentials and auth interceptors into the lendingd gRPC server

## Testing
- go test -v ./services/lending/server
- go test -v ./services/lending
- go test ./services/lendingd/config

------
https://chatgpt.com/codex/tasks/task_e_68e305d1a5d8832d9abf0949e2a218ee