### PR TITLE
POS-PAYMASTER-2: Caps & abuse guards

### DIFF
--- a/cmd/consensusd/main.go
+++ b/cmd/consensusd/main.go
@@ -177,6 +177,16 @@ func main() {
 	node.SetMempoolUnlimitedOptIn(cfg.Mempool.AllowUnlimited)
 	node.SetMempoolLimit(cfg.Mempool.MaxTransactions)
 
+	paymasterLimits, err := cfg.Global.PaymasterLimits()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to parse paymaster limits: %v", err))
+	}
+	node.SetPaymasterLimits(core.PaymasterLimits{
+		MerchantDailyCapWei: paymasterLimits.MerchantDailyCapWei,
+		DeviceDailyTxCap:    paymasterLimits.DeviceDailyTxCap,
+		GlobalDailyCapWei:   paymasterLimits.GlobalDailyCapWei,
+	})
+
 	govPolicy, err := cfg.Governance.Policy()
 	if err != nil {
 		panic(fmt.Sprintf("Failed to parse governance policy: %v", err))

--- a/cmd/nhb/main.go
+++ b/cmd/nhb/main.go
@@ -96,6 +96,16 @@ func main() {
 	node.SetMempoolUnlimitedOptIn(cfg.Mempool.AllowUnlimited)
 	node.SetMempoolLimit(cfg.Mempool.MaxTransactions)
 
+	paymasterLimits, err := cfg.Global.PaymasterLimits()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to parse paymaster limits: %v", err))
+	}
+	node.SetPaymasterLimits(core.PaymasterLimits{
+		MerchantDailyCapWei: paymasterLimits.MerchantDailyCapWei,
+		DeviceDailyTxCap:    paymasterLimits.DeviceDailyTxCap,
+		GlobalDailyCapWei:   paymasterLimits.GlobalDailyCapWei,
+	})
+
 	govPolicy, err := cfg.Governance.Policy()
 	if err != nil {
 		panic(fmt.Sprintf("Failed to parse governance policy: %v", err))

--- a/config/config.go
+++ b/config/config.go
@@ -135,6 +135,10 @@ func defaultGlobalConfig() Global {
 		Mempool: Mempool{MaxBytes: 16 << 20},
 		Blocks:  Blocks{MaxTxs: 5000},
 		Pauses:  Pauses{},
+		Paymaster: Paymaster{
+			MerchantDailyCapWei: "0",
+			GlobalDailyCapWei:   "0",
+		},
 	}
 }
 
@@ -505,6 +509,16 @@ func (cfg *Config) ensureGlobalDefaults(meta toml.MetaData) {
 	}
 	if !meta.IsDefined("global", "blocks", "MaxTxs") {
 		cfg.Global.Blocks.MaxTxs = defaults.Blocks.MaxTxs
+	}
+
+	if strings.TrimSpace(cfg.Global.Paymaster.MerchantDailyCapWei) == "" {
+		cfg.Global.Paymaster.MerchantDailyCapWei = defaults.Paymaster.MerchantDailyCapWei
+	}
+	if strings.TrimSpace(cfg.Global.Paymaster.GlobalDailyCapWei) == "" {
+		cfg.Global.Paymaster.GlobalDailyCapWei = defaults.Paymaster.GlobalDailyCapWei
+	}
+	if !meta.IsDefined("global", "paymaster", "DeviceDailyTxCap") {
+		cfg.Global.Paymaster.DeviceDailyTxCap = defaults.Paymaster.DeviceDailyTxCap
 	}
 }
 

--- a/config/global.go
+++ b/config/global.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"fmt"
+	"math/big"
+)
+
+// PaymasterLimits represents the parsed paymaster throttling limits.
+type PaymasterLimits struct {
+	MerchantDailyCapWei *big.Int
+	DeviceDailyTxCap    uint64
+	GlobalDailyCapWei   *big.Int
+}
+
+// PaymasterLimits parses the configured paymaster throttling caps into runtime values.
+func (g Global) PaymasterLimits() (PaymasterLimits, error) {
+	limits := PaymasterLimits{DeviceDailyTxCap: g.Paymaster.DeviceDailyTxCap}
+	merchantCap, err := parseUintAmount(g.Paymaster.MerchantDailyCapWei)
+	if err != nil {
+		return limits, fmt.Errorf("invalid global.paymaster.MerchantDailyCapWei: %w", err)
+	}
+	limits.MerchantDailyCapWei = merchantCap
+	globalCap, err := parseUintAmount(g.Paymaster.GlobalDailyCapWei)
+	if err != nil {
+		return limits, fmt.Errorf("invalid global.paymaster.GlobalDailyCapWei: %w", err)
+	}
+	limits.GlobalDailyCapWei = globalCap
+	return limits, nil
+}

--- a/config/types.go
+++ b/config/types.go
@@ -26,6 +26,13 @@ type Blocks struct {
 	MaxTxs int64
 }
 
+// Paymaster captures sponsorship throttling configuration knobs.
+type Paymaster struct {
+	MerchantDailyCapWei string
+	DeviceDailyTxCap    uint64
+	GlobalDailyCapWei   string
+}
+
 // Consensus controls the BFT round timeouts.
 type Consensus struct {
 	ProposalTimeout  time.Duration `toml:"ProposalTimeout"`
@@ -68,4 +75,5 @@ type Global struct {
 	Blocks     Blocks
 	Pauses     Pauses
 	Quotas     Quotas
+	Paymaster  Paymaster
 }

--- a/config/validate.go
+++ b/config/validate.go
@@ -22,6 +22,9 @@ func ValidateConfig(g Global) error {
 	if g.Blocks.MaxTxs <= 0 {
 		return fmt.Errorf("blocks: max_txs <= 0")
 	}
+	if _, err := g.PaymasterLimits(); err != nil {
+		return fmt.Errorf("paymaster: %w", err)
+	}
 	return nil
 }
 

--- a/core/sponsorship.go
+++ b/core/sponsorship.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	nhbstate "nhbchain/core/state"
 	"nhbchain/core/types"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -19,8 +20,59 @@ const (
 	SponsorshipStatusSignatureMissing    SponsorshipStatus = "signature_missing"
 	SponsorshipStatusSignatureInvalid    SponsorshipStatus = "signature_invalid"
 	SponsorshipStatusInsufficientBalance SponsorshipStatus = "insufficient_balance"
+	SponsorshipStatusThrottled           SponsorshipStatus = "throttled"
 	SponsorshipStatusReady               SponsorshipStatus = "ready"
 )
+
+// PaymasterThrottleScope identifies the scope for a throttled sponsorship attempt.
+type PaymasterThrottleScope string
+
+const (
+	// PaymasterThrottleScopeMerchant indicates the merchant aggregate exceeded its budget.
+	PaymasterThrottleScopeMerchant PaymasterThrottleScope = "merchant"
+	// PaymasterThrottleScopeDevice indicates the device exhausted its transaction allocation.
+	PaymasterThrottleScopeDevice PaymasterThrottleScope = "device"
+	// PaymasterThrottleScopeGlobal indicates the global sponsorship cap has been consumed.
+	PaymasterThrottleScopeGlobal PaymasterThrottleScope = "global"
+)
+
+// PaymasterThrottle captures context for a throttled sponsorship attempt.
+type PaymasterThrottle struct {
+	Scope            PaymasterThrottleScope
+	Merchant         string
+	DeviceID         string
+	Day              string
+	LimitWei         *big.Int
+	UsedBudgetWei    *big.Int
+	AttemptBudgetWei *big.Int
+	TxCount          uint64
+	LimitTxCount     uint64
+}
+
+// Clone returns a deep copy of the throttle metadata.
+func (p *PaymasterThrottle) Clone() *PaymasterThrottle {
+	if p == nil {
+		return nil
+	}
+	clone := &PaymasterThrottle{
+		Scope:        p.Scope,
+		Merchant:     p.Merchant,
+		DeviceID:     p.DeviceID,
+		Day:          p.Day,
+		TxCount:      p.TxCount,
+		LimitTxCount: p.LimitTxCount,
+	}
+	if p.LimitWei != nil {
+		clone.LimitWei = new(big.Int).Set(p.LimitWei)
+	}
+	if p.UsedBudgetWei != nil {
+		clone.UsedBudgetWei = new(big.Int).Set(p.UsedBudgetWei)
+	}
+	if p.AttemptBudgetWei != nil {
+		clone.AttemptBudgetWei = new(big.Int).Set(p.AttemptBudgetWei)
+	}
+	return clone
+}
 
 // SponsorshipAssessment summarises the pre-flight checks for a paymaster
 // sponsored transaction. Callers may surface the status and reason to clients.
@@ -30,6 +82,83 @@ type SponsorshipAssessment struct {
 	Sponsor  common.Address
 	GasCost  *big.Int
 	GasPrice *big.Int
+	Throttle *PaymasterThrottle
+	day      string
+	merchant string
+	deviceID string
+}
+
+// PaymasterLimits captures the configured sponsorship bounds enforced per merchant, device, and globally.
+type PaymasterLimits struct {
+	MerchantDailyCapWei *big.Int
+	DeviceDailyTxCap    uint64
+	GlobalDailyCapWei   *big.Int
+}
+
+// Clone returns a deep copy of the limits structure.
+func (l PaymasterLimits) Clone() PaymasterLimits {
+	clone := PaymasterLimits{DeviceDailyTxCap: l.DeviceDailyTxCap}
+	if l.MerchantDailyCapWei != nil {
+		clone.MerchantDailyCapWei = new(big.Int).Set(l.MerchantDailyCapWei)
+	}
+	if l.GlobalDailyCapWei != nil {
+		clone.GlobalDailyCapWei = new(big.Int).Set(l.GlobalDailyCapWei)
+	}
+	return clone
+}
+
+// PaymasterCounters aggregates usage statistics for the configured scopes on a given day.
+type PaymasterCounters struct {
+	Day string
+
+	Merchant string
+	DeviceID string
+
+	MerchantBudgetWei  *big.Int
+	MerchantChargedWei *big.Int
+	MerchantTxCount    uint64
+
+	DeviceBudgetWei  *big.Int
+	DeviceChargedWei *big.Int
+	DeviceTxCount    uint64
+
+	GlobalBudgetWei  *big.Int
+	GlobalChargedWei *big.Int
+	GlobalTxCount    uint64
+}
+
+// Clone returns a deep copy of the counters snapshot.
+func (p *PaymasterCounters) Clone() *PaymasterCounters {
+	if p == nil {
+		return nil
+	}
+	clone := &PaymasterCounters{
+		Day:             p.Day,
+		Merchant:        p.Merchant,
+		DeviceID:        p.DeviceID,
+		MerchantTxCount: p.MerchantTxCount,
+		DeviceTxCount:   p.DeviceTxCount,
+		GlobalTxCount:   p.GlobalTxCount,
+	}
+	if p.MerchantBudgetWei != nil {
+		clone.MerchantBudgetWei = new(big.Int).Set(p.MerchantBudgetWei)
+	}
+	if p.MerchantChargedWei != nil {
+		clone.MerchantChargedWei = new(big.Int).Set(p.MerchantChargedWei)
+	}
+	if p.DeviceBudgetWei != nil {
+		clone.DeviceBudgetWei = new(big.Int).Set(p.DeviceBudgetWei)
+	}
+	if p.DeviceChargedWei != nil {
+		clone.DeviceChargedWei = new(big.Int).Set(p.DeviceChargedWei)
+	}
+	if p.GlobalBudgetWei != nil {
+		clone.GlobalBudgetWei = new(big.Int).Set(p.GlobalBudgetWei)
+	}
+	if p.GlobalChargedWei != nil {
+		clone.GlobalChargedWei = new(big.Int).Set(p.GlobalChargedWei)
+	}
+	return clone
 }
 
 // EvaluateSponsorship inspects the transaction and returns the expected
@@ -98,7 +227,233 @@ func (sp *StateProcessor) EvaluateSponsorship(tx *types.Transaction) (*Sponsorsh
 		return assessment, nil
 	}
 
+	assessment.merchant = nhbstate.NormalizePaymasterMerchant(tx.MerchantAddress)
+	assessment.deviceID = nhbstate.NormalizePaymasterDevice(tx.DeviceID)
+	assessment.day = sp.currentPaymasterDay()
+
+	if err := sp.checkPaymasterCaps(assessment); err != nil {
+		return nil, err
+	}
+	if assessment.Status == SponsorshipStatusThrottled {
+		return assessment, nil
+	}
+
 	assessment.Status = SponsorshipStatusReady
 	assessment.Reason = ""
 	return assessment, nil
+}
+
+func (sp *StateProcessor) currentPaymasterDay() string {
+	if sp == nil {
+		return ""
+	}
+	return nhbstate.NormalizePaymasterDay(sp.blockTimestamp().UTC().Format(nhbstate.PaymasterDayFormat))
+}
+
+func (sp *StateProcessor) checkPaymasterCaps(assessment *SponsorshipAssessment) error {
+	if sp == nil || assessment == nil {
+		return nil
+	}
+	limits := sp.paymasterLimits.Clone()
+	if assessment.GasCost == nil {
+		return nil
+	}
+	budget := new(big.Int).Set(assessment.GasCost)
+	if budget.Sign() <= 0 {
+		return nil
+	}
+
+	manager := nhbstate.NewManager(sp.Trie)
+	day := assessment.day
+
+	// Global cap check.
+	if limits.GlobalDailyCapWei != nil && limits.GlobalDailyCapWei.Sign() > 0 {
+		global, _, err := manager.PaymasterGetGlobalDay(day)
+		if err != nil {
+			return err
+		}
+		used := big.NewInt(0)
+		if global != nil && global.BudgetWei != nil {
+			used = new(big.Int).Set(global.BudgetWei)
+		}
+		projected := new(big.Int).Add(used, budget)
+		if projected.Cmp(limits.GlobalDailyCapWei) > 0 {
+			assessment.Status = SponsorshipStatusThrottled
+			assessment.Reason = "global sponsorship cap reached"
+			assessment.Throttle = &PaymasterThrottle{
+				Scope:            PaymasterThrottleScopeGlobal,
+				Day:              day,
+				LimitWei:         new(big.Int).Set(limits.GlobalDailyCapWei),
+				UsedBudgetWei:    used,
+				AttemptBudgetWei: budget,
+			}
+			return nil
+		}
+	}
+
+	merchant := assessment.merchant
+	if limits.MerchantDailyCapWei != nil && limits.MerchantDailyCapWei.Sign() > 0 {
+		if merchant == "" {
+			assessment.Status = SponsorshipStatusThrottled
+			assessment.Reason = "merchant address required for sponsorship throttling"
+			assessment.Throttle = &PaymasterThrottle{
+				Scope:            PaymasterThrottleScopeMerchant,
+				Day:              day,
+				LimitWei:         new(big.Int).Set(limits.MerchantDailyCapWei),
+				AttemptBudgetWei: budget,
+			}
+			return nil
+		}
+		merchantRecord, _, err := manager.PaymasterGetMerchantDay(merchant, day)
+		if err != nil {
+			return err
+		}
+		used := big.NewInt(0)
+		txCount := uint64(0)
+		if merchantRecord != nil {
+			if merchantRecord.BudgetWei != nil {
+				used = new(big.Int).Set(merchantRecord.BudgetWei)
+			}
+			txCount = merchantRecord.TxCount
+		}
+		projected := new(big.Int).Add(used, budget)
+		if projected.Cmp(limits.MerchantDailyCapWei) > 0 {
+			assessment.Status = SponsorshipStatusThrottled
+			assessment.Reason = "merchant sponsorship cap reached"
+			assessment.Throttle = &PaymasterThrottle{
+				Scope:            PaymasterThrottleScopeMerchant,
+				Merchant:         merchant,
+				Day:              day,
+				LimitWei:         new(big.Int).Set(limits.MerchantDailyCapWei),
+				UsedBudgetWei:    used,
+				AttemptBudgetWei: budget,
+				TxCount:          txCount,
+			}
+			return nil
+		}
+	}
+
+	if limits.DeviceDailyTxCap > 0 {
+		device := assessment.deviceID
+		if device == "" || merchant == "" {
+			assessment.Status = SponsorshipStatusThrottled
+			assessment.Reason = "device identifier required for sponsorship throttling"
+			assessment.Throttle = &PaymasterThrottle{
+				Scope:            PaymasterThrottleScopeDevice,
+				Merchant:         merchant,
+				DeviceID:         device,
+				Day:              day,
+				AttemptBudgetWei: budget,
+				LimitTxCount:     limits.DeviceDailyTxCap,
+			}
+			return nil
+		}
+		deviceRecord, _, err := manager.PaymasterGetDeviceDay(merchant, device, day)
+		if err != nil {
+			return err
+		}
+		txCount := uint64(0)
+		if deviceRecord != nil {
+			txCount = deviceRecord.TxCount
+		}
+		if txCount >= limits.DeviceDailyTxCap {
+			assessment.Status = SponsorshipStatusThrottled
+			assessment.Reason = "device sponsorship cap reached"
+			assessment.Throttle = &PaymasterThrottle{
+				Scope:            PaymasterThrottleScopeDevice,
+				Merchant:         merchant,
+				DeviceID:         device,
+				Day:              day,
+				AttemptBudgetWei: budget,
+				TxCount:          txCount,
+				LimitTxCount:     limits.DeviceDailyTxCap,
+			}
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// PaymasterLimits returns the current sponsorship caps applied to the state processor.
+func (sp *StateProcessor) PaymasterLimits() PaymasterLimits {
+	if sp == nil {
+		return PaymasterLimits{}
+	}
+	return sp.paymasterLimits.Clone()
+}
+
+// SetPaymasterLimits updates the sponsorship caps enforced during evaluation.
+func (sp *StateProcessor) SetPaymasterLimits(limits PaymasterLimits) {
+	if sp == nil {
+		return
+	}
+	sp.paymasterLimits = limits.Clone()
+}
+
+// PaymasterCounters aggregates the current usage metrics for the provided scope and day.
+func (sp *StateProcessor) PaymasterCounters(merchant, device, day string) (*PaymasterCounters, error) {
+	if sp == nil {
+		return nil, fmt.Errorf("state processor not initialised")
+	}
+	manager := nhbstate.NewManager(sp.Trie)
+	normalizedDay := nhbstate.NormalizePaymasterDay(day)
+	if normalizedDay == "" {
+		normalizedDay = sp.currentPaymasterDay()
+	}
+	normalizedMerchant := nhbstate.NormalizePaymasterMerchant(merchant)
+	normalizedDevice := nhbstate.NormalizePaymasterDevice(device)
+
+	snapshot := &PaymasterCounters{Day: normalizedDay, Merchant: normalizedMerchant, DeviceID: normalizedDevice}
+
+	if normalizedMerchant != "" {
+		merchantRecord, _, err := manager.PaymasterGetMerchantDay(normalizedMerchant, normalizedDay)
+		if err != nil {
+			return nil, err
+		}
+		if merchantRecord != nil {
+			snapshot.MerchantTxCount = merchantRecord.TxCount
+			snapshot.MerchantBudgetWei = new(big.Int).Set(merchantRecord.BudgetWei)
+			snapshot.MerchantChargedWei = new(big.Int).Set(merchantRecord.ChargedWei)
+		} else {
+			snapshot.MerchantBudgetWei = big.NewInt(0)
+			snapshot.MerchantChargedWei = big.NewInt(0)
+		}
+	} else {
+		snapshot.MerchantBudgetWei = big.NewInt(0)
+		snapshot.MerchantChargedWei = big.NewInt(0)
+	}
+
+	if normalizedMerchant != "" && normalizedDevice != "" {
+		deviceRecord, _, err := manager.PaymasterGetDeviceDay(normalizedMerchant, normalizedDevice, normalizedDay)
+		if err != nil {
+			return nil, err
+		}
+		if deviceRecord != nil {
+			snapshot.DeviceTxCount = deviceRecord.TxCount
+			snapshot.DeviceBudgetWei = new(big.Int).Set(deviceRecord.BudgetWei)
+			snapshot.DeviceChargedWei = new(big.Int).Set(deviceRecord.ChargedWei)
+		} else {
+			snapshot.DeviceBudgetWei = big.NewInt(0)
+			snapshot.DeviceChargedWei = big.NewInt(0)
+		}
+	} else {
+		snapshot.DeviceBudgetWei = big.NewInt(0)
+		snapshot.DeviceChargedWei = big.NewInt(0)
+	}
+
+	globalRecord, _, err := manager.PaymasterGetGlobalDay(normalizedDay)
+	if err != nil {
+		return nil, err
+	}
+	if globalRecord != nil {
+		snapshot.GlobalTxCount = globalRecord.TxCount
+		snapshot.GlobalBudgetWei = new(big.Int).Set(globalRecord.BudgetWei)
+		snapshot.GlobalChargedWei = new(big.Int).Set(globalRecord.ChargedWei)
+	} else {
+		snapshot.GlobalBudgetWei = big.NewInt(0)
+		snapshot.GlobalChargedWei = big.NewInt(0)
+	}
+
+	return snapshot, nil
 }

--- a/core/sponsorship_test.go
+++ b/core/sponsorship_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
+	"nhbchain/core/events"
+	nhbstate "nhbchain/core/state"
 	"nhbchain/core/types"
 	"nhbchain/crypto"
 	"nhbchain/storage"
@@ -192,5 +195,373 @@ func TestEvaluateSponsorship(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestEvaluateSponsorshipThrottling(t *testing.T) {
+	baseTime := time.Date(2024, time.January, 1, 12, 0, 0, 0, time.UTC)
+
+	paymasterKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate paymaster key: %v", err)
+	}
+	paymasterAddr := paymasterKey.PubKey().Address().Bytes()
+
+	type expect struct {
+		status SponsorshipStatus
+		scope  PaymasterThrottleScope
+	}
+
+	cases := []struct {
+		name   string
+		limits PaymasterLimits
+		setup  func(t *testing.T, sp *StateProcessor, tx *types.Transaction)
+		want   expect
+	}{
+		{
+			name: "within merchant cap",
+			limits: PaymasterLimits{
+				MerchantDailyCapWei: big.NewInt(100),
+				DeviceDailyTxCap:    5,
+				GlobalDailyCapWei:   big.NewInt(500),
+			},
+			setup: func(t *testing.T, sp *StateProcessor, tx *types.Transaction) {
+				manager := nhbstate.NewManager(sp.Trie)
+				day := sp.currentPaymasterDay()
+				merchant := nhbstate.NormalizePaymasterMerchant(tx.MerchantAddress)
+				if err := manager.PaymasterPutMerchantDay(&nhbstate.PaymasterMerchantDay{
+					Merchant:   merchant,
+					Day:        day,
+					TxCount:    1,
+					BudgetWei:  big.NewInt(90),
+					ChargedWei: big.NewInt(80),
+				}); err != nil {
+					t.Fatalf("seed merchant meter: %v", err)
+				}
+				if err := manager.PaymasterPutGlobalDay(&nhbstate.PaymasterGlobalDay{
+					Day:        day,
+					TxCount:    1,
+					BudgetWei:  big.NewInt(90),
+					ChargedWei: big.NewInt(80),
+				}); err != nil {
+					t.Fatalf("seed global meter: %v", err)
+				}
+			},
+			want: expect{status: SponsorshipStatusReady},
+		},
+		{
+			name: "merchant cap exceeded",
+			limits: PaymasterLimits{
+				MerchantDailyCapWei: big.NewInt(100),
+				DeviceDailyTxCap:    10,
+				GlobalDailyCapWei:   big.NewInt(1000),
+			},
+			setup: func(t *testing.T, sp *StateProcessor, tx *types.Transaction) {
+				manager := nhbstate.NewManager(sp.Trie)
+				day := sp.currentPaymasterDay()
+				merchant := nhbstate.NormalizePaymasterMerchant(tx.MerchantAddress)
+				if err := manager.PaymasterPutMerchantDay(&nhbstate.PaymasterMerchantDay{
+					Merchant:   merchant,
+					Day:        day,
+					TxCount:    3,
+					BudgetWei:  big.NewInt(95),
+					ChargedWei: big.NewInt(90),
+				}); err != nil {
+					t.Fatalf("seed merchant meter: %v", err)
+				}
+			},
+			want: expect{status: SponsorshipStatusThrottled, scope: PaymasterThrottleScopeMerchant},
+		},
+		{
+			name: "global cap exceeded",
+			limits: PaymasterLimits{
+				MerchantDailyCapWei: big.NewInt(1000),
+				DeviceDailyTxCap:    10,
+				GlobalDailyCapWei:   big.NewInt(100),
+			},
+			setup: func(t *testing.T, sp *StateProcessor, tx *types.Transaction) {
+				manager := nhbstate.NewManager(sp.Trie)
+				day := sp.currentPaymasterDay()
+				if err := manager.PaymasterPutGlobalDay(&nhbstate.PaymasterGlobalDay{
+					Day:        day,
+					TxCount:    5,
+					BudgetWei:  big.NewInt(95),
+					ChargedWei: big.NewInt(90),
+				}); err != nil {
+					t.Fatalf("seed global meter: %v", err)
+				}
+			},
+			want: expect{status: SponsorshipStatusThrottled, scope: PaymasterThrottleScopeGlobal},
+		},
+		{
+			name: "device cap exceeded",
+			limits: PaymasterLimits{
+				MerchantDailyCapWei: big.NewInt(1000),
+				DeviceDailyTxCap:    1,
+				GlobalDailyCapWei:   big.NewInt(1000),
+			},
+			setup: func(t *testing.T, sp *StateProcessor, tx *types.Transaction) {
+				manager := nhbstate.NewManager(sp.Trie)
+				day := sp.currentPaymasterDay()
+				merchant := nhbstate.NormalizePaymasterMerchant(tx.MerchantAddress)
+				device := nhbstate.NormalizePaymasterDevice(tx.DeviceID)
+				if err := manager.PaymasterPutDeviceDay(&nhbstate.PaymasterDeviceDay{
+					Merchant:   merchant,
+					DeviceID:   device,
+					Day:        day,
+					TxCount:    1,
+					BudgetWei:  big.NewInt(10),
+					ChargedWei: big.NewInt(10),
+				}); err != nil {
+					t.Fatalf("seed device meter: %v", err)
+				}
+			},
+			want: expect{status: SponsorshipStatusThrottled, scope: PaymasterThrottleScopeDevice},
+		},
+		{
+			name: "day rollover clears usage",
+			limits: PaymasterLimits{
+				MerchantDailyCapWei: big.NewInt(100),
+				DeviceDailyTxCap:    5,
+				GlobalDailyCapWei:   big.NewInt(100),
+			},
+			setup: func(t *testing.T, sp *StateProcessor, tx *types.Transaction) {
+				manager := nhbstate.NewManager(sp.Trie)
+				prior := baseTime.Add(-24 * time.Hour)
+				day := nhbstate.NormalizePaymasterDay(prior.Format(nhbstate.PaymasterDayFormat))
+				merchant := nhbstate.NormalizePaymasterMerchant(tx.MerchantAddress)
+				if err := manager.PaymasterPutMerchantDay(&nhbstate.PaymasterMerchantDay{
+					Merchant:   merchant,
+					Day:        day,
+					TxCount:    5,
+					BudgetWei:  big.NewInt(100),
+					ChargedWei: big.NewInt(100),
+				}); err != nil {
+					t.Fatalf("seed prior merchant meter: %v", err)
+				}
+				if err := manager.PaymasterPutGlobalDay(&nhbstate.PaymasterGlobalDay{
+					Day:        day,
+					TxCount:    5,
+					BudgetWei:  big.NewInt(100),
+					ChargedWei: big.NewInt(100),
+				}); err != nil {
+					t.Fatalf("seed prior global meter: %v", err)
+				}
+				sp.BeginBlock(1, baseTime.Add(24*time.Hour))
+			},
+			want: expect{status: SponsorshipStatusReady},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sp := newSponsorshipState(t)
+			sp.BeginBlock(1, baseTime)
+			sp.SetPaymasterLimits(tc.limits)
+
+			tx := &types.Transaction{
+				ChainID:         types.NHBChainID(),
+				Type:            types.TxTypeTransfer,
+				Nonce:           0,
+				To:              make([]byte, 20),
+				GasLimit:        10,
+				GasPrice:        big.NewInt(1),
+				MerchantAddress: "merchant-1",
+				DeviceID:        "device-1",
+			}
+
+			if err := sp.setAccount(paymasterAddr, &types.Account{BalanceNHB: big.NewInt(1_000_000)}); err != nil {
+				t.Fatalf("seed paymaster: %v", err)
+			}
+
+			tx.Paymaster = append([]byte(nil), paymasterAddr...)
+			signPaymaster(t, tx, paymasterKey)
+
+			if tc.setup != nil {
+				tc.setup(t, sp, tx)
+			}
+
+			assessment, err := sp.EvaluateSponsorship(tx)
+			if err != nil {
+				t.Fatalf("evaluate: %v", err)
+			}
+			if assessment.Status != tc.want.status {
+				t.Fatalf("expected status %s, got %s", tc.want.status, assessment.Status)
+			}
+			if tc.want.status == SponsorshipStatusThrottled {
+				if assessment.Throttle == nil {
+					t.Fatalf("expected throttle metadata")
+				}
+				if assessment.Throttle.Scope != tc.want.scope {
+					t.Fatalf("expected scope %s, got %s", tc.want.scope, assessment.Throttle.Scope)
+				}
+			} else if assessment.Throttle != nil {
+				t.Fatalf("unexpected throttle metadata for status %s", assessment.Status)
+			}
+		})
+	}
+}
+
+func TestPaymasterThrottledEventEmitted(t *testing.T) {
+	sp := newSponsorshipState(t)
+	blockTime := time.Date(2024, time.January, 2, 8, 0, 0, 0, time.UTC)
+	sp.BeginBlock(1, blockTime)
+
+	senderKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate sender key: %v", err)
+	}
+	senderAddr := senderKey.PubKey().Address().Bytes()
+
+	paymasterKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate paymaster key: %v", err)
+	}
+	paymasterAddr := paymasterKey.PubKey().Address().Bytes()
+
+	if err := sp.setAccount(paymasterAddr, &types.Account{BalanceNHB: big.NewInt(1_000_000)}); err != nil {
+		t.Fatalf("seed paymaster: %v", err)
+	}
+	if err := sp.setAccount(senderAddr, &types.Account{BalanceNHB: big.NewInt(1_000_000)}); err != nil {
+		t.Fatalf("seed sender: %v", err)
+	}
+
+	tx := &types.Transaction{
+		ChainID:         types.NHBChainID(),
+		Type:            types.TxTypeTransfer,
+		Nonce:           0,
+		To:              make([]byte, 20),
+		GasLimit:        21000,
+		GasPrice:        big.NewInt(1),
+		MerchantAddress: "merchant-2",
+		DeviceID:        "device-2",
+	}
+	tx.Paymaster = append([]byte(nil), paymasterAddr...)
+	signPaymaster(t, tx, paymasterKey)
+	signTransaction(t, tx, senderKey)
+
+	requiredBudget := new(big.Int).Mul(new(big.Int).SetUint64(tx.GasLimit), tx.GasPrice)
+	globalLimit := new(big.Int).Sub(requiredBudget, big.NewInt(1))
+	sp.SetPaymasterLimits(PaymasterLimits{
+		MerchantDailyCapWei: big.NewInt(1_000_000),
+		DeviceDailyTxCap:    10,
+		GlobalDailyCapWei:   globalLimit,
+	})
+
+	assessment, err := sp.EvaluateSponsorship(tx)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if assessment == nil || assessment.Status != SponsorshipStatusThrottled {
+		t.Fatalf("expected throttled assessment, got %+v", assessment)
+	}
+	txHash, err := tx.Hash()
+	if err != nil {
+		t.Fatalf("hash transaction: %v", err)
+	}
+	sp.emitSponsorshipFailureEvent(common.BytesToAddress(senderAddr), assessment, bytesToHash32(txHash))
+
+	eventsList := sp.Events()
+	found := false
+	for _, evt := range eventsList {
+		if evt.Type == events.TypePaymasterThrottled {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected paymaster throttled event in %+v", eventsList)
+	}
+}
+
+func TestPaymasterCountersAccumulate(t *testing.T) {
+	sp := newSponsorshipState(t)
+	blockTime := time.Date(2024, time.January, 3, 9, 0, 0, 0, time.UTC)
+	sp.BeginBlock(1, blockTime)
+
+	senderKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate sender key: %v", err)
+	}
+	senderAddr := senderKey.PubKey().Address().Bytes()
+
+	paymasterKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate paymaster key: %v", err)
+	}
+	paymasterAddr := paymasterKey.PubKey().Address().Bytes()
+
+	gasPrice := big.NewInt(2)
+	tx := &types.Transaction{
+		ChainID:         types.NHBChainID(),
+		Type:            types.TxTypeTransfer,
+		Nonce:           0,
+		To:              make([]byte, 20),
+		GasLimit:        21000,
+		GasPrice:        gasPrice,
+		MerchantAddress: "merchant-3",
+		DeviceID:        "device-3",
+	}
+	tx.Paymaster = append([]byte(nil), paymasterAddr...)
+	signTransaction(t, tx, senderKey)
+	signPaymaster(t, tx, paymasterKey)
+
+	if err := sp.setAccount(paymasterAddr, &types.Account{BalanceNHB: big.NewInt(1_000_000)}); err != nil {
+		t.Fatalf("seed paymaster: %v", err)
+	}
+	if err := sp.setAccount(senderAddr, &types.Account{BalanceNHB: big.NewInt(1_000_000)}); err != nil {
+		t.Fatalf("seed sender: %v", err)
+	}
+
+	sp.SetPaymasterLimits(PaymasterLimits{
+		MerchantDailyCapWei: big.NewInt(1_000_000_000),
+		DeviceDailyTxCap:    10,
+		GlobalDailyCapWei:   big.NewInt(1_000_000_000),
+	})
+
+	day := sp.currentPaymasterDay()
+	ctx := &sponsorshipRuntime{
+		merchant: nhbstate.NormalizePaymasterMerchant(tx.MerchantAddress),
+		device:   nhbstate.NormalizePaymasterDevice(tx.DeviceID),
+		day:      day,
+		gasPrice: new(big.Int).Set(gasPrice),
+		budget:   new(big.Int).Mul(new(big.Int).SetUint64(tx.GasLimit), gasPrice),
+	}
+	hash, err := tx.Hash()
+	if err != nil {
+		t.Fatalf("hash transaction: %v", err)
+	}
+	ctx.txHash = bytesToHash32(hash)
+	ctx.sponsor = common.BytesToAddress(paymasterAddr)
+	ctx.sender = common.BytesToAddress(senderAddr)
+
+	charged := new(big.Int).Set(ctx.budget)
+	if err := sp.recordPaymasterUsage(ctx, charged); err != nil {
+		t.Fatalf("record usage: %v", err)
+	}
+
+	snapshot, err := sp.PaymasterCounters(tx.MerchantAddress, tx.DeviceID, day)
+	if err != nil {
+		t.Fatalf("counters: %v", err)
+	}
+
+	expectedBudget := new(big.Int).Mul(new(big.Int).SetUint64(tx.GasLimit), gasPrice)
+	if snapshot.GlobalTxCount != 1 {
+		t.Fatalf("expected global tx count 1, got %d", snapshot.GlobalTxCount)
+	}
+	if snapshot.MerchantTxCount != 1 {
+		t.Fatalf("expected merchant tx count 1, got %d", snapshot.MerchantTxCount)
+	}
+	if snapshot.DeviceTxCount != 1 {
+		t.Fatalf("expected device tx count 1, got %d", snapshot.DeviceTxCount)
+	}
+	if snapshot.GlobalBudgetWei.Cmp(expectedBudget) != 0 {
+		t.Fatalf("expected global budget %s, got %s", expectedBudget, snapshot.GlobalBudgetWei)
+	}
+	if snapshot.MerchantBudgetWei.Cmp(expectedBudget) != 0 {
+		t.Fatalf("expected merchant budget %s, got %s", expectedBudget, snapshot.MerchantBudgetWei)
+	}
+	if snapshot.DeviceBudgetWei.Cmp(expectedBudget) != 0 {
+		t.Fatalf("expected device budget %s, got %s", expectedBudget, snapshot.DeviceBudgetWei)
 	}
 }

--- a/core/state/paymaster_counters.go
+++ b/core/state/paymaster_counters.go
@@ -1,0 +1,303 @@
+package state
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+)
+
+// PaymasterDayFormat defines the canonical layout for paymaster epoch days.
+const PaymasterDayFormat = "2006-01-02"
+
+var (
+	paymasterDeviceDayPrefix   = []byte("paymaster/counter/device/")
+	paymasterMerchantDayPrefix = []byte("paymaster/counter/merchant/")
+	paymasterGlobalDayPrefix   = []byte("paymaster/counter/global/")
+)
+
+// PaymasterDeviceDay captures the per-device sponsorship usage metrics for a single UTC day.
+type PaymasterDeviceDay struct {
+	Merchant   string
+	DeviceID   string
+	Day        string
+	TxCount    uint64
+	BudgetWei  *big.Int
+	ChargedWei *big.Int
+}
+
+// Clone returns a deep copy of the device day record.
+func (p *PaymasterDeviceDay) Clone() *PaymasterDeviceDay {
+	if p == nil {
+		return nil
+	}
+	clone := &PaymasterDeviceDay{
+		Merchant: NormalizePaymasterMerchant(p.Merchant),
+		DeviceID: NormalizePaymasterDevice(p.DeviceID),
+		Day:      NormalizePaymasterDay(p.Day),
+		TxCount:  p.TxCount,
+	}
+	if p.BudgetWei != nil {
+		clone.BudgetWei = new(big.Int).Set(p.BudgetWei)
+	}
+	if p.ChargedWei != nil {
+		clone.ChargedWei = new(big.Int).Set(p.ChargedWei)
+	}
+	ensurePaymasterDeviceDefaults(clone)
+	return clone
+}
+
+// PaymasterMerchantDay captures the per-merchant sponsorship usage metrics for a single UTC day.
+type PaymasterMerchantDay struct {
+	Merchant   string
+	Day        string
+	TxCount    uint64
+	BudgetWei  *big.Int
+	ChargedWei *big.Int
+}
+
+// Clone returns a deep copy of the merchant day record.
+func (p *PaymasterMerchantDay) Clone() *PaymasterMerchantDay {
+	if p == nil {
+		return nil
+	}
+	clone := &PaymasterMerchantDay{
+		Merchant: NormalizePaymasterMerchant(p.Merchant),
+		Day:      NormalizePaymasterDay(p.Day),
+		TxCount:  p.TxCount,
+	}
+	if p.BudgetWei != nil {
+		clone.BudgetWei = new(big.Int).Set(p.BudgetWei)
+	}
+	if p.ChargedWei != nil {
+		clone.ChargedWei = new(big.Int).Set(p.ChargedWei)
+	}
+	ensurePaymasterMerchantDefaults(clone)
+	return clone
+}
+
+// PaymasterGlobalDay captures the global sponsorship usage for a single UTC day.
+type PaymasterGlobalDay struct {
+	Day        string
+	TxCount    uint64
+	BudgetWei  *big.Int
+	ChargedWei *big.Int
+}
+
+// Clone returns a deep copy of the global day record.
+func (p *PaymasterGlobalDay) Clone() *PaymasterGlobalDay {
+	if p == nil {
+		return nil
+	}
+	clone := &PaymasterGlobalDay{
+		Day:     NormalizePaymasterDay(p.Day),
+		TxCount: p.TxCount,
+	}
+	if p.BudgetWei != nil {
+		clone.BudgetWei = new(big.Int).Set(p.BudgetWei)
+	}
+	if p.ChargedWei != nil {
+		clone.ChargedWei = new(big.Int).Set(p.ChargedWei)
+	}
+	ensurePaymasterGlobalDefaults(clone)
+	return clone
+}
+
+// NormalizePaymasterMerchant returns the canonical representation for the merchant identifier.
+func NormalizePaymasterMerchant(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	return strings.ToLower(trimmed)
+}
+
+// NormalizePaymasterDevice returns the canonical representation for the device identifier.
+func NormalizePaymasterDevice(value string) string {
+	return strings.TrimSpace(value)
+}
+
+// NormalizePaymasterDay normalises the day key to the canonical paymaster day format.
+func NormalizePaymasterDay(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	if parsed, err := time.Parse(PaymasterDayFormat, trimmed); err == nil {
+		return parsed.UTC().Format(PaymasterDayFormat)
+	}
+	return trimmed
+}
+
+func ensurePaymasterDeviceDefaults(record *PaymasterDeviceDay) {
+	if record == nil {
+		return
+	}
+	if record.BudgetWei == nil {
+		record.BudgetWei = big.NewInt(0)
+	}
+	if record.ChargedWei == nil {
+		record.ChargedWei = big.NewInt(0)
+	}
+	record.Merchant = NormalizePaymasterMerchant(record.Merchant)
+	record.DeviceID = NormalizePaymasterDevice(record.DeviceID)
+	record.Day = NormalizePaymasterDay(record.Day)
+}
+
+func ensurePaymasterMerchantDefaults(record *PaymasterMerchantDay) {
+	if record == nil {
+		return
+	}
+	if record.BudgetWei == nil {
+		record.BudgetWei = big.NewInt(0)
+	}
+	if record.ChargedWei == nil {
+		record.ChargedWei = big.NewInt(0)
+	}
+	record.Merchant = NormalizePaymasterMerchant(record.Merchant)
+	record.Day = NormalizePaymasterDay(record.Day)
+}
+
+func ensurePaymasterGlobalDefaults(record *PaymasterGlobalDay) {
+	if record == nil {
+		return
+	}
+	if record.BudgetWei == nil {
+		record.BudgetWei = big.NewInt(0)
+	}
+	if record.ChargedWei == nil {
+		record.ChargedWei = big.NewInt(0)
+	}
+	record.Day = NormalizePaymasterDay(record.Day)
+}
+
+func paymasterDeviceDayKey(merchant, device, day string) []byte {
+	merchantKey := NormalizePaymasterMerchant(merchant)
+	deviceKey := NormalizePaymasterDevice(device)
+	dayKey := NormalizePaymasterDay(day)
+	buf := make([]byte, len(paymasterDeviceDayPrefix)+len(dayKey)+1+len(merchantKey)+1+len(deviceKey))
+	copy(buf, paymasterDeviceDayPrefix)
+	offset := len(paymasterDeviceDayPrefix)
+	copy(buf[offset:], dayKey)
+	offset += len(dayKey)
+	buf[offset] = '/'
+	offset++
+	copy(buf[offset:], merchantKey)
+	offset += len(merchantKey)
+	buf[offset] = '/'
+	offset++
+	copy(buf[offset:], deviceKey)
+	return buf
+}
+
+func paymasterMerchantDayKey(merchant, day string) []byte {
+	merchantKey := NormalizePaymasterMerchant(merchant)
+	dayKey := NormalizePaymasterDay(day)
+	buf := make([]byte, len(paymasterMerchantDayPrefix)+len(dayKey)+1+len(merchantKey))
+	copy(buf, paymasterMerchantDayPrefix)
+	offset := len(paymasterMerchantDayPrefix)
+	copy(buf[offset:], dayKey)
+	offset += len(dayKey)
+	buf[offset] = '/'
+	offset++
+	copy(buf[offset:], merchantKey)
+	return buf
+}
+
+func paymasterGlobalDayKey(day string) []byte {
+	dayKey := NormalizePaymasterDay(day)
+	buf := make([]byte, len(paymasterGlobalDayPrefix)+len(dayKey))
+	copy(buf, paymasterGlobalDayPrefix)
+	copy(buf[len(paymasterGlobalDayPrefix):], dayKey)
+	return buf
+}
+
+// PaymasterGetDeviceDay retrieves the device usage record for the given merchant and day.
+func (m *Manager) PaymasterGetDeviceDay(merchant, device, day string) (*PaymasterDeviceDay, bool, error) {
+	if m == nil {
+		return nil, false, fmt.Errorf("state manager not initialised")
+	}
+	key := paymasterDeviceDayKey(merchant, device, day)
+	var stored PaymasterDeviceDay
+	ok, err := m.KVGet(key, &stored)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	ensurePaymasterDeviceDefaults(&stored)
+	return stored.Clone(), true, nil
+}
+
+// PaymasterPutDeviceDay stores the device usage record for the provided merchant and day.
+func (m *Manager) PaymasterPutDeviceDay(record *PaymasterDeviceDay) error {
+	if m == nil {
+		return fmt.Errorf("state manager not initialised")
+	}
+	if record == nil {
+		return fmt.Errorf("paymaster device record must not be nil")
+	}
+	ensurePaymasterDeviceDefaults(record)
+	return m.KVPut(paymasterDeviceDayKey(record.Merchant, record.DeviceID, record.Day), record)
+}
+
+// PaymasterGetMerchantDay retrieves the merchant usage record for the provided day.
+func (m *Manager) PaymasterGetMerchantDay(merchant, day string) (*PaymasterMerchantDay, bool, error) {
+	if m == nil {
+		return nil, false, fmt.Errorf("state manager not initialised")
+	}
+	key := paymasterMerchantDayKey(merchant, day)
+	var stored PaymasterMerchantDay
+	ok, err := m.KVGet(key, &stored)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	ensurePaymasterMerchantDefaults(&stored)
+	return stored.Clone(), true, nil
+}
+
+// PaymasterPutMerchantDay stores the merchant usage record for the provided day.
+func (m *Manager) PaymasterPutMerchantDay(record *PaymasterMerchantDay) error {
+	if m == nil {
+		return fmt.Errorf("state manager not initialised")
+	}
+	if record == nil {
+		return fmt.Errorf("paymaster merchant record must not be nil")
+	}
+	ensurePaymasterMerchantDefaults(record)
+	return m.KVPut(paymasterMerchantDayKey(record.Merchant, record.Day), record)
+}
+
+// PaymasterGetGlobalDay retrieves the global usage record for the provided day.
+func (m *Manager) PaymasterGetGlobalDay(day string) (*PaymasterGlobalDay, bool, error) {
+	if m == nil {
+		return nil, false, fmt.Errorf("state manager not initialised")
+	}
+	key := paymasterGlobalDayKey(day)
+	var stored PaymasterGlobalDay
+	ok, err := m.KVGet(key, &stored)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	ensurePaymasterGlobalDefaults(&stored)
+	return stored.Clone(), true, nil
+}
+
+// PaymasterPutGlobalDay stores the global usage record for the provided day.
+func (m *Manager) PaymasterPutGlobalDay(record *PaymasterGlobalDay) error {
+	if m == nil {
+		return fmt.Errorf("state manager not initialised")
+	}
+	if record == nil {
+		return fmt.Errorf("paymaster global record must not be nil")
+	}
+	ensurePaymasterGlobalDefaults(record)
+	return m.KVPut(paymasterGlobalDayKey(record.Day), record)
+}

--- a/docs/changelogs/POS-PAYMASTER-2.md
+++ b/docs/changelogs/POS-PAYMASTER-2.md
@@ -1,0 +1,10 @@
+# POS-PAYMASTER-2 — Caps & Abuse Guards
+
+## Summary
+- Added persistent paymaster counters scoped to merchant, device, and global budgets with daily rollovers.
+- Introduced configuration options for merchant NHB caps, per-device transaction limits, and a network-wide sponsorship ceiling.
+- Surfaced throttling events and RPC visibility for operators and provided operational guidance in the paymaster runbook.
+
+## Operator Actions
+- Review `docs/ops/paymaster.md` for budgeting examples and alerting practices.
+- Set `[global.paymaster]` caps in the node configuration and monitor counters for hot merchants/devices.

--- a/docs/ops/paymaster.md
+++ b/docs/ops/paymaster.md
@@ -1,0 +1,69 @@
+# Paymaster Sponsorship Guardrails
+
+The paymaster module can now enforce daily budgets at multiple scopes to prevent runaway fee sponsorship. Operators can configure caps, monitor usage, and react to throttling events using the guidance in this document.
+
+## Configuration
+
+The global configuration file exposes three knobs under `[global.paymaster]`:
+
+| Key | Description |
+| --- | --- |
+| `MerchantDailyCapWei` | Maximum NHB (wei) a merchant can sponsor across all devices in a UTC day. `0` disables the bound. |
+| `DeviceDailyTxCap` | Maximum number of sponsored transactions a single device may submit per day. `0` disables the bound. |
+| `GlobalDailyCapWei` | Network-wide NHB (wei) sponsorship budget per day. `0` disables the bound. |
+
+Values accept the same integer formats as other monetary fields (for example `250000000000000000000`, `250e18`). Update the TOML file and restart consensusd to apply changes:
+
+```toml
+[global.paymaster]
+MerchantDailyCapWei = "250e18"
+DeviceDailyTxCap = 200
+GlobalDailyCapWei = "1000e18"
+```
+
+## Budget Planning
+
+When sizing caps consider:
+
+* **Average ticket size**: Multiply the expected gas limit by the gas price to estimate per-transaction sponsorship cost.
+* **Device distribution**: Set `DeviceDailyTxCap` slightly above the peak per-terminal volume to catch abuse without harming legitimate traffic.
+* **Merchant spread**: Derive `MerchantDailyCapWei` by multiplying the average device spend by the number of active devices plus a safety margin.
+* **Network aggregate**: Ensure `GlobalDailyCapWei` comfortably exceeds the sum of merchant budgets so a single participant cannot starve the fleet.
+
+Example: if a POS transaction consumes ~25,000 gas at 1 gwei, each sponsorship costs `2.5e4 * 1e9 = 2.5e13 wei` (~0.000025 NHB). A merchant operating 40 lanes with a target of 1,500 transactions per lane could be capped at:
+
+```
+MerchantDailyCapWei = 40 lanes * 1,500 tx * 2.5e13 wei ≈ 1.5e18 wei (1.5 NHB)
+DeviceDailyTxCap   = 2,000
+GlobalDailyCapWei  = number_of_merchants * MerchantDailyCapWei * 1.2 safety factor
+```
+
+## Monitoring & Alerting
+
+* The node emits a `paymaster.throttled` event whenever a sponsorship attempt exceeds a cap. Attributes include the scope (`merchant`, `device`, or `global`), the day, and limit metadata.
+* Use the RPC method `transactions_sponsorshipCounters` to poll current usage. Example request:
+
+```json
+{
+  "method": "transactions_sponsorshipCounters",
+  "params": [{
+    "merchant": "merchant-1",
+    "deviceId": "device-12",
+    "day": "2024-05-19"
+  }]
+}
+```
+
+The response returns per-scope budgets (`budgetWei`), actual charges (`chargedWei`), and transaction counts for the day.
+
+Set alerts when usage approaches 80–90% of any cap so operators can increase limits or investigate abuse before throttling begins.
+
+## Troubleshooting
+
+If a merchant reports throttled terminals:
+
+1. Check the latest `paymaster.throttled` events to confirm the scope and cap involved.
+2. Query counters for the merchant/device/day via RPC to evaluate actual consumption.
+3. Adjust the relevant cap(s) in `[global.paymaster]` if the budget is too conservative, or contact the merchant if volume looks abnormal.
+
+Remember that caps reset at midnight UTC. Counter queries shortly after rollover should show zeroed metrics, confirming the guard reset.

--- a/rpc/modules/transactions.go
+++ b/rpc/modules/transactions.go
@@ -6,8 +6,10 @@ import (
 	"math/big"
 	"net/http"
 	"strings"
+	"time"
 
 	"nhbchain/core"
+	nhbstate "nhbchain/core/state"
 	"nhbchain/core/types"
 	"nhbchain/crypto"
 
@@ -26,12 +28,43 @@ func NewTransactionsModule(node *core.Node) *TransactionsModule {
 
 // SponsorshipPreviewResult summarises the sponsorship evaluation for a transaction payload.
 type SponsorshipPreviewResult struct {
-	Status            string `json:"status"`
-	Reason            string `json:"reason,omitempty"`
-	Sponsor           string `json:"sponsor,omitempty"`
-	GasPriceWei       string `json:"gasPriceWei,omitempty"`
-	RequiredBudgetWei string `json:"requiredBudgetWei,omitempty"`
-	ModuleEnabled     bool   `json:"moduleEnabled"`
+	Status            string                   `json:"status"`
+	Reason            string                   `json:"reason,omitempty"`
+	Sponsor           string                   `json:"sponsor,omitempty"`
+	GasPriceWei       string                   `json:"gasPriceWei,omitempty"`
+	RequiredBudgetWei string                   `json:"requiredBudgetWei,omitempty"`
+	ModuleEnabled     bool                     `json:"moduleEnabled"`
+	Throttle          *SponsorshipThrottleInfo `json:"throttle,omitempty"`
+}
+
+// SponsorshipThrottleInfo surfaces throttle metadata for a rejected sponsorship attempt.
+type SponsorshipThrottleInfo struct {
+	Scope         string `json:"scope"`
+	Merchant      string `json:"merchant,omitempty"`
+	DeviceID      string `json:"deviceId,omitempty"`
+	Day           string `json:"day,omitempty"`
+	LimitWei      string `json:"limitWei,omitempty"`
+	UsedBudgetWei string `json:"usedBudgetWei,omitempty"`
+	AttemptWei    string `json:"attemptBudgetWei,omitempty"`
+	TxCount       uint64 `json:"txCount,omitempty"`
+	LimitTxCount  uint64 `json:"limitTxCount,omitempty"`
+}
+
+// SponsorshipCounterTotals aggregates usage statistics for a scope.
+type SponsorshipCounterTotals struct {
+	BudgetWei  string `json:"budgetWei"`
+	ChargedWei string `json:"chargedWei"`
+	TxCount    uint64 `json:"txCount"`
+}
+
+// SponsorshipCountersResult summarises usage counters for the requested scope and day.
+type SponsorshipCountersResult struct {
+	Day            string                    `json:"day"`
+	Merchant       string                    `json:"merchant,omitempty"`
+	DeviceID       string                    `json:"deviceId,omitempty"`
+	MerchantTotals *SponsorshipCounterTotals `json:"merchantTotals,omitempty"`
+	DeviceTotals   *SponsorshipCounterTotals `json:"deviceTotals,omitempty"`
+	GlobalTotals   SponsorshipCounterTotals  `json:"globalTotals"`
 }
 
 // SponsorshipConfigResult describes the current module configuration.
@@ -43,6 +76,13 @@ type SponsorshipConfigResult struct {
 type setSponsorshipParams struct {
 	Caller  string `json:"caller"`
 	Enabled bool   `json:"enabled"`
+}
+
+// sponsorshipCountersParams captures optional filter inputs for counter queries.
+type sponsorshipCountersParams struct {
+	Merchant string `json:"merchant,omitempty"`
+	DeviceID string `json:"deviceId,omitempty"`
+	Day      string `json:"day,omitempty"`
 }
 
 // PreviewSponsorship returns the sponsorship assessment for the provided transaction payload without executing it.
@@ -74,8 +114,35 @@ func (m *TransactionsModule) PreviewSponsorship(raw json.RawMessage) (*Sponsorsh
 		if assessment.GasCost != nil {
 			result.RequiredBudgetWei = new(big.Int).Set(assessment.GasCost).String()
 		}
+		if assessment.Throttle != nil {
+			result.Throttle = encodeThrottle(assessment.Throttle)
+		}
 	}
 	return result, nil
+}
+
+func encodeThrottle(throttle *core.PaymasterThrottle) *SponsorshipThrottleInfo {
+	if throttle == nil {
+		return nil
+	}
+	info := &SponsorshipThrottleInfo{
+		Scope:        string(throttle.Scope),
+		Merchant:     throttle.Merchant,
+		DeviceID:     throttle.DeviceID,
+		Day:          throttle.Day,
+		TxCount:      throttle.TxCount,
+		LimitTxCount: throttle.LimitTxCount,
+	}
+	if throttle.LimitWei != nil {
+		info.LimitWei = new(big.Int).Set(throttle.LimitWei).String()
+	}
+	if throttle.UsedBudgetWei != nil {
+		info.UsedBudgetWei = new(big.Int).Set(throttle.UsedBudgetWei).String()
+	}
+	if throttle.AttemptBudgetWei != nil {
+		info.AttemptWei = new(big.Int).Set(throttle.AttemptBudgetWei).String()
+	}
+	return info
 }
 
 // SetSponsorshipEnabled updates the paymaster module status after verifying the caller is authorised.
@@ -112,4 +179,57 @@ func (m *TransactionsModule) SponsorshipConfig() (*SponsorshipConfigResult, *Mod
 		return nil, &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: "transactions module not initialised"}
 	}
 	return &SponsorshipConfigResult{Enabled: m.node.PaymasterModuleEnabled(), AdminRole: "ROLE_PAYMASTER_ADMIN"}, nil
+}
+
+// SponsorshipCounters returns usage counters for the requested scopes and day.
+func (m *TransactionsModule) SponsorshipCounters(raw json.RawMessage) (*SponsorshipCountersResult, *ModuleError) {
+	if m == nil || m.node == nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: "transactions module not initialised"}
+	}
+	var params sponsorshipCountersParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "invalid parameter object", Data: err.Error()}
+		}
+	}
+	day := strings.TrimSpace(params.Day)
+	if day == "" {
+		day = time.Now().UTC().Format(nhbstate.PaymasterDayFormat)
+	} else {
+		if _, err := time.Parse(nhbstate.PaymasterDayFormat, day); err != nil {
+			return nil, &ModuleError{HTTPStatus: http.StatusBadRequest, Code: codeInvalidParams, Message: "invalid day format", Data: err.Error()}
+		}
+	}
+	snapshot, err := m.node.PaymasterCounters(params.Merchant, params.DeviceID, day)
+	if err != nil {
+		return nil, &ModuleError{HTTPStatus: http.StatusInternalServerError, Code: codeServerError, Message: err.Error()}
+	}
+	result := &SponsorshipCountersResult{Day: snapshot.Day, Merchant: snapshot.Merchant, DeviceID: snapshot.DeviceID}
+	result.GlobalTotals = SponsorshipCounterTotals{
+		BudgetWei:  bigIntToString(snapshot.GlobalBudgetWei),
+		ChargedWei: bigIntToString(snapshot.GlobalChargedWei),
+		TxCount:    snapshot.GlobalTxCount,
+	}
+	if snapshot.Merchant != "" {
+		result.MerchantTotals = &SponsorshipCounterTotals{
+			BudgetWei:  bigIntToString(snapshot.MerchantBudgetWei),
+			ChargedWei: bigIntToString(snapshot.MerchantChargedWei),
+			TxCount:    snapshot.MerchantTxCount,
+		}
+	}
+	if snapshot.Merchant != "" && snapshot.DeviceID != "" {
+		result.DeviceTotals = &SponsorshipCounterTotals{
+			BudgetWei:  bigIntToString(snapshot.DeviceBudgetWei),
+			ChargedWei: bigIntToString(snapshot.DeviceChargedWei),
+			TxCount:    snapshot.DeviceTxCount,
+		}
+	}
+	return result, nil
+}
+
+func bigIntToString(value *big.Int) string {
+	if value == nil {
+		return "0"
+	}
+	return new(big.Int).Set(value).String()
 }


### PR DESCRIPTION
## Summary
- add persistent paymaster sponsorship counters with state helpers and enforcement in the sponsorship pipeline
- wire new paymaster throttling configuration through node/CLI surfaces and expose counter snapshots over RPC
- document operator workflows for sizing caps and create a changelog entry for POS-PAYMASTER-2

## Testing
- go test ./core -run TestPaymaster

------
https://chatgpt.com/codex/tasks/task_e_68e371d5f914832db4f0383692f19e67