### PR TITLE
Secure OTC swap RPC client and gateway

### DIFF
--- a/docs/otc/api.md
+++ b/docs/otc/api.md
@@ -10,6 +10,27 @@ Supported roles are `teller`, `supervisor`, `compliance`, `superadmin`, and `aud
 
 Base path: `/api/v1`
 
+## Swap RPC authentication
+
+The OTC gateway authenticates to the swap RPC using partner-specific API keys. Operations teams provision credentials via the swap governance process and distribute them to OTC operators out-of-band. Each credential pair consists of:
+
+- `OTC_SWAP_API_KEY` – the public identifier reported in the `X-Api-Key` header.
+- `OTC_SWAP_API_SECRET` – the shared secret used to sign requests.
+
+Partners must also configure an explicit method allowlist so the gateway cannot accidentally invoke privileged RPCs:
+
+- `OTC_SWAP_METHOD_ALLOWLIST` – comma/space-separated list of permitted JSON-RPC methods (defaults to `swap_submitVoucher`, `swap_voucher_get`, `swap_voucher_list`, `swap_voucher_export`).
+- `OTC_SWAP_RATE_LIMIT_PER_MINUTE` – optional throttle applied client-side before issuing requests.
+
+Every JSON-RPC request sent to the swap gateway includes the HMAC headers enforced by `gateway/auth`:
+
+- `X-Api-Key`
+- `X-Timestamp`
+- `X-Nonce`
+- `X-Signature`
+
+The timestamp and nonce pair must be unique per request within the replay window. Operators should monitor for 401/429 responses indicating invalid signatures or quota violations and rotate credentials when staff changes occur.
+
 ## `POST /invoices`
 Create a new OTC invoice.
 

--- a/services/otc-gateway/main.go
+++ b/services/otc-gateway/main.go
@@ -93,7 +93,17 @@ func main() {
 		log.Fatalf("identity client error: %v", err)
 	}
 
-	swapClient := swaprpc.NewClient(swaprpc.Config{URL: cfg.SwapRPCBase, Provider: cfg.SwapProvider})
+	swapClient, err := swaprpc.NewClient(swaprpc.Config{
+		URL:               cfg.SwapRPCBase,
+		Provider:          cfg.SwapProvider,
+		APIKey:            cfg.SwapAPIKey,
+		APISecret:         cfg.SwapAPISecret,
+		AllowedMethods:    cfg.SwapMethodAllow,
+		RequestsPerMinute: cfg.SwapRateLimit,
+	})
+	if err != nil {
+		log.Fatalf("swap client error: %v", err)
+	}
 
 	srv := server.New(server.Config{
 		DB:                db,

--- a/services/otc-gateway/swaprpc/client_test.go
+++ b/services/otc-gateway/swaprpc/client_test.go
@@ -1,0 +1,168 @@
+package swaprpc
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	gatewayauth "nhbchain/gateway/auth"
+)
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *rpcError       `json:"error"`
+}
+
+func TestClientSignsRequests(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	nonce := "nonce-1"
+	var capturedBody []byte
+	var capturedHeaders http.Header
+	var capturedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		capturedBody = append([]byte(nil), body...)
+		capturedHeaders = r.Header.Clone()
+		capturedPath = gatewayauth.CanonicalRequestPath(r)
+		resp := rpcResponse{JSONRPC: jsonRPCVersion, ID: 1, Result: json.RawMessage(`{"ok":true}`)}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		URL:               server.URL,
+		Provider:          "test",
+		APIKey:            "partner",
+		APISecret:         "secret",
+		AllowedMethods:    []string{"swap_voucher_list"},
+		RequestsPerMinute: 10,
+		Now:               func() time.Time { return now },
+		Nonce:             func() (string, error) { return nonce, nil },
+	})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	var out map[string]interface{}
+	if err := client.call(context.Background(), "swap_voucher_list", []interface{}{int64(0), int64(0)}, &out); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+
+	if got := capturedHeaders.Get(gatewayauth.HeaderAPIKey); got != "partner" {
+		t.Fatalf("expected api key header, got %q", got)
+	}
+	ts := capturedHeaders.Get(gatewayauth.HeaderTimestamp)
+	if ts == "" {
+		t.Fatalf("missing timestamp header")
+	}
+	if ts != strconv.FormatInt(now.Unix(), 10) {
+		t.Fatalf("unexpected timestamp %q", ts)
+	}
+	if gotNonce := capturedHeaders.Get(gatewayauth.HeaderNonce); gotNonce != nonce {
+		t.Fatalf("unexpected nonce %q", gotNonce)
+	}
+	expectedSig := gatewayauth.ComputeSignature("secret", ts, nonce, http.MethodPost, capturedPath, capturedBody)
+	if sig := capturedHeaders.Get(gatewayauth.HeaderSignature); sig != hex.EncodeToString(expectedSig) {
+		t.Fatalf("unexpected signature %q", sig)
+	}
+}
+
+func TestClientRejectsDisallowedMethod(t *testing.T) {
+	client, err := NewClient(Config{
+		URL:            "http://127.0.0.1",
+		Provider:       "test",
+		APIKey:         "partner",
+		APISecret:      "secret",
+		AllowedMethods: []string{"swap_voucher_list"},
+	})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if err := client.call(context.Background(), "swap_submitVoucher", nil, nil); err == nil {
+		t.Fatalf("expected error for disallowed method")
+	}
+}
+
+func TestClientRateLimiting(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+	counter := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := rpcResponse{JSONRPC: jsonRPCVersion, ID: 1, Result: json.RawMessage(`{"ok":true}`)}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		URL:               server.URL,
+		Provider:          "test",
+		APIKey:            "partner",
+		APISecret:         "secret",
+		AllowedMethods:    []string{"swap_voucher_list"},
+		RequestsPerMinute: 1,
+		RateWindow:        time.Minute,
+		Now:               func() time.Time { return now },
+		Nonce: func() (string, error) {
+			counter++
+			return fmt.Sprintf("nonce-%d", counter), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	if err := client.call(context.Background(), "swap_voucher_list", []interface{}{int64(0), int64(0)}, nil); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := client.call(context.Background(), "swap_voucher_list", []interface{}{int64(0), int64(0)}, nil); err == nil {
+		t.Fatalf("expected rate limit error on second call")
+	}
+}
+
+// Ensure the custom client can decode JSON-RPC responses when a result is expected.
+func TestClientDecodesResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req rpcRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		resp := rpcResponse{JSONRPC: jsonRPCVersion, ID: req.ID, Result: json.RawMessage(`{"ok":true}`)}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		URL:               server.URL,
+		Provider:          "test",
+		APIKey:            "partner",
+		APISecret:         "secret",
+		AllowedMethods:    []string{"swap_voucher_list"},
+		RequestsPerMinute: 10,
+		Now:               func() time.Time { return time.Unix(1700000000, 0).UTC() },
+		Nonce: func() (string, error) {
+			return "nonce", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	var out map[string]interface{}
+	if err := client.call(context.Background(), "swap_voucher_list", []interface{}{int64(0), int64(0)}, &out); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatalf("expected result to populate output")
+	}
+}


### PR DESCRIPTION
## Summary
- load OTC swap API key, secret, method allowlist, and client rate limit from the environment
- sign every swap RPC call with gateway/auth headers while enforcing per-method allowlists and client-side throttling
- validate swap RPC HMAC headers and partner quotas on the node side with accompanying tests and documentation updates

## Testing
- `go test ./services/otc-gateway/swaprpc -count=1` *(hangs in this environment)*
- `go test ./rpc/...` *(not run due to earlier hang)*

------
https://chatgpt.com/codex/tasks/task_e_68e3261e0dd0832d915d38a8148fe71d