### PR TITLE
feat(pos): add payment lifecycle engine

### DIFF
--- a/core/events/payments.go
+++ b/core/events/payments.go
@@ -2,6 +2,8 @@ package events
 
 import (
 	"encoding/hex"
+	"math/big"
+	"strconv"
 	"strings"
 
 	"nhbchain/core/types"
@@ -11,6 +13,15 @@ const (
 	// TypePaymentIntentConsumed is emitted once a POS payment intent reference
 	// is successfully consumed on-chain.
 	TypePaymentIntentConsumed = "payments.intent_consumed"
+	// TypePaymentAuthorized is emitted when funds are locked for a POS
+	// authorization.
+	TypePaymentAuthorized = "payments.authorized"
+	// TypePaymentCaptured is emitted after an authorization is successfully
+	// captured and the funds transferred to the merchant.
+	TypePaymentCaptured = "payments.captured"
+	// TypePaymentVoided marks authorizations that returned funds to the
+	// payer either manually or due to expiry.
+	TypePaymentVoided = "payments.voided"
 )
 
 // PaymentIntentConsumed represents a point-of-sale payment intent that has been
@@ -45,6 +56,119 @@ func (e PaymentIntentConsumed) Event() *types.Event {
 	return &types.Event{Type: TypePaymentIntentConsumed, Attributes: attrs}
 }
 
+// PaymentAuthorized summarises a newly created payment authorization that has
+// locked funds on the payer account.
+type PaymentAuthorized struct {
+	AuthorizationID [32]byte
+	Payer           [20]byte
+	Merchant        [20]byte
+	Amount          *big.Int
+	Expiry          uint64
+	IntentRef       []byte
+}
+
+// EventType satisfies the events.Event interface.
+func (PaymentAuthorized) EventType() string { return TypePaymentAuthorized }
+
+// Event converts the structured payload into a wire-friendly representation.
+func (e PaymentAuthorized) Event() *types.Event {
+	if zeroBytes(e.AuthorizationID[:]) {
+		return nil
+	}
+	attrs := map[string]string{
+		"authorizationId": hex.EncodeToString(e.AuthorizationID[:]),
+	}
+	if !zeroBytes(e.Payer[:]) {
+		attrs["payer"] = hex.EncodeToString(e.Payer[:])
+	}
+	if !zeroBytes(e.Merchant[:]) {
+		attrs["merchant"] = hex.EncodeToString(e.Merchant[:])
+	}
+	if e.Amount != nil {
+		attrs["amount"] = e.Amount.String()
+	}
+	if e.Expiry != 0 {
+		attrs["expiry"] = strconv.FormatUint(e.Expiry, 10)
+	}
+	if len(e.IntentRef) > 0 {
+		attrs["intentRef"] = hex.EncodeToString(e.IntentRef)
+	}
+	return &types.Event{Type: TypePaymentAuthorized, Attributes: attrs}
+}
+
+// PaymentCaptured reports a successful capture event for a payment
+// authorization.
+type PaymentCaptured struct {
+	AuthorizationID [32]byte
+	Payer           [20]byte
+	Merchant        [20]byte
+	CapturedAmount  *big.Int
+	RefundedAmount  *big.Int
+}
+
+// EventType satisfies the events.Event interface.
+func (PaymentCaptured) EventType() string { return TypePaymentCaptured }
+
+// Event converts the capture payload into a broadcastable event.
+func (e PaymentCaptured) Event() *types.Event {
+	if zeroBytes(e.AuthorizationID[:]) {
+		return nil
+	}
+	attrs := map[string]string{
+		"authorizationId": hex.EncodeToString(e.AuthorizationID[:]),
+	}
+	if !zeroBytes(e.Payer[:]) {
+		attrs["payer"] = hex.EncodeToString(e.Payer[:])
+	}
+	if !zeroBytes(e.Merchant[:]) {
+		attrs["merchant"] = hex.EncodeToString(e.Merchant[:])
+	}
+	if e.CapturedAmount != nil {
+		attrs["capturedAmount"] = e.CapturedAmount.String()
+	}
+	if e.RefundedAmount != nil {
+		attrs["refundedAmount"] = e.RefundedAmount.String()
+	}
+	return &types.Event{Type: TypePaymentCaptured, Attributes: attrs}
+}
+
+// PaymentVoided records the release of an authorization lock back to the payer.
+type PaymentVoided struct {
+	AuthorizationID [32]byte
+	Payer           [20]byte
+	Merchant        [20]byte
+	RefundedAmount  *big.Int
+	Reason          string
+	Expired         bool
+}
+
+// EventType satisfies the events.Event interface.
+func (PaymentVoided) EventType() string { return TypePaymentVoided }
+
+// Event converts the void payload into a broadcastable event.
+func (e PaymentVoided) Event() *types.Event {
+	if zeroBytes(e.AuthorizationID[:]) {
+		return nil
+	}
+	attrs := map[string]string{
+		"authorizationId": hex.EncodeToString(e.AuthorizationID[:]),
+		"expired":         strconv.FormatBool(e.Expired),
+	}
+	if !zeroBytes(e.Payer[:]) {
+		attrs["payer"] = hex.EncodeToString(e.Payer[:])
+	}
+	if !zeroBytes(e.Merchant[:]) {
+		attrs["merchant"] = hex.EncodeToString(e.Merchant[:])
+	}
+	if e.RefundedAmount != nil {
+		attrs["refundedAmount"] = e.RefundedAmount.String()
+	}
+	if reason := strings.TrimSpace(e.Reason); reason != "" {
+		attrs["reason"] = reason
+	}
+	return &types.Event{Type: TypePaymentVoided, Attributes: attrs}
+}
+
 func withHexPrefix(raw []byte) string {
 	if len(raw) == 0 {
 		return ""
@@ -54,4 +178,13 @@ func withHexPrefix(raw []byte) string {
 		return ""
 	}
 	return "0x" + encoded
+}
+
+func zeroBytes(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/docs/changelogs/POS-LIFECYCLE-5.md
+++ b/docs/changelogs/POS-LIFECYCLE-5.md
@@ -1,0 +1,16 @@
+# POS-LIFECYCLE-5
+
+## Summary
+
+* Added a POS payment lifecycle engine that supports authorizing, capturing, and
+  voiding ZapNHB transactions with automatic expiry handling.
+* Emitted structured events for authorization, capture, and void milestones to
+  keep downstream services synchronized.
+* Documented the lifecycle, error codes, and new RPC messages in
+  `docs/specs/pos-lifecycle.md`.
+* Introduced unit tests covering partial captures, double-capture rejection, and
+  automatic voiding on expiry.
+
+## Testing
+
+* `go test ./native/pos...`

--- a/docs/specs/pos-lifecycle.md
+++ b/docs/specs/pos-lifecycle.md
@@ -1,0 +1,111 @@
+# POS-LIFECYCLE-5: Card-Style Payment Authorization
+
+## Overview
+
+This task introduces a card-style lifecycle for point-of-sale (POS) payments.
+Merchants can lock ZapNHB from a payer, capture any amount up to the locked
+value, or void the authorization to return funds. Expired authorizations are
+voided automatically to guarantee balances are restored without manual
+intervention.
+
+Key additions include:
+
+* A lifecycle engine that manages authorizations, captures, and voids while
+  updating account balances atomically.
+* Events emitted for each lifecycle milestone so downstream services can track
+  payments in real time.
+* New RPC messages that expose authorization, capture, and void entry points.
+* Documentation of timing guarantees, error codes, and state transitions.
+
+## Lifecycle flow
+
+```mermaid
+graph TD
+    A[Authorize] -->|lock funds| B[Pending]
+    B -->|Capture <= amount| C[Captured]
+    B -->|Void| D[Voided]
+    B -->|Expiry reached| E[Expired]
+    C -->|Emit payments.captured| F[Merchant credited]
+    D -->|Emit payments.voided| G[Payer refunded]
+    E -->|Emit payments.voided(expired)| G
+```
+
+* **Authorize**: Locks the requested ZapNHB in `LockedZNHB` and records an
+  authorization ID tied to the payer, merchant, amount, expiry, and optional
+  `intent_ref`.
+* **Capture**: Transfers any amount up to the authorized total to the merchant
+  account. Remaining funds are returned to the payer in the same transaction.
+* **Void**: Releases the entire lock back to the payer. This can be triggered
+  manually via `MsgVoidPayment` or automatically when the expiry timestamp is
+  reached.
+
+## Message schema
+
+| Message | Description |
+| --- | --- |
+| `MsgAuthorizePayment` | Locks ZapNHB on the payer account. Returns `authorization_id`. |
+| `MsgCapturePayment` | Captures up to the locked amount, refunding any remainder. |
+| `MsgVoidPayment` | Manually voids an authorization prior to capture. |
+
+All amounts are decimal strings representing ZapNHB. Timestamps are UNIX seconds.
+
+## State transitions
+
+Authorizations are stored beneath the `pos/auth/<id>` namespace. Each record
+tracks the total amount, captured portion, refunded portion, current status, and
+metadata such as expiry and reason strings for voids. Per-payer counters ensure
+authorization IDs remain unique while keeping them deterministic (hash of payer
+address and nonce).
+
+Account updates are atomic:
+
+1. **Authorize**: `BalanceZNHB -= amount`; `LockedZNHB += amount`.
+2. **Capture**: `LockedZNHB -= amount_authorized`; merchant `BalanceZNHB +=
+   amount_captured`; payer `BalanceZNHB += remainder`.
+3. **Void / Expire**: `LockedZNHB -= amount_authorized`; payer `BalanceZNHB +=
+   amount_authorized`.
+
+If any persistence step fails, balances are rolled back to the pre-operation
+state before the error is returned.
+
+## Timing and expiry
+
+* Authorizations must specify an expiry strictly greater than the block
+  timestamp that executes the authorize message.
+* Captures after the expiry automatically void the authorization, emitting a
+  `payments.voided` event with `expired=true` and returning the funds.
+* Manual voids leave the authorization record in `voided` status so idempotent
+  retries do not fail.
+
+## Errors
+
+| Error | Condition |
+| --- | --- |
+| `pos: lifecycle not initialised` | Lifecycle engine configured without state. |
+| `pos: address required` | Payer or merchant address was missing/zeroed. |
+| `pos: amount must be positive` | Amount was zero or negative. |
+| `pos: insufficient balance` | Payer lacks enough ZapNHB to lock. |
+| `pos: authorization expired` | Authorization expired before capture. |
+| `pos: authorization already captured` | Attempted double capture. |
+| `pos: authorization voided` | Capture attempted after a manual void. |
+| `pos: authorization not found` | Unknown authorization ID. |
+
+## Events
+
+| Event | Payload |
+| --- | --- |
+| `payments.authorized` | `authorizationId`, `payer`, `merchant`, `amount`, `expiry`, optional `intentRef`. |
+| `payments.captured` | `authorizationId`, `payer`, `merchant`, `capturedAmount`, `refundedAmount`. |
+| `payments.voided` | `authorizationId`, `payer`, `merchant`, `refundedAmount`, `reason`, `expired`. |
+
+Events are emitted even when voided automatically so settlement systems can
+resolve outstanding holds.
+
+## Integration points
+
+* **RPC**: The new messages are exposed via the `pos.v1.Tx` service defined in
+  `proto/pos/tx.proto`.
+* **Testing**: Unit tests cover partial capture, double-capture rejection, and
+  automatic expiry handling.
+* **Telemetry**: Existing payment processors can subscribe to the new event
+  types to synchronize state with NHBChain.

--- a/native/pos/auth.go
+++ b/native/pos/auth.go
@@ -1,0 +1,544 @@
+package pos
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"strings"
+	"time"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	"nhbchain/core/events"
+	"nhbchain/core/types"
+)
+
+// lifecycleState abstracts the subset of state manager functionality required by
+// the POS payment lifecycle engine.
+type lifecycleState interface {
+	KVGet(key []byte, out interface{}) (bool, error)
+	KVPut(key []byte, value interface{}) error
+	KVDelete(key []byte) error
+	GetAccount(addr []byte) (*types.Account, error)
+	PutAccount(addr []byte, account *types.Account) error
+}
+
+var (
+	authorizationPrefix    = []byte("pos/auth/")
+	authorizationNoncePref = []byte("pos/auth/nonce/")
+)
+
+// AuthorizationStatus captures the lifecycle state for a payment authorization.
+type AuthorizationStatus uint8
+
+const (
+	// AuthorizationStatusPending marks an authorization that still holds a
+	// locked balance and may be captured or voided.
+	AuthorizationStatusPending AuthorizationStatus = iota
+	// AuthorizationStatusCaptured indicates the authorization was captured
+	// and the locked balance transferred to the merchant.
+	AuthorizationStatusCaptured
+	// AuthorizationStatusVoided marks authorizations that were manually
+	// voided before capture, returning the locked balance to the payer.
+	AuthorizationStatusVoided
+	// AuthorizationStatusExpired marks authorizations that expired before
+	// capture. The locked balance has been returned to the payer.
+	AuthorizationStatusExpired
+)
+
+// Authorization represents a locked POS payment authorization tracked on-chain.
+type Authorization struct {
+	ID             [32]byte
+	Payer          [20]byte
+	Merchant       [20]byte
+	Amount         *big.Int
+	CapturedAmount *big.Int
+	RefundedAmount *big.Int
+	Expiry         uint64
+	IntentRef      []byte
+	Status         AuthorizationStatus
+	CreatedAt      uint64
+	UpdatedAt      uint64
+	VoidReason     string
+}
+
+// Clone returns a deep copy of the authorization to avoid mutating shared
+// pointers.
+func (a *Authorization) Clone() *Authorization {
+	if a == nil {
+		return nil
+	}
+	clone := *a
+	if a.Amount != nil {
+		clone.Amount = new(big.Int).Set(a.Amount)
+	}
+	if a.CapturedAmount != nil {
+		clone.CapturedAmount = new(big.Int).Set(a.CapturedAmount)
+	}
+	if a.RefundedAmount != nil {
+		clone.RefundedAmount = new(big.Int).Set(a.RefundedAmount)
+	}
+	clone.IntentRef = append([]byte(nil), a.IntentRef...)
+	return &clone
+}
+
+// Lifecycle orchestrates the authorization/capture/void flow for card-like POS
+// transactions.
+type Lifecycle struct {
+	state   lifecycleState
+	emitter events.Emitter
+	nowFn   func() time.Time
+}
+
+// NewLifecycle constructs a lifecycle engine bound to the provided state
+// backend.
+func NewLifecycle(state lifecycleState) *Lifecycle {
+	return &Lifecycle{
+		state:   state,
+		emitter: events.NoopEmitter{},
+		nowFn:   func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// SetEmitter overrides the event emitter used by the lifecycle engine.
+func (l *Lifecycle) SetEmitter(emitter events.Emitter) {
+	if l == nil {
+		return
+	}
+	if emitter == nil {
+		l.emitter = events.NoopEmitter{}
+		return
+	}
+	l.emitter = emitter
+}
+
+// SetNowFunc overrides the time source used for expiry checks. Passing nil
+// restores the default UTC clock.
+func (l *Lifecycle) SetNowFunc(now func() time.Time) {
+	if l == nil {
+		return
+	}
+	if now == nil {
+		l.nowFn = func() time.Time { return time.Now().UTC() }
+		return
+	}
+	l.nowFn = now
+}
+
+var (
+	errLifecycleUninitialised    = errors.New("pos: lifecycle not initialised")
+	errAuthorizationNotFound     = errors.New("pos: authorization not found")
+	errAuthorizationConsumed     = errors.New("pos: authorization already captured")
+	errAuthorizationVoided       = errors.New("pos: authorization voided")
+	errAuthorizationExpired      = errors.New("pos: authorization expired")
+	errAuthorizationInvalidAddr  = errors.New("pos: address required")
+	errAuthorizationInvalidAmt   = errors.New("pos: amount must be positive")
+	errAuthorizationInsufficient = errors.New("pos: insufficient balance")
+)
+
+// Authorize locks the supplied ZapNHB amount on the payer account and records a
+// payment authorization that can later be captured or voided.
+func (l *Lifecycle) Authorize(payer, merchant [20]byte, amount *big.Int, expiry uint64, intentRef []byte) (*Authorization, error) {
+	if l == nil || l.state == nil {
+		return nil, errLifecycleUninitialised
+	}
+	if isZeroAddress(payer[:]) {
+		return nil, errAuthorizationInvalidAddr
+	}
+	if isZeroAddress(merchant[:]) {
+		return nil, errAuthorizationInvalidAddr
+	}
+	if amount == nil || amount.Sign() <= 0 {
+		return nil, errAuthorizationInvalidAmt
+	}
+	now := l.nowFn().UTC()
+	if expiry == 0 || uint64(now.Unix()) >= expiry {
+		return nil, errAuthorizationExpired
+	}
+	payerAcc, err := l.state.GetAccount(payer[:])
+	if err != nil {
+		return nil, err
+	}
+	payerAcc = cloneAccount(payerAcc)
+	if payerAcc.BalanceZNHB.Cmp(amount) < 0 {
+		return nil, errAuthorizationInsufficient
+	}
+	payerAcc.BalanceZNHB = new(big.Int).Sub(payerAcc.BalanceZNHB, amount)
+	payerAcc.LockedZNHB = new(big.Int).Add(payerAcc.LockedZNHB, amount)
+	if err := l.state.PutAccount(payer[:], payerAcc); err != nil {
+		return nil, err
+	}
+	authID, nonce, err := l.nextAuthorizationID(payer)
+	if err != nil {
+		// restore balance changes before returning
+		payerAcc.BalanceZNHB = new(big.Int).Add(payerAcc.BalanceZNHB, amount)
+		payerAcc.LockedZNHB = new(big.Int).Sub(payerAcc.LockedZNHB, amount)
+		_ = l.state.PutAccount(payer[:], payerAcc)
+		return nil, err
+	}
+	rollback := func() {
+		l.revertAuthorizationNonce(payer, nonce)
+		payerAcc.BalanceZNHB = new(big.Int).Add(payerAcc.BalanceZNHB, amount)
+		payerAcc.LockedZNHB = new(big.Int).Sub(payerAcc.LockedZNHB, amount)
+		_ = l.state.PutAccount(payer[:], payerAcc)
+	}
+	record := &Authorization{
+		ID:             authID,
+		Payer:          payer,
+		Merchant:       merchant,
+		Amount:         new(big.Int).Set(amount),
+		CapturedAmount: big.NewInt(0),
+		RefundedAmount: big.NewInt(0),
+		Expiry:         expiry,
+		IntentRef:      append([]byte(nil), intentRef...),
+		Status:         AuthorizationStatusPending,
+		CreatedAt:      uint64(now.Unix()),
+		UpdatedAt:      uint64(now.Unix()),
+	}
+	if err := l.persistAuthorization(record); err != nil {
+		rollback()
+		return nil, err
+	}
+	l.emitter.Emit(events.PaymentAuthorized{
+		AuthorizationID: authID,
+		Payer:           payer,
+		Merchant:        merchant,
+		Amount:          new(big.Int).Set(amount),
+		Expiry:          expiry,
+		IntentRef:       append([]byte(nil), intentRef...),
+	})
+	return record.Clone(), nil
+}
+
+// Capture transfers the locked funds to the merchant, optionally releasing any
+// remaining authorization amount back to the payer when capturing less than the
+// authorized total.
+func (l *Lifecycle) Capture(id [32]byte, amount *big.Int) (*Authorization, error) {
+	if l == nil || l.state == nil {
+		return nil, errLifecycleUninitialised
+	}
+	if amount == nil || amount.Sign() <= 0 {
+		return nil, errAuthorizationInvalidAmt
+	}
+	auth, err := l.loadAuthorization(id)
+	if err != nil {
+		return nil, err
+	}
+	if auth.Status == AuthorizationStatusCaptured {
+		return nil, errAuthorizationConsumed
+	}
+	if auth.Status == AuthorizationStatusVoided {
+		return nil, errAuthorizationVoided
+	}
+	if auth.Status == AuthorizationStatusExpired {
+		return nil, errAuthorizationExpired
+	}
+	now := l.nowFn().UTC()
+	if uint64(now.Unix()) >= auth.Expiry {
+		updated, err := l.autoVoid(auth, AuthorizationStatusExpired, "expired")
+		if err != nil {
+			return nil, err
+		}
+		return updated, errAuthorizationExpired
+	}
+	if amount.Cmp(auth.Amount) > 0 {
+		return nil, fmt.Errorf("pos: capture exceeds authorization")
+	}
+	payerAcc, err := l.state.GetAccount(auth.Payer[:])
+	if err != nil {
+		return nil, err
+	}
+	merchantAcc, err := l.state.GetAccount(auth.Merchant[:])
+	if err != nil {
+		return nil, err
+	}
+	payerAcc = cloneAccount(payerAcc)
+	merchantAcc = cloneAccount(merchantAcc)
+	if payerAcc.LockedZNHB.Cmp(auth.Amount) < 0 {
+		return nil, fmt.Errorf("pos: locked balance inconsistent")
+	}
+	refund := new(big.Int).Sub(auth.Amount, amount)
+	payerAcc.LockedZNHB = new(big.Int).Sub(payerAcc.LockedZNHB, auth.Amount)
+	if refund.Sign() > 0 {
+		payerAcc.BalanceZNHB = new(big.Int).Add(payerAcc.BalanceZNHB, refund)
+	}
+	merchantAcc.BalanceZNHB = new(big.Int).Add(merchantAcc.BalanceZNHB, amount)
+	if err := l.state.PutAccount(auth.Payer[:], payerAcc); err != nil {
+		return nil, err
+	}
+	if err := l.state.PutAccount(auth.Merchant[:], merchantAcc); err != nil {
+		return nil, err
+	}
+	auth.Status = AuthorizationStatusCaptured
+	auth.CapturedAmount = new(big.Int).Set(amount)
+	auth.RefundedAmount = new(big.Int).Set(refund)
+	auth.UpdatedAt = uint64(now.Unix())
+	auth.VoidReason = ""
+	if err := l.persistAuthorization(auth); err != nil {
+		// best-effort rollback; balances restored to previous state
+		payerAcc.LockedZNHB = new(big.Int).Add(payerAcc.LockedZNHB, auth.Amount)
+		if refund.Sign() > 0 {
+			payerAcc.BalanceZNHB = new(big.Int).Sub(payerAcc.BalanceZNHB, refund)
+		}
+		_ = l.state.PutAccount(auth.Payer[:], payerAcc)
+		merchantAcc.BalanceZNHB = new(big.Int).Sub(merchantAcc.BalanceZNHB, amount)
+		_ = l.state.PutAccount(auth.Merchant[:], merchantAcc)
+		return nil, err
+	}
+	l.emitter.Emit(events.PaymentCaptured{
+		AuthorizationID: auth.ID,
+		Payer:           auth.Payer,
+		Merchant:        auth.Merchant,
+		CapturedAmount:  new(big.Int).Set(amount),
+		RefundedAmount:  new(big.Int).Set(refund),
+	})
+	return auth.Clone(), nil
+}
+
+// Void releases the locked funds back to the payer. The reason string is
+// recorded for analytics and defaults to "manual" when empty.
+func (l *Lifecycle) Void(id [32]byte, reason string) (*Authorization, error) {
+	if l == nil || l.state == nil {
+		return nil, errLifecycleUninitialised
+	}
+	auth, err := l.loadAuthorization(id)
+	if err != nil {
+		return nil, err
+	}
+	if auth.Status == AuthorizationStatusCaptured {
+		return nil, errAuthorizationConsumed
+	}
+	if auth.Status == AuthorizationStatusVoided {
+		return auth.Clone(), nil
+	}
+	if auth.Status == AuthorizationStatusExpired {
+		return auth.Clone(), nil
+	}
+	status := AuthorizationStatusVoided
+	if strings.TrimSpace(reason) == "" {
+		reason = "manual"
+	}
+	updated, err := l.autoVoid(auth, status, reason)
+	if err != nil {
+		return nil, err
+	}
+	return updated.Clone(), nil
+}
+
+// autoVoid releases the locked balance and persists the voided authorization
+// with the provided status and reason.
+func (l *Lifecycle) autoVoid(auth *Authorization, status AuthorizationStatus, reason string) (*Authorization, error) {
+	if auth == nil {
+		return nil, errAuthorizationNotFound
+	}
+	payerAcc, err := l.state.GetAccount(auth.Payer[:])
+	if err != nil {
+		return nil, err
+	}
+	payerAcc = cloneAccount(payerAcc)
+	if payerAcc.LockedZNHB.Cmp(auth.Amount) < 0 {
+		return nil, fmt.Errorf("pos: locked balance inconsistent")
+	}
+	payerAcc.LockedZNHB = new(big.Int).Sub(payerAcc.LockedZNHB, auth.Amount)
+	payerAcc.BalanceZNHB = new(big.Int).Add(payerAcc.BalanceZNHB, auth.Amount)
+	if err := l.state.PutAccount(auth.Payer[:], payerAcc); err != nil {
+		return nil, err
+	}
+	now := l.nowFn().UTC()
+	auth.Status = status
+	auth.CapturedAmount = big.NewInt(0)
+	auth.RefundedAmount = new(big.Int).Set(auth.Amount)
+	auth.UpdatedAt = uint64(now.Unix())
+	auth.VoidReason = strings.TrimSpace(reason)
+	if err := l.persistAuthorization(auth); err != nil {
+		payerAcc.LockedZNHB = new(big.Int).Add(payerAcc.LockedZNHB, auth.Amount)
+		payerAcc.BalanceZNHB = new(big.Int).Sub(payerAcc.BalanceZNHB, auth.Amount)
+		_ = l.state.PutAccount(auth.Payer[:], payerAcc)
+		return nil, err
+	}
+	l.emitter.Emit(events.PaymentVoided{
+		AuthorizationID: auth.ID,
+		Payer:           auth.Payer,
+		Merchant:        auth.Merchant,
+		RefundedAmount:  new(big.Int).Set(auth.Amount),
+		Reason:          auth.VoidReason,
+		Expired:         status == AuthorizationStatusExpired,
+	})
+	return auth, nil
+}
+
+func (l *Lifecycle) loadAuthorization(id [32]byte) (*Authorization, error) {
+	if l == nil || l.state == nil {
+		return nil, errLifecycleUninitialised
+	}
+	var stored storedAuthorization
+	ok, err := l.state.KVGet(authorizationKey(id), &stored)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errAuthorizationNotFound
+	}
+	record := stored.toAuthorization()
+	return record, nil
+}
+
+func (l *Lifecycle) persistAuthorization(auth *Authorization) error {
+	if l == nil || l.state == nil {
+		return errLifecycleUninitialised
+	}
+	stored := newStoredAuthorization(auth)
+	return l.state.KVPut(authorizationKey(auth.ID), stored)
+}
+
+func (l *Lifecycle) nextAuthorizationID(payer [20]byte) ([32]byte, uint64, error) {
+	var counter storedAuthorizationNonce
+	key := authorizationNonceKey(payer)
+	ok, err := l.state.KVGet(key, &counter)
+	if err != nil {
+		return [32]byte{}, 0, err
+	}
+	nonce := counter.Counter
+	if !ok {
+		nonce = 0
+	}
+	if nonce == math.MaxUint64 {
+		return [32]byte{}, 0, fmt.Errorf("pos: authorization nonce overflow")
+	}
+	buf := make([]byte, len(payer)+8)
+	copy(buf, payer[:])
+	binary.BigEndian.PutUint64(buf[len(payer):], nonce)
+	hash := ethcrypto.Keccak256(buf)
+	var id [32]byte
+	copy(id[:], hash)
+	counter.Counter = nonce + 1
+	if err := l.state.KVPut(key, counter); err != nil {
+		return [32]byte{}, 0, err
+	}
+	return id, nonce, nil
+}
+
+func (l *Lifecycle) revertAuthorizationNonce(payer [20]byte, nonce uint64) {
+	key := authorizationNonceKey(payer)
+	_ = l.state.KVPut(key, storedAuthorizationNonce{Counter: nonce})
+}
+
+func authorizationKey(id [32]byte) []byte {
+	return append([]byte(nil), append(authorizationPrefix, fmt.Sprintf("%x", id[:])...)...)
+}
+
+func authorizationNonceKey(payer [20]byte) []byte {
+	return append([]byte(nil), append(authorizationNoncePref, fmt.Sprintf("%x", payer[:])...)...)
+}
+
+func isZeroAddress(addr []byte) bool {
+	for _, b := range addr {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneAccount(acc *types.Account) *types.Account {
+	if acc == nil {
+		return &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), LockedZNHB: big.NewInt(0)}
+	}
+	cloned := *acc
+	if acc.BalanceNHB != nil {
+		cloned.BalanceNHB = new(big.Int).Set(acc.BalanceNHB)
+	} else {
+		cloned.BalanceNHB = big.NewInt(0)
+	}
+	if acc.BalanceZNHB != nil {
+		cloned.BalanceZNHB = new(big.Int).Set(acc.BalanceZNHB)
+	} else {
+		cloned.BalanceZNHB = big.NewInt(0)
+	}
+	if acc.LockedZNHB != nil {
+		cloned.LockedZNHB = new(big.Int).Set(acc.LockedZNHB)
+	} else {
+		cloned.LockedZNHB = big.NewInt(0)
+	}
+	return &cloned
+}
+
+type storedAuthorization struct {
+	ID             [32]byte
+	Payer          [20]byte
+	Merchant       [20]byte
+	Amount         *big.Int
+	CapturedAmount *big.Int
+	RefundedAmount *big.Int
+	Expiry         uint64
+	IntentRef      []byte
+	Status         uint8
+	CreatedAt      uint64
+	UpdatedAt      uint64
+	VoidReason     string
+}
+
+type storedAuthorizationNonce struct {
+	Counter uint64
+}
+
+func newStoredAuthorization(a *Authorization) *storedAuthorization {
+	if a == nil {
+		return nil
+	}
+	stored := &storedAuthorization{
+		ID:         a.ID,
+		Payer:      a.Payer,
+		Merchant:   a.Merchant,
+		Expiry:     a.Expiry,
+		IntentRef:  append([]byte(nil), a.IntentRef...),
+		Status:     uint8(a.Status),
+		CreatedAt:  a.CreatedAt,
+		UpdatedAt:  a.UpdatedAt,
+		VoidReason: strings.TrimSpace(a.VoidReason),
+	}
+	if a.Amount != nil {
+		stored.Amount = new(big.Int).Set(a.Amount)
+	}
+	if a.CapturedAmount != nil {
+		stored.CapturedAmount = new(big.Int).Set(a.CapturedAmount)
+	}
+	if a.RefundedAmount != nil {
+		stored.RefundedAmount = new(big.Int).Set(a.RefundedAmount)
+	}
+	return stored
+}
+
+func (s *storedAuthorization) toAuthorization() *Authorization {
+	if s == nil {
+		return nil
+	}
+	record := &Authorization{
+		ID:         s.ID,
+		Payer:      s.Payer,
+		Merchant:   s.Merchant,
+		Amount:     big.NewInt(0),
+		Expiry:     s.Expiry,
+		IntentRef:  append([]byte(nil), s.IntentRef...),
+		Status:     AuthorizationStatus(s.Status),
+		CreatedAt:  s.CreatedAt,
+		UpdatedAt:  s.UpdatedAt,
+		VoidReason: strings.TrimSpace(s.VoidReason),
+	}
+	if s.Amount != nil {
+		record.Amount = new(big.Int).Set(s.Amount)
+	}
+	if s.CapturedAmount != nil {
+		record.CapturedAmount = new(big.Int).Set(s.CapturedAmount)
+	} else {
+		record.CapturedAmount = big.NewInt(0)
+	}
+	if s.RefundedAmount != nil {
+		record.RefundedAmount = new(big.Int).Set(s.RefundedAmount)
+	} else {
+		record.RefundedAmount = big.NewInt(0)
+	}
+	return record
+}

--- a/native/pos/auth_test.go
+++ b/native/pos/auth_test.go
@@ -1,0 +1,177 @@
+package pos
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"nhbchain/core/types"
+)
+
+type memoryLifecycleState struct {
+	kv       map[string][]byte
+	accounts map[string]*types.Account
+}
+
+func newMemoryLifecycleState() *memoryLifecycleState {
+	return &memoryLifecycleState{
+		kv:       make(map[string][]byte),
+		accounts: make(map[string]*types.Account),
+	}
+}
+
+func (m *memoryLifecycleState) KVGet(key []byte, out interface{}) (bool, error) {
+	encoded, ok := m.kv[string(key)]
+	if !ok {
+		return false, nil
+	}
+	if out == nil {
+		return true, nil
+	}
+	if err := rlp.DecodeBytes(encoded, out); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (m *memoryLifecycleState) KVPut(key []byte, value interface{}) error {
+	encoded, err := rlp.EncodeToBytes(value)
+	if err != nil {
+		return err
+	}
+	m.kv[string(key)] = encoded
+	return nil
+}
+
+func (m *memoryLifecycleState) KVDelete(key []byte) error {
+	delete(m.kv, string(key))
+	return nil
+}
+
+func (m *memoryLifecycleState) GetAccount(addr []byte) (*types.Account, error) {
+	if acc, ok := m.accounts[string(addr)]; ok {
+		return cloneAccount(acc), nil
+	}
+	return &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), LockedZNHB: big.NewInt(0)}, nil
+}
+
+func (m *memoryLifecycleState) PutAccount(addr []byte, account *types.Account) error {
+	m.accounts[string(addr)] = cloneAccount(account)
+	return nil
+}
+
+func TestLifecyclePartialCapture(t *testing.T) {
+	state := newMemoryLifecycleState()
+	var payer, merchant [20]byte
+	payer[1] = 0x01
+	merchant[2] = 0x02
+	state.accounts[string(payer[:])] = &types.Account{BalanceZNHB: big.NewInt(1_000), BalanceNHB: big.NewInt(0), LockedZNHB: big.NewInt(0)}
+	state.accounts[string(merchant[:])] = &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), LockedZNHB: big.NewInt(0)}
+
+	engine := NewLifecycle(state)
+	base := time.Unix(1_700_000_000, 0)
+	engine.SetNowFunc(func() time.Time { return base })
+
+	auth, err := engine.Authorize(payer, merchant, big.NewInt(600), uint64(base.Add(time.Hour).Unix()), []byte("intent-001"))
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	payerAcc, _ := state.GetAccount(payer[:])
+	if payerAcc.BalanceZNHB.Cmp(big.NewInt(400)) != 0 {
+		t.Fatalf("payer balance after auth: got %s want 400", payerAcc.BalanceZNHB)
+	}
+	if payerAcc.LockedZNHB.Cmp(big.NewInt(600)) != 0 {
+		t.Fatalf("payer locked after auth: got %s want 600", payerAcc.LockedZNHB)
+	}
+
+	engine.SetNowFunc(func() time.Time { return base.Add(10 * time.Minute) })
+	updated, err := engine.Capture(auth.ID, big.NewInt(250))
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if updated.Status != AuthorizationStatusCaptured {
+		t.Fatalf("status after capture: got %v want captured", updated.Status)
+	}
+	if updated.CapturedAmount.Cmp(big.NewInt(250)) != 0 {
+		t.Fatalf("captured amount: got %s want 250", updated.CapturedAmount)
+	}
+	if updated.RefundedAmount.Cmp(big.NewInt(350)) != 0 {
+		t.Fatalf("refunded amount: got %s want 350", updated.RefundedAmount)
+	}
+	payerAcc, _ = state.GetAccount(payer[:])
+	if payerAcc.LockedZNHB.Sign() != 0 {
+		t.Fatalf("payer locked after capture: got %s want 0", payerAcc.LockedZNHB)
+	}
+	if payerAcc.BalanceZNHB.Cmp(big.NewInt(750)) != 0 {
+		t.Fatalf("payer balance after capture: got %s want 750", payerAcc.BalanceZNHB)
+	}
+	merchantAcc, _ := state.GetAccount(merchant[:])
+	if merchantAcc.BalanceZNHB.Cmp(big.NewInt(250)) != 0 {
+		t.Fatalf("merchant balance after capture: got %s want 250", merchantAcc.BalanceZNHB)
+	}
+}
+
+func TestLifecycleDoubleCaptureRejected(t *testing.T) {
+	state := newMemoryLifecycleState()
+	var payer, merchant [20]byte
+	payer[3] = 0x44
+	merchant[4] = 0x55
+	state.accounts[string(payer[:])] = &types.Account{BalanceZNHB: big.NewInt(500), BalanceNHB: big.NewInt(0), LockedZNHB: big.NewInt(0)}
+	state.accounts[string(merchant[:])] = &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), LockedZNHB: big.NewInt(0)}
+	engine := NewLifecycle(state)
+	now := time.Unix(1_800_000_000, 0)
+	engine.SetNowFunc(func() time.Time { return now })
+
+	auth, err := engine.Authorize(payer, merchant, big.NewInt(300), uint64(now.Add(time.Hour).Unix()), nil)
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	engine.SetNowFunc(func() time.Time { return now.Add(5 * time.Minute) })
+	if _, err := engine.Capture(auth.ID, big.NewInt(300)); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if _, err := engine.Capture(auth.ID, big.NewInt(10)); !errors.Is(err, errAuthorizationConsumed) {
+		t.Fatalf("double capture error: got %v want %v", err, errAuthorizationConsumed)
+	}
+}
+
+func TestLifecycleAutoVoidOnExpiry(t *testing.T) {
+	state := newMemoryLifecycleState()
+	var payer, merchant [20]byte
+	payer[5] = 0x99
+	merchant[6] = 0x77
+	state.accounts[string(payer[:])] = &types.Account{BalanceZNHB: big.NewInt(800), BalanceNHB: big.NewInt(0), LockedZNHB: big.NewInt(0)}
+	state.accounts[string(merchant[:])] = &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), LockedZNHB: big.NewInt(0)}
+	engine := NewLifecycle(state)
+	base := time.Unix(1_900_000_000, 0)
+	engine.SetNowFunc(func() time.Time { return base })
+
+	auth, err := engine.Authorize(payer, merchant, big.NewInt(500), uint64(base.Add(15*time.Minute).Unix()), []byte("intent-exp"))
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	engine.SetNowFunc(func() time.Time { return base.Add(20 * time.Minute) })
+	updated, err := engine.Capture(auth.ID, big.NewInt(200))
+	if !errors.Is(err, errAuthorizationExpired) {
+		t.Fatalf("capture after expiry error: got %v want %v", err, errAuthorizationExpired)
+	}
+	if updated.Status != AuthorizationStatusExpired {
+		t.Fatalf("status after auto-void: got %v want expired", updated.Status)
+	}
+	if updated.RefundedAmount.Cmp(big.NewInt(500)) != 0 {
+		t.Fatalf("refunded after auto-void: got %s want 500", updated.RefundedAmount)
+	}
+	if updated.VoidReason != "expired" {
+		t.Fatalf("void reason: got %q want %q", updated.VoidReason, "expired")
+	}
+	payerAcc, _ := state.GetAccount(payer[:])
+	if payerAcc.LockedZNHB.Sign() != 0 {
+		t.Fatalf("payer locked after auto-void: got %s want 0", payerAcc.LockedZNHB)
+	}
+	if payerAcc.BalanceZNHB.Cmp(big.NewInt(800)) != 0 {
+		t.Fatalf("payer balance after auto-void: got %s want 800", payerAcc.BalanceZNHB)
+	}
+}

--- a/proto/pos/tx.proto
+++ b/proto/pos/tx.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package pos.v1;
+
+option go_package = "nhbchain/proto/pos;posv1";
+
+message MsgAuthorizePayment {
+  string payer = 1;
+  string merchant = 2;
+  string amount = 3;
+  uint64 expiry = 4;
+  bytes intent_ref = 5;
+}
+
+message MsgAuthorizePaymentResponse {
+  string authorization_id = 1;
+}
+
+message MsgCapturePayment {
+  string merchant = 1;
+  string authorization_id = 2;
+  string amount = 3;
+}
+
+message MsgCapturePaymentResponse {
+  string authorization_id = 1;
+  string captured_amount = 2;
+  string refunded_amount = 3;
+}
+
+message MsgVoidPayment {
+  string merchant = 1;
+  string authorization_id = 2;
+  string reason = 3;
+}
+
+message MsgVoidPaymentResponse {
+  string authorization_id = 1;
+  string refunded_amount = 2;
+  bool expired = 3;
+}
+
+service Tx {
+  rpc AuthorizePayment(MsgAuthorizePayment) returns (MsgAuthorizePaymentResponse);
+  rpc CapturePayment(MsgCapturePayment) returns (MsgCapturePaymentResponse);
+  rpc VoidPayment(MsgVoidPayment) returns (MsgVoidPaymentResponse);
+}


### PR DESCRIPTION
## Summary
- add a point-of-sale lifecycle engine with authorization, capture, and void flows
- emit structured payment events and expose new Tx RPC messages
- document the lifecycle and changelog for POS-LIFECYCLE-5

## Testing
- go test ./native/pos...


------
https://chatgpt.com/codex/tasks/task_e_68e39e7cb254832db64f7d85861fd40a