### PR TITLE
Add identity gating and compliance metadata to OTC minting

### DIFF
--- a/services/otc-gateway/config/config.go
+++ b/services/otc-gateway/config/config.go
@@ -15,6 +15,9 @@ type Config struct {
 	S3Bucket          string
 	ChainID           string
 	SwapRPCBase       string
+	IdentityBaseURL   string
+	IdentityAPIKey    string
+	IdentityTimeout   time.Duration
 	DefaultTZ         *time.Location
 	HSMBaseURL        string
 	HSMCACert         string
@@ -57,6 +60,17 @@ func FromEnv() (*Config, error) {
 	}
 	if rpcBase == "" {
 		return nil, fmt.Errorf("OTC_SWAP_RPC_BASE is required")
+	}
+
+	identityBase := os.Getenv("OTC_IDENTITY_BASE_URL")
+	if identityBase == "" {
+		return nil, fmt.Errorf("OTC_IDENTITY_BASE_URL is required")
+	}
+	identityAPIKey := os.Getenv("OTC_IDENTITY_API_KEY")
+	identityTimeoutSeconds := getEnvDefault("OTC_IDENTITY_TIMEOUT_SECONDS", "10")
+	identityTimeoutValue, err := strconv.Atoi(identityTimeoutSeconds)
+	if err != nil || identityTimeoutValue <= 0 {
+		return nil, fmt.Errorf("invalid OTC_IDENTITY_TIMEOUT_SECONDS %q", identityTimeoutSeconds)
 	}
 
 	hsmBase := os.Getenv("OTC_HSM_BASE_URL")
@@ -111,6 +125,9 @@ func FromEnv() (*Config, error) {
 		S3Bucket:          bucket,
 		ChainID:           chainID,
 		SwapRPCBase:       rpcBase,
+		IdentityBaseURL:   identityBase,
+		IdentityAPIKey:    identityAPIKey,
+		IdentityTimeout:   time.Duration(identityTimeoutValue) * time.Second,
 		DefaultTZ:         tz,
 		HSMBaseURL:        hsmBase,
 		HSMCACert:         hsmCACert,

--- a/services/otc-gateway/identity/client.go
+++ b/services/otc-gateway/identity/client.go
@@ -1,0 +1,81 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Config defines the HTTP client settings for the identity gateway.
+type Config struct {
+	BaseURL string
+	APIKey  string
+	Timeout time.Duration
+}
+
+// Client retrieves compliance attestations and partner metadata required for minting.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// Resolution captures the identity payload returned by the upstream service.
+type Resolution struct {
+	PartnerDID       string          `json:"partnerDid"`
+	Verified         bool            `json:"verified"`
+	SanctionsStatus  string          `json:"sanctionsStatus"`
+	ComplianceTags   []string        `json:"complianceTags"`
+	TravelRulePacket json.RawMessage `json:"travelRulePacket"`
+}
+
+// NewClient constructs a client with sane defaults.
+func NewClient(cfg Config) (*Client, error) {
+	base := strings.TrimSpace(cfg.BaseURL)
+	if base == "" {
+		return nil, fmt.Errorf("identity: base url required")
+	}
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &Client{
+		baseURL: strings.TrimRight(base, "/"),
+		apiKey:  strings.TrimSpace(cfg.APIKey),
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+	}, nil
+}
+
+// ResolvePartner fetches DID and compliance metadata for the supplied partner identifier.
+func (c *Client) ResolvePartner(ctx context.Context, partnerID uuid.UUID) (*Resolution, error) {
+	if c == nil {
+		return nil, fmt.Errorf("identity: client not configured")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/partners/%s/compliance", c.baseURL, partnerID.String()), nil)
+	if err != nil {
+		return nil, fmt.Errorf("identity: request: %w", err)
+	}
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("identity: call: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("identity: unexpected status %d", resp.StatusCode)
+	}
+	var payload Resolution
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("identity: decode: %w", err)
+	}
+	return &payload, nil
+}

--- a/services/otc-gateway/main.go
+++ b/services/otc-gateway/main.go
@@ -17,6 +17,7 @@ import (
 	telemetry "nhbchain/observability/otel"
 	"nhbchain/services/otc-gateway/config"
 	"nhbchain/services/otc-gateway/hsm"
+	"nhbchain/services/otc-gateway/identity"
 	"nhbchain/services/otc-gateway/models"
 	"nhbchain/services/otc-gateway/recon"
 	"nhbchain/services/otc-gateway/server"
@@ -83,6 +84,15 @@ func main() {
 		log.Fatalf("hsm client error: %v", err)
 	}
 
+	identityClient, err := identity.NewClient(identity.Config{
+		BaseURL: cfg.IdentityBaseURL,
+		APIKey:  cfg.IdentityAPIKey,
+		Timeout: cfg.IdentityTimeout,
+	})
+	if err != nil {
+		log.Fatalf("identity client error: %v", err)
+	}
+
 	swapClient := swaprpc.NewClient(swaprpc.Config{URL: cfg.SwapRPCBase, Provider: cfg.SwapProvider})
 
 	srv := server.New(server.Config{
@@ -91,6 +101,7 @@ func main() {
 		ChainID:           chainID,
 		S3Bucket:          cfg.S3Bucket,
 		SwapClient:        swapClient,
+		Identity:          identityClient,
 		Signer:            signer,
 		VoucherTTL:        cfg.VoucherTTL,
 		Provider:          cfg.SwapProvider,

--- a/services/otc-gateway/models/models.go
+++ b/services/otc-gateway/models/models.go
@@ -98,18 +98,22 @@ type PartnerApproval struct {
 
 // Invoice describes OTC orders across their lifecycle.
 type Invoice struct {
-	ID          uuid.UUID    `gorm:"type:uuid;primaryKey"`
-	BranchID    uuid.UUID    `gorm:"type:uuid;index"`
-	CreatedByID uuid.UUID    `gorm:"type:uuid;index"`
-	Amount      float64      `gorm:"not null"`
-	Currency    string       `gorm:"size:16"`
-	State       InvoiceState `gorm:"size:32;index"`
-	Region      string       `gorm:"index"`
-	Reference   string       `gorm:"size:128"`
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	Receipts    []Receipt
-	Decisions   []Decision
+	ID               uuid.UUID    `gorm:"type:uuid;primaryKey"`
+	BranchID         uuid.UUID    `gorm:"type:uuid;index"`
+	CreatedByID      uuid.UUID    `gorm:"type:uuid;index"`
+	Amount           float64      `gorm:"not null"`
+	Currency         string       `gorm:"size:16"`
+	State            InvoiceState `gorm:"size:32;index"`
+	Region           string       `gorm:"index"`
+	Reference        string       `gorm:"size:128"`
+	PartnerDID       string       `gorm:"size:255"`
+	ComplianceTags   []byte       `gorm:"type:jsonb"`
+	TravelRulePacket []byte       `gorm:"type:jsonb"`
+	SanctionsStatus  string       `gorm:"size:64"`
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	Receipts         []Receipt
+	Decisions        []Decision
 }
 
 // Receipt captures receipt uploads stored in S3.
@@ -133,22 +137,26 @@ type Decision struct {
 
 // Voucher represents chain submissions generated from invoices.
 type Voucher struct {
-	ID           uuid.UUID `gorm:"type:uuid;primaryKey"`
-	InvoiceID    uuid.UUID `gorm:"type:uuid;uniqueIndex"`
-	ChainID      string    `gorm:"index"`
-	Payload      string
-	ProviderTxID string `gorm:"size:128;uniqueIndex"`
-	Hash         string `gorm:"size:130"`
-	Signature    string `gorm:"type:text"`
-	SignerDN     string `gorm:"size:255"`
-	TxHash       string `gorm:"size:130"`
-	VoucherHash  string `gorm:"size:130"`
-	Status       string `gorm:"size:32;index"`
-	ExpiresAt    time.Time
-	SubmittedAt  *time.Time
-	SubmittedBy  *uuid.UUID `gorm:"type:uuid"`
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	ID               uuid.UUID `gorm:"type:uuid;primaryKey"`
+	InvoiceID        uuid.UUID `gorm:"type:uuid;uniqueIndex"`
+	ChainID          string    `gorm:"index"`
+	Payload          string
+	ProviderTxID     string `gorm:"size:128;uniqueIndex"`
+	Hash             string `gorm:"size:130"`
+	Signature        string `gorm:"type:text"`
+	SignerDN         string `gorm:"size:255"`
+	TxHash           string `gorm:"size:130"`
+	VoucherHash      string `gorm:"size:130"`
+	Status           string `gorm:"size:32;index"`
+	ExpiresAt        time.Time
+	SubmittedAt      *time.Time
+	SubmittedBy      *uuid.UUID `gorm:"type:uuid"`
+	PartnerDID       string     `gorm:"size:255"`
+	ComplianceTags   []byte     `gorm:"type:jsonb"`
+	TravelRulePacket []byte     `gorm:"type:jsonb"`
+	SanctionsStatus  string     `gorm:"size:64"`
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
 }
 
 // Event is the staff audit trail structure.

--- a/services/otc-gateway/server/partners.go
+++ b/services/otc-gateway/server/partners.go
@@ -364,16 +364,16 @@ func (s *Server) ensureApprovedPartner(w http.ResponseWriter, claims *auth.Claim
 	return partner, false
 }
 
-func (s *Server) ensureInvoicePartnerApproved(tx *gorm.DB, creator uuid.UUID) error {
+func (s *Server) ensureInvoicePartnerApproved(tx *gorm.DB, creator uuid.UUID) (*models.Partner, error) {
 	partner, err := s.partnerForSubject(tx, creator.String())
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil
+			return nil, nil
 		}
-		return err
+		return nil, err
 	}
 	if !partner.Approved {
-		return errPartnerPending
+		return partner, errPartnerPending
 	}
-	return nil
+	return partner, nil
 }

--- a/services/otc-gateway/server/server_test.go
+++ b/services/otc-gateway/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,7 +19,8 @@ import (
 
 func setupTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", uuid.NewString())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("failed to open sqlite: %v", err)
 	}


### PR DESCRIPTION
## Summary
- extend OTC invoice and voucher records with partner DID, compliance tags, and Travel Rule packet fields, and add an identity client for resolving partner metadata
- require verified partner identity before signing, persist the compliance payload on vouchers, and forward it through the new swap RPC submission envelope
- wire identity configuration into the gateway, document the Travel Rule handoff, and add regression tests covering compliance metadata storage and gating

## Testing
- go test ./services/otc-gateway/...


------
https://chatgpt.com/codex/tasks/task_e_68e31ef8d3ec832d86bcf84a0516acc7