### PR TITLE
Add chaos bugcheck target and include in CI summary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: proto sdk tidy up down audit:static audit:tests audit:determinism audit:e2e audit:chaos audit:perf audit:netsec audit:ledger audit:supply audit:config audit:docs audit:endpoints
-.PHONY: bugcheck bugcheck-tools bugcheck-static bugcheck-race bugcheck-fuzz bugcheck-determinism bugcheck-gateway bugcheck-network bugcheck-perf bugcheck-proto bugcheck-docs
+.PHONY: bugcheck bugcheck-tools bugcheck-static bugcheck-race bugcheck-fuzz bugcheck-determinism bugcheck-chaos bugcheck-gateway bugcheck-network bugcheck-perf bugcheck-proto bugcheck-docs
 
 bugcheck:
 	@bash scripts/bugcheck.sh
@@ -28,6 +28,9 @@ bugcheck-fuzz:
 
 bugcheck-determinism:
 	@$(MAKE) audit:determinism
+
+bugcheck-chaos:
+	@$(MAKE) audit:chaos
 
 bugcheck-gateway:
 	@go test -run TestEndToEndFinancialFlows ./tests/e2e

--- a/scripts/bugcheck.sh
+++ b/scripts/bugcheck.sh
@@ -114,19 +114,22 @@ run_check "fuzz-critical" "60s fuzzing on critical state transition tests" "crit
 # 3. Determinism and BFT safety on 3-node localnet
 run_check "determinism" "Determinism and BFT safety audit" "critical" make bugcheck-determinism || true
 
-# 4. Gateway end-to-end flows
+# 4. Chaos fault-injection resilience
+run_check "chaos" "Chaos fault-injection audit" "critical" make bugcheck-chaos || true
+
+# 5. Gateway end-to-end flows
 run_check "gateway-e2e" "Gateway swap, lending, governance, escrow flows" "critical" make bugcheck-gateway || true
 
-# 5. Network hardening checks
+# 6. Network hardening checks
 run_check "network-hardening" "Rate limits, TLS, mTLS, and auth smoke" "critical" make bugcheck-network || true
 
-# 6. Performance benchmarks and SLA validation
+# 7. Performance benchmarks and SLA validation
 run_check "performance" "Benchmark finality and proposer commit latency" "critical" make bugcheck-perf || true
 
-# 7. Protobuf compatibility
+# 8. Protobuf compatibility
 run_check "protobuf" "buf lint and breaking checks" "critical" make bugcheck-proto || true
 
-# 8. Documentation and examples validation
+# 9. Documentation and examples validation
 run_check "docs" "Docs/examples validation" "critical" make bugcheck-docs || true
 
 # Emit JSON summary


### PR DESCRIPTION
## Summary
- add a bugcheck-chaos phony target that delegates to the chaos audit make phase
- run the chaos audit from scripts/bugcheck.sh so its results are captured in the bugcheck summary
- validated that the existing artifact upload already collects logs/ and artifacts/bugcheck-* outputs, so chaos logs and artifacts remain covered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e315e9b3c4832d8bbd62531e12e823