### PR TITLE
Add fiat funding confirmation workflow and compliance dashboards

### DIFF
--- a/docs/otc/funding.md
+++ b/docs/otc/funding.md
@@ -1,0 +1,65 @@
+# OTC Funding Verification Workflow
+
+The OTC gateway now records fiat settlement state alongside each invoice and voucher. This
+section outlines how operations and compliance teams should verify deposits before
+initiating mint requests.
+
+## Data model extensions
+
+Invoices and vouchers carry additional fiat metadata:
+
+- **FiatAmount / FiatCurrency** – the confirmed gross amount and currency remitted by the
+  counterparty.
+- **FundingStatus** – `PENDING`, `CONFIRMED`, or `REJECTED` to track settlement progress.
+- **FundingReference** – the bank, custodian, or internal reference that links the fiat
+  deposit to an OTC order.
+- **FIAT_CONFIRMED state** – invoices transition from `APPROVED` into `FIAT_CONFIRMED` once
+  funding has been validated. Only FIAT_CONFIRMED invoices may be signed or submitted on
+  chain.
+
+## Confirmation flow
+
+1. **Bank or custodian webhook** – the new `/integrations/otc/funding/webhook` endpoint
+   accepts authenticated notifications. Each payload must include the invoice identifier,
+   the fiat amount and currency, the dossier key on file, and the external funding
+   reference.
+2. **Dossier validation** – the webhook processor loads the originating partner, enforces
+   that the partner is approved, and compares the submitted dossier key against the latest
+   KYB dossier stored in the system. Mismatches raise errors for manual review.
+3. **State transition** – confirmed notifications update the invoice with fiat metadata,
+   mark the funding status as `CONFIRMED`, and move the invoice into `FIAT_CONFIRMED`.
+   An audit trail entry (`invoice.funding_confirmed`) captures the reference, custodian,
+   and amount.
+4. **Sign and submit** – the signer enforces that invoices remain `FIAT_CONFIRMED` and that
+   fiat metadata is present before minting. Funding references are recorded alongside the
+   voucher hash for downstream reconciliation.
+
+## Compliance dashboard
+
+Operations Console users can monitor funding readiness through the "Funding Assurance"
+section. The dashboard surfaces:
+
+- Counts of pending, confirmed, and rejected wires.
+- Confirmed fiat volume versus total notional to highlight reconciliation progress.
+- A live checklist of invoices still awaiting confirmation, including branches, amounts,
+  and last update timestamps.
+
+These metrics complement the Prometheus feed and ensure the funding queue is cleared
+before invoking Sign & Submit.
+
+## Reconciliation expectations
+
+- **Pending queue** – entries should be worked within the same business day. Escalate
+  cases that remain pending beyond 24 hours.
+- **Funding references** – every confirmed invoice must store the reference provided by the
+  banking or custody platform. This identifier is logged with the voucher hash and must be
+  supplied to reconciliation when matching on-chain mints to fiat deposits.
+- **Rejected wires** – when the webhook marks an invoice as `REJECTED`, transition the
+  invoice back to `PENDING_REVIEW` and document remediation steps before reattempting
+  funding.
+- **Monitoring** – the reconciliation ratio on the dashboard should trend toward 100% prior
+  to mint windows. Investigate any delta between confirmed fiat volume and OTC notional
+  before releasing vouchers.
+
+Following this workflow ensures fiat deposits are verified, auditable, and fully traceable
+through mint submission.

--- a/docs/otc/overview.md
+++ b/docs/otc/overview.md
@@ -8,6 +8,7 @@ The OTC gateway is a standalone Go microservice that orchestrates partner-facing
 - Lifecycle management of OTC invoices from creation through minting, rejection, or expiry.
 - Configurable branch and regional caps with per-invoice limits enforced during approval.
 - KYB dossier intake, partner approvals, and dossier refresh tracking with immutable audit trails.
+- Fiat funding verification through custodial webhooks, FIAT_CONFIRMED gating, and compliance dashboards.
 - Structured audit trail capturing every state transition and privileged action.
 - Idempotent API semantics for safe client retries.
 

--- a/services/otc-gateway/funding/processor.go
+++ b/services/otc-gateway/funding/processor.go
@@ -1,0 +1,152 @@
+package funding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"nhbchain/services/otc-gateway/models"
+)
+
+// Processor coordinates funding confirmation state transitions based on custodian webhooks.
+//
+// It validates inbound notifications against approved partner dossiers before
+// marking the invoice as FIAT_CONFIRMED. Successful confirmations emit an audit
+// event attributed to the system actor (uuid.Nil).
+type Processor struct {
+	db  *gorm.DB
+	now func() time.Time
+}
+
+// NewProcessor constructs a funding processor backed by the provided database.
+func NewProcessor(db *gorm.DB, now func() time.Time) *Processor {
+	if now == nil {
+		now = time.Now
+	}
+	return &Processor{db: db, now: now}
+}
+
+// Notification represents the expected payload from a banking or custodian webhook.
+type Notification struct {
+	InvoiceID        uuid.UUID         `json:"invoice_id"`
+	FiatAmount       float64           `json:"fiat_amount"`
+	FiatCurrency     string            `json:"fiat_currency"`
+	FundingReference string            `json:"funding_reference"`
+	DossierKey       string            `json:"dossier_key"`
+	Custodian        string            `json:"custodian"`
+	Status           string            `json:"status"`
+	Metadata         map[string]string `json:"metadata"`
+}
+
+var (
+	// ErrInvoiceNotFound indicates the supplied invoice identifier was unknown.
+	ErrInvoiceNotFound = errors.New("funding: invoice not found")
+	// ErrInvoiceFinalised indicates the invoice can no longer transition into FIAT_CONFIRMED.
+	ErrInvoiceFinalised = errors.New("funding: invoice already finalised")
+	// ErrInvalidState is returned when the invoice is not ready for funding confirmation.
+	ErrInvalidState = errors.New("funding: invoice not eligible for confirmation")
+	// ErrPartnerNotApproved denotes that the associated partner record is not approved.
+	ErrPartnerNotApproved = errors.New("funding: partner not approved")
+	// ErrDossierMismatch indicates the webhook dossier key did not match the stored dossier.
+	ErrDossierMismatch = errors.New("funding: dossier mismatch")
+	// ErrMissingDossier indicates the partner has no dossier on record to compare against.
+	ErrMissingDossier = errors.New("funding: missing dossier for partner")
+)
+
+// Process validates and applies a funding confirmation notification.
+func (p *Processor) Process(ctx context.Context, payload Notification) (*models.Invoice, error) {
+	if p == nil || p.db == nil {
+		return nil, fmt.Errorf("funding: processor not configured")
+	}
+	if payload.InvoiceID == uuid.Nil {
+		return nil, fmt.Errorf("funding: invoice_id is required")
+	}
+	if payload.FiatAmount <= 0 {
+		return nil, fmt.Errorf("funding: fiat_amount must be positive")
+	}
+	currency := strings.ToUpper(strings.TrimSpace(payload.FiatCurrency))
+	if currency == "" {
+		return nil, fmt.Errorf("funding: fiat_currency is required")
+	}
+	reference := strings.TrimSpace(payload.FundingReference)
+	if reference == "" {
+		return nil, fmt.Errorf("funding: funding_reference is required")
+	}
+	dossier := strings.TrimSpace(payload.DossierKey)
+
+	var updated models.Invoice
+	err := p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var invoice models.Invoice
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&invoice, "id = ?", payload.InvoiceID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrInvoiceNotFound
+			}
+			return err
+		}
+		switch invoice.State {
+		case models.StateMinted, models.StateSubmitted:
+			return ErrInvoiceFinalised
+		case models.StateApproved, models.StateFiatConfirmed:
+			// permitted
+		default:
+			return ErrInvalidState
+		}
+
+		var contact models.PartnerContact
+		if err := tx.Preload("Partner").First(&contact, "subject = ?", strings.ToLower(invoice.CreatedByID.String())).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrPartnerNotApproved
+			}
+			return err
+		}
+		if contact.Partner == nil || !contact.Partner.Approved {
+			return ErrPartnerNotApproved
+		}
+		expectedDossier := strings.TrimSpace(contact.Partner.KYBDossierKey)
+		if expectedDossier == "" {
+			return ErrMissingDossier
+		}
+		if dossier != "" && !strings.EqualFold(expectedDossier, dossier) {
+			return ErrDossierMismatch
+		}
+
+		now := p.now()
+		invoice.FiatAmount = payload.FiatAmount
+		invoice.FiatCurrency = currency
+		invoice.FundingReference = reference
+		invoice.FundingStatus = models.FundingStatusConfirmed
+		if invoice.State != models.StateFiatConfirmed {
+			invoice.State = models.StateFiatConfirmed
+		}
+		invoice.UpdatedAt = now
+		if err := tx.Save(&invoice).Error; err != nil {
+			return err
+		}
+
+		details := fmt.Sprintf("funding_ref=%s custodian=%s amount=%.2f currency=%s", reference, strings.TrimSpace(payload.Custodian), payload.FiatAmount, currency)
+		event := models.Event{
+			ID:        uuid.New(),
+			InvoiceID: &invoice.ID,
+			UserID:    uuid.Nil,
+			Action:    "invoice.funding_confirmed",
+			Details:   details,
+			CreatedAt: now,
+		}
+		if err := tx.Create(&event).Error; err != nil {
+			return err
+		}
+
+		updated = invoice
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &updated, nil
+}

--- a/services/otc-gateway/funding/processor_test.go
+++ b/services/otc-gateway/funding/processor_test.go
@@ -1,0 +1,150 @@
+package funding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"nhbchain/services/otc-gateway/models"
+)
+
+func setupFundingTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", uuid.NewString())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := models.AutoMigrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func TestProcessorProcess(t *testing.T) {
+	db := setupFundingTestDB(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	processor := NewProcessor(db, func() time.Time { return now })
+
+	branch := models.Branch{ID: uuid.New(), Name: "Global", Region: "US", RegionCap: 5_000_000, InvoiceLimit: 1_000_000, CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(&branch).Error; err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	partner := models.Partner{ID: uuid.New(), Name: "Atlas", LegalName: "Atlas LLC", KYBDossierKey: "s3://kyb/atlas.json", Approved: true, SubmittedBy: uuid.New(), CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(&partner).Error; err != nil {
+		t.Fatalf("create partner: %v", err)
+	}
+
+	operator := uuid.New()
+	contact := models.PartnerContact{ID: uuid.New(), PartnerID: partner.ID, Subject: strings.ToLower(operator.String()), CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(&contact).Error; err != nil {
+		t.Fatalf("create contact: %v", err)
+	}
+
+	invoice := models.Invoice{
+		ID:            uuid.New(),
+		BranchID:      branch.ID,
+		CreatedByID:   operator,
+		Amount:        250000,
+		Currency:      "USDC",
+		FiatCurrency:  "USD",
+		FundingStatus: models.FundingStatusPending,
+		State:         models.StateApproved,
+		Region:        branch.Region,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := db.Create(&invoice).Error; err != nil {
+		t.Fatalf("create invoice: %v", err)
+	}
+
+	notification := Notification{
+		InvoiceID:        invoice.ID,
+		FiatAmount:       250000,
+		FiatCurrency:     "usd",
+		FundingReference: "BNK-REF-1234",
+		DossierKey:       partner.KYBDossierKey,
+		Custodian:        "First National",
+	}
+
+	updated, err := processor.Process(context.Background(), notification)
+	if err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if updated.State != models.StateFiatConfirmed {
+		t.Fatalf("expected state FIAT_CONFIRMED got %s", updated.State)
+	}
+	if updated.FundingStatus != models.FundingStatusConfirmed {
+		t.Fatalf("expected funding status CONFIRMED got %s", updated.FundingStatus)
+	}
+	if updated.FundingReference != notification.FundingReference {
+		t.Fatalf("expected funding reference persisted")
+	}
+
+	var event models.Event
+	if err := db.First(&event, "invoice_id = ? AND action = ?", invoice.ID, "invoice.funding_confirmed").Error; err != nil {
+		t.Fatalf("load funding event: %v", err)
+	}
+	if !strings.Contains(event.Details, notification.FundingReference) {
+		t.Fatalf("expected funding reference in event: %s", event.Details)
+	}
+}
+
+func TestProcessorProcessDossierMismatch(t *testing.T) {
+	db := setupFundingTestDB(t)
+	processor := NewProcessor(db, time.Now)
+	now := time.Now().UTC()
+
+	branch := models.Branch{ID: uuid.New(), Name: "Global", Region: "US", RegionCap: 5_000_000, InvoiceLimit: 1_000_000, CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(&branch).Error; err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+
+	partner := models.Partner{ID: uuid.New(), Name: "Atlas", LegalName: "Atlas LLC", KYBDossierKey: "s3://kyb/atlas.json", Approved: true, SubmittedBy: uuid.New(), CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(&partner).Error; err != nil {
+		t.Fatalf("create partner: %v", err)
+	}
+
+	operator := uuid.New()
+	contact := models.PartnerContact{ID: uuid.New(), PartnerID: partner.ID, Subject: strings.ToLower(operator.String()), CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(&contact).Error; err != nil {
+		t.Fatalf("create contact: %v", err)
+	}
+
+	invoice := models.Invoice{
+		ID:            uuid.New(),
+		BranchID:      branch.ID,
+		CreatedByID:   operator,
+		Amount:        100000,
+		Currency:      "USDC",
+		FiatCurrency:  "USD",
+		FundingStatus: models.FundingStatusPending,
+		State:         models.StateApproved,
+		Region:        branch.Region,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := db.Create(&invoice).Error; err != nil {
+		t.Fatalf("create invoice: %v", err)
+	}
+
+	notification := Notification{
+		InvoiceID:        invoice.ID,
+		FiatAmount:       100000,
+		FiatCurrency:     "usd",
+		FundingReference: "BNK-REF-5678",
+		DossierKey:       "s3://kyb/other.json",
+	}
+
+	if _, err := processor.Process(context.Background(), notification); !errors.Is(err, ErrDossierMismatch) {
+		t.Fatalf("expected dossier mismatch got %v", err)
+	}
+}

--- a/services/otc-gateway/server/funding.go
+++ b/services/otc-gateway/server/funding.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"nhbchain/services/otc-gateway/funding"
+)
+
+// HandleFundingWebhook ingests custodian notifications and marks invoices as FIAT_CONFIRMED.
+func (s *Server) HandleFundingWebhook(w http.ResponseWriter, r *http.Request) {
+	if s.Funding == nil {
+		http.Error(w, "funding processor unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	var payload funding.Notification
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	invoice, err := s.Funding.Process(r.Context(), payload)
+	if err != nil {
+		switch {
+		case errors.Is(err, funding.ErrInvoiceNotFound):
+			http.Error(w, "invoice not found", http.StatusNotFound)
+		case errors.Is(err, funding.ErrInvoiceFinalised):
+			http.Error(w, "invoice already finalised", http.StatusConflict)
+		case errors.Is(err, funding.ErrInvalidState):
+			http.Error(w, "invoice not eligible for confirmation", http.StatusConflict)
+		case errors.Is(err, funding.ErrPartnerNotApproved):
+			http.Error(w, "partner not approved", http.StatusPreconditionFailed)
+		case errors.Is(err, funding.ErrMissingDossier):
+			http.Error(w, "partner dossier missing", http.StatusPreconditionFailed)
+		case errors.Is(err, funding.ErrDossierMismatch):
+			http.Error(w, "dossier mismatch", http.StatusForbidden)
+		default:
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
+		return
+	}
+	s.writeJSON(w, http.StatusOK, map[string]interface{}{
+		"invoice_id":        invoice.ID,
+		"state":             invoice.State,
+		"funding_status":    invoice.FundingStatus,
+		"funding_reference": invoice.FundingReference,
+	})
+}

--- a/services/otc-gateway/server/sign_submit_test.go
+++ b/services/otc-gateway/server/sign_submit_test.go
@@ -180,8 +180,8 @@ func TestSignAndSubmit_Minted(t *testing.T) {
 	if err := db.Where("invoice_id = ? AND action = ?", invoice.ID, "invoice.signed").First(&event).Error; err != nil {
 		t.Fatalf("load signed event: %v", err)
 	}
-	if !strings.Contains(event.Details, "hash=") || !strings.Contains(event.Details, "signer_dn=") {
-		t.Fatalf("expected hash and signer dn in event: %s", event.Details)
+	if !strings.Contains(event.Details, "hash=") || !strings.Contains(event.Details, "signer_dn=") || !strings.Contains(event.Details, "funding_ref=") {
+		t.Fatalf("expected hash, signer dn, and funding ref in event: %s", event.Details)
 	}
 }
 
@@ -500,15 +500,19 @@ func createApprovedInvoice(t *testing.T, db *gorm.DB, branch models.Branch, crea
 	t.Helper()
 	now := time.Now().UTC()
 	invoice := models.Invoice{
-		ID:          uuid.New(),
-		BranchID:    branch.ID,
-		CreatedByID: creator,
-		Amount:      amount,
-		Currency:    "USD",
-		State:       models.StateApproved,
-		Region:      branch.Region,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ID:               uuid.New(),
+		BranchID:         branch.ID,
+		CreatedByID:      creator,
+		Amount:           amount,
+		Currency:         "USD",
+		FiatAmount:       amount,
+		FiatCurrency:     "USD",
+		FundingStatus:    models.FundingStatusConfirmed,
+		FundingReference: fmt.Sprintf("FUND-%s", uuid.NewString()[:8]),
+		State:            models.StateFiatConfirmed,
+		Region:           branch.Region,
+		CreatedAt:        now,
+		UpdatedAt:        now,
 	}
 	if err := db.Create(&invoice).Error; err != nil {
 		t.Fatalf("create invoice: %v", err)

--- a/services/otc-gateway/server/workflow.go
+++ b/services/otc-gateway/server/workflow.go
@@ -10,7 +10,8 @@ var allowedTransitions = map[models.InvoiceState][]models.InvoiceState{
 	models.StateCreated:         {models.StateReceiptUploaded},
 	models.StateReceiptUploaded: {models.StatePendingReview},
 	models.StatePendingReview:   {models.StateApproved, models.StateRejected},
-	models.StateApproved:        {models.StateSigned, models.StateRejected},
+	models.StateApproved:        {models.StateFiatConfirmed, models.StateRejected},
+	models.StateFiatConfirmed:   {models.StateSigned, models.StateRejected},
 	models.StateSigned:          {models.StateSubmitted, models.StateRejected},
 	models.StateSubmitted:       {models.StateMinted},
 }

--- a/services/otc-ops-ui/app/api/invoices/route.ts
+++ b/services/otc-ops-ui/app/api/invoices/route.ts
@@ -10,6 +10,8 @@ function parseFilters(url: URL): InvoiceFilters {
   if (branch) filters.branch = branch;
   const status = url.searchParams.get("status");
   if (status) filters.status = status as InvoiceFilters["status"];
+  const fundingStatus = url.searchParams.get("fundingStatus");
+  if (fundingStatus) filters.fundingStatus = fundingStatus as InvoiceFilters["fundingStatus"];
   const minDate = url.searchParams.get("minDate");
   if (minDate) filters.minDate = minDate;
   const maxDate = url.searchParams.get("maxDate");

--- a/services/otc-ops-ui/app/globals.css
+++ b/services/otc-ops-ui/app/globals.css
@@ -176,6 +176,135 @@ main {
   background: rgba(99, 102, 241, 0.15);
 }
 
+.funding {
+  text-transform: capitalize;
+  font-weight: 600;
+}
+
+.funding.confirmed {
+  color: #4ade80;
+}
+
+.funding.pending {
+  color: #fbbf24;
+}
+
+.funding.rejected {
+  color: #f87171;
+}
+
+.compliance-dashboard {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.compliance-dashboard h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.compliance-dashboard p {
+  margin: 0.5rem 0 0;
+  color: #94a3b8;
+  max-width: 60ch;
+}
+
+.compliance-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.compliance-card {
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.compliance-card .label {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+
+.compliance-card .value {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.compliance-card .detail {
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}
+
+.compliance-queue {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+}
+
+.compliance-queue .queue-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.compliance-queue h3 {
+  margin: 0;
+}
+
+.compliance-queue span {
+  color: #94a3b8;
+}
+
+.compliance-queue ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.compliance-queue li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(30, 41, 59, 0.6);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.compliance-queue li.empty {
+  justify-content: center;
+  color: #94a3b8;
+}
+
+.compliance-queue li div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.compliance-queue .timestamp {
+  color: #cbd5f5;
+  font-size: 0.8rem;
+}
+
 .viewer {
   background: rgba(15, 23, 42, 0.7);
   border: 1px solid rgba(148, 163, 184, 0.2);

--- a/services/otc-ops-ui/components/OperationsConsole.tsx
+++ b/services/otc-ops-ui/components/OperationsConsole.tsx
@@ -4,6 +4,7 @@ import dayjs from "dayjs";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActionPayload, Invoice, InvoiceFilters, InvoiceStage } from "../lib/types";
 import { InvoiceFiltersForm } from "./filters";
+import { ComplianceDashboard } from "./complianceDashboard";
 import { InvoiceTable } from "./table";
 import { InvoiceViewer } from "./viewer";
 import { PartnerBoard } from "./partnerBoard";
@@ -13,6 +14,7 @@ const stages: { key: InvoiceStage; label: string }[] = [
   { key: "receipt", label: "Receipt" },
   { key: "review", label: "Review" },
   { key: "approval", label: "Approval" },
+  { key: "funding", label: "Funding" },
   { key: "completed", label: "Completed" },
   { key: "rejected", label: "Rejected" }
 ];
@@ -133,6 +135,8 @@ export function OperationsConsole() {
       </header>
 
       <PartnerBoard partners={partnerReadiness} />
+
+      <ComplianceDashboard invoices={invoices} />
 
       <section className="stage-tabs">
         {stages.map((stage) => (

--- a/services/otc-ops-ui/components/complianceDashboard.tsx
+++ b/services/otc-ops-ui/components/complianceDashboard.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import { useMemo } from "react";
+import { Invoice } from "../lib/types";
+
+dayjs.extend(relativeTime);
+
+interface Props {
+  invoices: Invoice[];
+}
+
+export function ComplianceDashboard({ invoices }: Props) {
+  const summary = useMemo(() => {
+    const tally: Record<"pending" | "confirmed" | "rejected", number> = {
+      pending: 0,
+      confirmed: 0,
+      rejected: 0
+    };
+    let pendingNotional = 0;
+    let confirmedVolume = 0;
+    let totalNotional = 0;
+
+    invoices.forEach((invoice) => {
+      totalNotional += invoice.amount;
+      tally[invoice.fundingStatus] += 1;
+      if (invoice.fundingStatus === "pending") {
+        pendingNotional += invoice.amount;
+      }
+      if (invoice.fundingStatus === "confirmed") {
+        confirmedVolume += invoice.fiatAmount || invoice.amount;
+      }
+    });
+
+    const pendingQueue = invoices
+      .filter((invoice) => invoice.fundingStatus === "pending")
+      .sort((a, b) => dayjs(a.updatedAt).valueOf() - dayjs(b.updatedAt).valueOf());
+
+    const reconciliation = totalNotional === 0 ? 0 : confirmedVolume / totalNotional;
+
+    return {
+      tally,
+      pendingNotional,
+      confirmedVolume,
+      reconciliation,
+      pendingQueue
+    };
+  }, [invoices]);
+
+  return (
+    <section className="compliance-dashboard">
+      <header>
+        <div>
+          <h2>Funding Assurance</h2>
+          <p>
+            Compliance visibility into fiat settlement confirmations, outstanding wires, and
+            reconciliation progress prior to mint submission.
+          </p>
+        </div>
+      </header>
+
+      <div className="compliance-grid">
+        <article className="compliance-card">
+          <span className="label">Pending confirmations</span>
+          <span className="value">{summary.tally.pending}</span>
+          <span className="detail">
+            ${summary.pendingNotional.toLocaleString(undefined, { maximumFractionDigits: 0 })} awaiting
+            attestation
+          </span>
+        </article>
+        <article className="compliance-card">
+          <span className="label">Confirmed volume</span>
+          <span className="value">
+            ${summary.confirmedVolume.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+          </span>
+          <span className="detail">Across {summary.tally.confirmed} dossiers</span>
+        </article>
+        <article className="compliance-card">
+          <span className="label">Reconciliation ratio</span>
+          <span className="value">
+            {(summary.reconciliation * 100).toLocaleString(undefined, {
+              maximumFractionDigits: 1
+            })}
+            %
+          </span>
+          <span className="detail">Confirmed vs. total notional</span>
+        </article>
+        <article className="compliance-card">
+          <span className="label">Rejected wires</span>
+          <span className="value">{summary.tally.rejected}</span>
+          <span className="detail">Requires manual escalation</span>
+        </article>
+      </div>
+
+      <div className="compliance-queue">
+        <div className="queue-header">
+          <h3>Pending funding checklist</h3>
+          <span>{summary.pendingQueue.length} dossiers awaiting confirmation</span>
+        </div>
+        <ul>
+          {summary.pendingQueue.slice(0, 5).map((invoice) => (
+            <li key={invoice.id}>
+              <div>
+                <strong>{invoice.id}</strong>
+                <span>{invoice.branch}</span>
+              </div>
+              <div>
+                <span>
+                  {invoice.amount.toLocaleString(undefined, {
+                    style: "currency",
+                    currency: invoice.currency === "USDC" ? "USD" : invoice.currency
+                  })}
+                </span>
+                <span className="timestamp">Updated {dayjs(invoice.updatedAt).fromNow()}</span>
+              </div>
+            </li>
+          ))}
+          {summary.pendingQueue.length === 0 && (
+            <li className="empty">All submitted invoices have verified fiat funding.</li>
+          )}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/services/otc-ops-ui/components/filters.tsx
+++ b/services/otc-ops-ui/components/filters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChangeEvent } from "react";
-import { InvoiceFilters, InvoiceStatus } from "../lib/types";
+import { FundingStatus, InvoiceFilters, InvoiceStatus } from "../lib/types";
 
 const statuses: InvoiceStatus[] = [
   "receipt_pending",
@@ -9,11 +9,15 @@ const statuses: InvoiceStatus[] = [
   "under_review",
   "awaiting_approval",
   "approved",
+  "funding_pending",
+  "funding_confirmed",
   "rejected",
   "escalated",
   "signed",
   "submitted"
 ];
+
+const fundingStatuses: FundingStatus[] = ["pending", "confirmed", "rejected"];
 
 interface Props {
   filters: InvoiceFilters;
@@ -50,6 +54,21 @@ export function InvoiceFiltersForm({ filters, onChange }: Props) {
           {statuses.map((status) => (
             <option key={status} value={status}>
               {status.replace(/_/g, " ")}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Funding Status
+        <select
+          name="fundingStatus"
+          value={filters.fundingStatus ?? ""}
+          onChange={handleChange}
+        >
+          <option value="">All</option>
+          {fundingStatuses.map((status) => (
+            <option key={status} value={status}>
+              {status}
             </option>
           ))}
         </select>

--- a/services/otc-ops-ui/components/table.tsx
+++ b/services/otc-ops-ui/components/table.tsx
@@ -29,6 +29,7 @@ export function InvoiceTable({ invoices, loading, selectedId, onSelect }: Props)
             <th>Branch</th>
             <th>Amount</th>
             <th>Status</th>
+            <th>Funding</th>
             <th>Updated</th>
           </tr>
         </thead>
@@ -49,6 +50,9 @@ export function InvoiceTable({ invoices, loading, selectedId, onSelect }: Props)
                 })}
               </td>
               <td>{invoice.status.replace(/_/g, " ")}</td>
+              <td className={`funding ${invoice.fundingStatus}`}>
+                {invoice.fundingStatus}
+              </td>
               <td>{dayjs(invoice.updatedAt).format("MMM D, HH:mm")}</td>
             </tr>
           ))}

--- a/services/otc-ops-ui/components/viewer.tsx
+++ b/services/otc-ops-ui/components/viewer.tsx
@@ -40,12 +40,14 @@ export function InvoiceViewer({ invoice, onAction }: Props) {
     {
       key: "sign",
       label: "Sign",
-      visible: role === "superadmin" && invoice.stage === "approval"
+      visible: role === "superadmin" && (invoice.stage === "approval" || invoice.stage === "funding")
     },
     {
       key: "submit",
       label: "Sign & Submit",
-      visible: role === "superadmin" && (invoice.status === "signed" || invoice.stage === "approval")
+      visible:
+        role === "superadmin" &&
+        (invoice.status === "signed" || invoice.stage === "approval" || invoice.stage === "funding")
     }
   ] as const;
 
@@ -97,6 +99,23 @@ export function InvoiceViewer({ invoice, onAction }: Props) {
           <div>
             <dt>TWAP</dt>
             <dd>{invoice.twapReference.toFixed(4)}</dd>
+          </div>
+          <div>
+            <dt>Fiat Amount</dt>
+            <dd>
+              {invoice.fiatAmount.toLocaleString(undefined, {
+                style: "currency",
+                currency: invoice.fiatCurrency || "USD"
+              })}
+            </dd>
+          </div>
+          <div>
+            <dt>Funding Status</dt>
+            <dd className={`funding ${invoice.fundingStatus}`}>{invoice.fundingStatus}</dd>
+          </div>
+          <div>
+            <dt>Funding Reference</dt>
+            <dd>{invoice.fundingReference ?? "Pending"}</dd>
           </div>
           <div>
             <dt>Voucher</dt>

--- a/services/otc-ops-ui/data/invoices.ts
+++ b/services/otc-ops-ui/data/invoices.ts
@@ -9,6 +9,9 @@ const sampleInvoices: Invoice[] = [
     counterparty: "Atlas Macro Fund",
     amount: 2500000,
     currency: "USDC",
+    fiatAmount: 0,
+    fiatCurrency: "USD",
+    fundingStatus: "pending",
     status: "receipt_pending",
     stage: "receipt",
     rate: 1.004,
@@ -41,6 +44,9 @@ const sampleInvoices: Invoice[] = [
     counterparty: "Sierra Digital",
     amount: 750000,
     currency: "USDT",
+    fiatAmount: 0,
+    fiatCurrency: "USD",
+    fundingStatus: "pending",
     status: "under_review",
     stage: "review",
     rate: 0.998,
@@ -79,12 +85,16 @@ const sampleInvoices: Invoice[] = [
     counterparty: "Helios Partners",
     amount: 1200000,
     currency: "USDC",
-    status: "awaiting_approval",
-    stage: "approval",
+    status: "funding_confirmed",
+    stage: "funding",
     rate: 1.001,
     twapReference: 1.0005,
     voucherId: "VCHR-1003",
     txHash: null,
+    fiatAmount: 1200000,
+    fiatCurrency: "USD",
+    fundingStatus: "confirmed",
+    fundingReference: "BANK-2024-0003",
     receiptEvidence: [
       {
         url: "https://example.com/evidence/inv-2024-0003.pdf",
@@ -110,6 +120,12 @@ const sampleInvoices: Invoice[] = [
         note: "Ready for approval",
         actor: "treasury-duty",
         timestamp: dayjs().subtract(1, "day").toISOString()
+      },
+      {
+        status: "funding_confirmed",
+        note: "Wire received by custodian",
+        actor: "treasury-duty",
+        timestamp: dayjs().subtract(8, "hour").toISOString()
       }
     ],
     createdAt: dayjs().subtract(6, "day").toISOString(),

--- a/services/otc-ops-ui/lib/invoiceStore.ts
+++ b/services/otc-ops-ui/lib/invoiceStore.ts
@@ -34,6 +34,7 @@ export class InvoiceStore {
       if (filters.stage && invoice.stage !== filters.stage) return false;
       if (filters.branch && invoice.branch !== filters.branch) return false;
       if (filters.status && invoice.status !== filters.status) return false;
+      if (filters.fundingStatus && invoice.fundingStatus !== filters.fundingStatus) return false;
       if (filters.minDate && dayjs(invoice.createdAt).isBefore(dayjs(filters.minDate))) return false;
       if (filters.maxDate && dayjs(invoice.createdAt).isAfter(dayjs(filters.maxDate))) return false;
       if (filters.minAmount && invoice.amount < filters.minAmount) return false;
@@ -105,8 +106,10 @@ function actionNote(status: InvoiceStatus, role: string) {
   switch (status) {
     case "approved":
       return `${role} approval completed`;
+    case "funding_confirmed":
+      return "Fiat funding confirmed";
     case "rejected":
-      return `${role} rejection`; 
+      return `${role} rejection`;
     case "escalated":
       return `${role} escalation`;
     case "signed":

--- a/services/otc-ops-ui/lib/types.ts
+++ b/services/otc-ops-ui/lib/types.ts
@@ -1,4 +1,4 @@
-export type InvoiceStage = "receipt" | "review" | "approval" | "completed" | "rejected";
+export type InvoiceStage = "receipt" | "review" | "approval" | "funding" | "completed" | "rejected";
 
 export type InvoiceStatus =
   | "receipt_pending"
@@ -6,10 +6,14 @@ export type InvoiceStatus =
   | "under_review"
   | "awaiting_approval"
   | "approved"
+  | "funding_pending"
+  | "funding_confirmed"
   | "rejected"
   | "escalated"
   | "signed"
   | "submitted";
+
+export type FundingStatus = "pending" | "confirmed" | "rejected";
 
 export interface EvidenceItem {
   url: string;
@@ -30,6 +34,10 @@ export interface Invoice {
   counterparty: string;
   amount: number;
   currency: string;
+  fiatAmount: number;
+  fiatCurrency: string;
+  fundingStatus: FundingStatus;
+  fundingReference?: string;
   status: InvoiceStatus;
   stage: InvoiceStage;
   rate: number;
@@ -47,6 +55,7 @@ export interface Invoice {
 export interface InvoiceFilters {
   branch?: string;
   status?: InvoiceStatus;
+  fundingStatus?: FundingStatus;
   minDate?: string;
   maxDate?: string;
   minAmount?: number;


### PR DESCRIPTION
## Summary
- extend invoices and vouchers with fiat funding fields and introduce the FIAT_CONFIRMED state
- add a funding processor with webhook ingestion, dossier validation, and signer gating updates
- surface funding status in the OTC ops UI with a compliance dashboard and document the workflow

## Testing
- go test ./services/otc-gateway/... *(hangs in CI sandbox while compiling sqlite dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e352fa5384832da5f0489a5598e88e