### PR TITLE
POS-SDK-9: publish NHB Pay spec and SDK examples

### DIFF
--- a/docs/api/gateway-pos.md
+++ b/docs/api/gateway-pos.md
@@ -1,0 +1,140 @@
+# POS gateway HTTP API
+
+The POS gateway exposes a lightweight HTTP surface for POS terminals and
+merchant middleware to submit signed NHB Pay intents and poll their lifecycle
+status. The gateway accepts the canonical NHB Pay URI payload described in
+[the POS intent spec](../specs/nhb-pay.md) and proxies submissions to the node's
+gRPC transaction service.
+
+All endpoints live under the `/api/pos` prefix and require TLS in production.
+Unless stated otherwise the gateway returns JSON responses and the standard
+`Content-Type: application/json` header.
+
+## `POST /api/pos/intents`
+
+Submit a signed NHB Pay intent. The gateway validates the payload, enqueues it
+through the POS Tx gRPC service, and returns an authorization reference that can
+be used for follow-up capture or void operations.
+
+### Request body
+
+```json
+{
+  "intentRef": "0x2d8c7fd3e1a94f4c998e4cfedc3a4567bb12aa09887766554433221100ff9a01",
+  "uri": "nhbpay://intent/2d8c7fd3e1a94f4c998e4cfedc3a4567bb12aa09887766554433221100ff9a01?amount=15.25&currency=USD&expiry=1707436800&merchant=nhb1m0ckmerchantaddre55&device=kiosk-7&paymaster=nhb1sponsorship&sig=5b0481e43cbb27c4c76bf0fa104d8a2ffb329a84797d0c0edc55fb6a2dcef0125c7d4090560ce10a4bf845ba1b4c745cf3e5012ef0d8c2a8d98d00ab91c5dd1a",
+  "payer": "nhb1samplepayer"
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `intentRef` | string | Lowercase hex-encoded 32 byte reference. |
+| `uri` | string | Canonical NHB Pay URI containing all metadata and merchant signature. |
+| `payer` | string | NHB address of the payer/customer wallet. |
+| `metadata` | object (optional) | Additional device or cashier metadata echoed back in status responses. |
+
+The gateway derives the amount, currency, expiry, and merchant address from the
+URI. Requests missing mandatory query parameters or with invalid signatures are
+rejected with `400 Bad Request`.
+
+### Response
+
+```json
+{
+  "authorizationId": "auth_01hatz8k8k8c8n3qsk4x3k8s1x",
+  "intentRef": "0x2d8c7fd3e1a94f4c998e4cfedc3a4567bb12aa09887766554433221100ff9a01",
+  "status": "pending",
+  "submittedAt": "2024-02-08T12:00:00Z"
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `authorizationId` | string | Reference returned by the POS gRPC Tx service. |
+| `intentRef` | string | Echoes the submitted intent reference. |
+| `status` | string | Initial lifecycle status (`pending` on success). |
+| `submittedAt` | RFC3339 string | Timestamp the gateway accepted the submission. |
+
+Successful submissions return HTTP `202 Accepted` along with the body above.
+
+The gateway returns the following status codes:
+
+| Code | Description |
+| --- | --- |
+| `202` | Intent accepted and forwarded to the network. |
+| `400` | Malformed request, missing signature, or replayed intent. |
+| `409` | Intent already consumed on-chain. |
+| `422` | Intent expired. |
+| `500` | Upstream gRPC or consensus error. |
+
+## `GET /api/pos/intents/{intentRef}`
+
+Fetch the lifecycle status for a previously submitted intent. This endpoint
+combines the gateway submission log with realtime finality updates streamed from
+`pos.v1.Realtime`.
+
+### Path parameters
+
+| Parameter | Description |
+| --- | --- |
+| `intentRef` | Lowercase hex string identifying the intent. |
+
+### Response
+
+```json
+{
+  "intentRef": "0x2d8c7fd3e1a94f4c998e4cfedc3a4567bb12aa09887766554433221100ff9a01",
+  "authorizationId": "auth_01hatz8k8k8c8n3qsk4x3k8s1x",
+  "status": "finalized",
+  "merchant": "nhb1m0ckmerchantaddre55",
+  "amount": "15.25",
+  "currency": "USD",
+  "payer": "nhb1samplepayer",
+  "paymaster": "nhb1sponsorship",
+  "device": "kiosk-7",
+  "submittedAt": "2024-02-08T12:00:00Z",
+  "finalizedAt": "2024-02-08T12:00:05Z",
+  "txHash": "0xe314f9f6f1c80c7a6f332cb4988b0d0d7aab70f6ea51a6f7cd2d6fef3b8c2c77",
+  "height": 145902,
+  "cursor": "pos-finality-145902-7"
+}
+```
+
+`status` transitions through the following states:
+
+| Status | Meaning |
+| --- | --- |
+| `pending` | Intent accepted and awaiting block inclusion. |
+| `finalized` | Intent finalized in a BFT block. |
+| `rejected` | Downstream node rejected the transaction (includes `errorCode`). |
+| `expired` | Gateway dropped the intent because `expiry` elapsed before acceptance. |
+
+If the intent is unknown the gateway returns `404 Not Found`.
+
+### Polling strategy
+
+Gateways retain submission metadata for at least 24 hours. Terminals SHOULD
+prefer the realtime gRPC/WebSocket stream for live updates and only poll the
+status endpoint during recovery or when a terminal cannot maintain a streaming
+connection.
+
+## Error schema
+
+Errors use the following JSON structure:
+
+```json
+{
+  "error": {
+    "code": "INTENT_EXPIRED",
+    "message": "intent expiry 1707436800 is in the past"
+  }
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `code` | Stable identifier for programmatic handling. |
+| `message` | Human-readable description. |
+
+Common error codes include `INVALID_SIGNATURE`, `INTENT_CONSUMED`,
+`INTENT_EXPIRED`, and `UPSTREAM_UNAVAILABLE`.

--- a/docs/changelogs/POS-SDK-9.md
+++ b/docs/changelogs/POS-SDK-9.md
@@ -1,0 +1,11 @@
+# POS-SDK-9: NHB-Pay spec + NFC/NDEF + SDK examples
+
+* Published the NHB Pay URI specification with canonical signing rules, updated
+  intent fields, and an end-to-end example URI.
+* Documented the NFC NDEF layouts for NHB Pay, including the dual URI/CBOR
+  records and the expected signature bytes.
+* Added Go and TypeScript SDK examples that create, sign, submit, and watch POS
+  intents via gRPC, demonstrating canonical string construction and realtime
+  finality streaming.
+* Documented the POS gateway HTTP endpoints for submitting intents and polling
+  status, with sample requests, responses, and error schemas.

--- a/docs/specs/nfc-ndef.md
+++ b/docs/specs/nfc-ndef.md
@@ -1,0 +1,91 @@
+# NHB Pay NFC intents
+
+This document describes the NFC Forum NDEF payloads that terminals MUST produce
+when broadcasting NHB Pay intents over tap-to-pay experiences. The layout keeps
+compatibility with existing wallet stacks by including both a human-readable URI
+record and a binary CBOR record for lossless metadata transport.
+
+## Record layout
+
+Terminals MUST emit an NDEF message containing the following records in order:
+
+1. **Well-known type `U` (URI record).** Contains the NHB Pay deep link defined
+   in [NHB Pay Point-of-Sale Intents](./nhb-pay.md). This allows wallets that
+   only understand URI records to still complete the payment flow.
+2. **MIME type `application/nhbpay+cbor`.** Contains the CBOR representation of
+   the canonical fields. Wallets SHOULD prefer this record to avoid ambiguity
+   introduced by URI encoding.
+
+Both records are flagged with the Short Record (SR) bit when the payload length
+is below 255 bytes. The URI identifier code MUST be set to `0x00` (no prefix)
+so that the payload stores the raw URI bytes.
+
+## CBOR payload
+
+The CBOR record encodes a map with the following keys:
+
+| Key | Type | Description |
+| --- | ---- | ----------- |
+| `intent_ref` | `bstr` | 32 byte reference copied verbatim from the envelope. |
+| `intent_expiry` | `uint` | Expiry timestamp in Unix seconds. |
+| `merchant_addr` | `tstr` | Canonical bech32 merchant address. |
+| `amount` | `tstr` | Decimal amount string, identical to the URI. |
+| `currency` | `tstr` | ISO-4217 currency code. |
+| `paymaster` | `tstr` (optional) | Paymaster identifier. |
+| `device_id` | `tstr` (optional) | POS device identifier. |
+| `sig` | `bstr` (optional) | Merchant signature bytes. Present when the URI also carries the `sig` parameter. |
+
+Terminals MAY include vendor-specific metadata inside a nested map under the key
+`ext`. Wallets MUST ignore unknown keys.
+
+### Signing bytes
+
+Terminals MUST derive the signature from the canonical string described in the
+[NHB Pay POS URI specification](./nhb-pay.md#canonical-string-to-sign). When
+present, the signature bytes stored in the CBOR payload are identical to the
+raw Ed25519 signature (not hex encoded). Wallets verifying a CBOR payload MUST
+hex encode the signature before comparing it with the URI query parameter, if
+present.
+
+### Example
+
+The example below shows a diagnostic hexdump of a CBOR record with all fields
+populated. Whitespace has been added for clarity.
+
+```
+A8                                      # map(8)
+  6A                                    # text(10)
+    696E74656E745F726566                # "intent_ref"
+  50                                    # bytes(16)
+    2D8C7FD3E1A94F4C998E4CFEDC3A4567
+  6D                                    # text(13)
+    696E74656E745F657870697279          # "intent_expiry"
+  1A 659D5B00                           # unsigned(1707436800)
+  6D                                    # text(13)
+    6D65726368616E745F61646472          # "merchant_addr"
+  78 18                                 # text(24)
+    6E6862316D30636B6D65726368616E7461646472653535
+  66                                    # text(6)
+    616D6F756E74                        # "amount"
+  65                                    # text(5)
+    31352E3235                          # "15.25"
+  68                                    # text(8)
+    63757272656E6379                    # "currency"
+  63                                    # text(3)
+    555344                              # "USD"
+  69                                    # text(9)
+    7061796D6173746572                  # "paymaster"
+  73                                    # text(19)
+    6E68623173706F6E736F7273686970      # "nhb1sponsorship"
+  69                                    # text(9)
+    6465766963655F6964                  # "device_id"
+  67                                    # text(7)
+    6B696F736B2D37                      # "kiosk-7"
+  63                                    # text(3)
+    736967                              # "sig"
+  58 40                                 # bytes(64)
+    5B0481E43CBB27C4C76BF0FA104D8A2FFB329A84797D0C0EDC55FB6A2DCEF012
+    5C7D4090560CE10A4BF845BA1B4C745CF3E5012EF0D8C2A8D98D00AB91C5DD1A
+```
+
+Wallets that cannot parse the CBOR payload SHOULD fall back to the URI record.

--- a/docs/specs/nhb-pay.md
+++ b/docs/specs/nhb-pay.md
@@ -1,20 +1,20 @@
 # NHB Pay Point-of-Sale Intents
 
-This document captures the wire-level metadata that wallets and terminals use to
-anchor point-of-sale (POS) payment intents on NHBchain. The consensus service
-persists the same fields inside every `TxEnvelope`, enabling validators to
-reject replayed payloads and to enforce a bounded settlement window.
+This document defines the portable payment intent payloads that NHB Pay POS
+terminals emit and compatible wallets consume. The same fields are attached to
+every on-chain `TxEnvelope` and signed along with the transaction body so that
+validators can reject replayed payloads and enforce bounded settlement windows.
 
 ## Envelope metadata
 
-The following fields are attached to every POS envelope. They are signed along
-with the underlying transaction to prevent tampering.
-
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| `intent_ref` | 32&nbsp;bytes | Merchant-generated nonce that uniquely identifies the payment intent. Terminals SHOULD generate a cryptographically random 32-byte value. Wallets and services MUST treat the field as opaque bytes on-chain. |
-| `intent_expiry` | `uint64` (seconds) | Unix timestamp indicating the absolute expiry of the intent. Validators clamp the stored expiry to `min(intent_expiry, block_time + 24h)` and reject any payload where `now >= intent_expiry`. |
+| `intent_ref` | 32&nbsp;bytes | Merchant generated nonce that uniquely identifies the payment intent. Terminals SHOULD generate a cryptographically random 32 byte value. Wallets and services MUST treat the field as opaque bytes on-chain. |
+| `intent_expiry` | `uint64` seconds | Unix timestamp indicating the absolute expiry of the intent. Validators clamp the stored expiry to `min(intent_expiry, block_time + 24h)` and reject any payload where `now >= intent_expiry`. |
 | `merchant_addr` | string | Canonical merchant address presented to the customer. The canonical representation is the NHB bech32 string (e.g. `nhb1...`). The consensus layer stores the trimmed string exactly as supplied. |
+| `amount` | string | Decimal amount in NHB minor units (for example `12.34`). The format mirrors API amounts: a base 10 string with up to 8 fractional digits. |
+| `currency` | string | ISO-4217 currency code associated with the amount (e.g. `USD`). |
+| `paymaster` | string (optional) | Address or identifier of the entity subsidising the payment. Wallets MUST ignore unknown paymaster schemes but SHOULD preserve the value when submitting transactions. |
 | `device_id` | string (optional) | Identifier emitted by the POS terminal. The value is opaque to consensus and is only surfaced in events for downstream telemetry. |
 
 ### Replay protection
@@ -33,35 +33,72 @@ with the underlying transaction to prevent tampering.
 Wallets SHOULD encode the metadata inside a URI with the following shape:
 
 ```
-nhbpay://intent/<intent_ref_hex>?expiry=<unix_seconds>&merchant=<bech32>[&device=<url-encoded>]
+nhbpay://intent/<intent_ref_hex>?amount=<decimal>&currency=<code>&expiry=<unix_seconds>&merchant=<bech32>[&paymaster=<scheme:value>][&device=<url-encoded>][&sig=<sig_hex>]
 ```
 
-* `<intent_ref_hex>` is the lowercase hex encoding of the 32-byte reference.
+* `<intent_ref_hex>` is the lowercase hex encoding of the 32 byte reference.
+* `amount` is the decimal string amount including fractional digits.
+* `currency` is the three letter ISO-4217 currency code.
 * `<unix_seconds>` is the decimal representation of `intent_expiry`.
 * `<bech32>` is the canonical merchant address.
-* The optional `device` parameter carries the terminal identifier. Values must
-  be URL encoded. Unknown query parameters MUST be ignored by wallets.
+* `paymaster` and `device` parameters are optional; their values MUST be URL
+  encoded. Unknown query parameters MUST be ignored by wallets.
+* `sig` is the lowercase hex encoding of the canonical signature described
+  below. Wallets MAY reject unsigned payloads depending on policy.
 
-### NFC payload
+#### Canonical string-to-sign
 
-When transporting an intent over NFC the byte payload MUST follow the sequence
-below:
+Terminals MUST derive the signature payload by concatenating the URI scheme and
+a sorted key/value list. The canonical plaintext is:
 
 ```
-intent_ref (32 bytes)
-intent_expiry (uint64, big-endian)
-merchant_addr (20 bytes)
-[device_id_len (uint8) || device_id bytes]
+nhbpay://intent/<intent_ref_hex>?amount=<amount>&currency=<currency>&expiry=<expiry>&merchant=<merchant>[&device=<device>][&paymaster=<paymaster>]
 ```
 
-* `merchant_addr` is the 20-byte account identifier obtained after decoding the
-  bech32 representation supplied in the URI.
-* `device_id` is optional; when present the leading byte encodes the length of
-  the subsequent UTF-8 sequence.
+* Optional parameters are included only when present in the original intent.
+* Keys are lowercase ASCII and MUST be appended in the order shown above.
+* Values MUST be percent decoded prior to signing.
+* The signature is generated with the merchant private key over the UTF-8 bytes
+  of the canonical string. Ed25519 is the default POS key type.
 
-Terminals and wallets MAY include additional vendor-specific data after the
-canonical segment provided they agree on the extension. Consensus logic only
-cares about the canonical fields listed in the table above.
+The resulting signature is hex encoded and placed in the `sig` query parameter
+of the URI. Wallets MUST verify the signature before constructing and
+submitting the payment transaction.
+
+##### Worked example
+
+Given the following parameters:
+
+| Field | Value |
+| ----- | ----- |
+| `intent_ref` | `0x2d8c7fd3e1a94f4c998e4cfedc3a4567bb12aa09887766554433221100ff9a01` |
+| `amount` | `15.25` |
+| `currency` | `USD` |
+| `merchant_addr` | `nhb1m0ckmerchantaddre55` |
+| `intent_expiry` | `1707436800` |
+| `device_id` | `kiosk-7` |
+| `paymaster` | `nhb1sponsorship` |
+
+The canonical string-to-sign is:
+
+```
+nhbpay://intent/2d8c7fd3e1a94f4c998e4cfedc3a4567bb12aa09887766554433221100ff9a01?amount=15.25&currency=USD&expiry=1707436800&merchant=nhb1m0ckmerchantaddre55&device=kiosk-7&paymaster=nhb1sponsorship
+```
+
+Assuming the merchant signs this string with Ed25519 and obtains the signature
+`0x5b0481e43cbb27c4c76bf0fa104d8a2ffb329a84797d0c0edc55fb6a2dcef0125c7d4090560ce10a4bf845ba1b4c745cf3e5012ef0d8c2a8d98d00ab91c5dd1a`, the full URI becomes:
+
+```
+nhbpay://intent/2d8c7fd3e1a94f4c998e4cfedc3a4567bb12aa09887766554433221100ff9a01?amount=15.25&currency=USD&expiry=1707436800&merchant=nhb1m0ckmerchantaddre55&device=kiosk-7&paymaster=nhb1sponsorship&sig=5b0481e43cbb27c4c76bf0fa104d8a2ffb329a84797d0c0edc55fb6a2dcef0125c7d4090560ce10a4bf845ba1b4c745cf3e5012ef0d8c2a8d98d00ab91c5dd1a
+```
+
+Wallets display or embed this URI in QR codes and deep links.
+
+### NFC payloads
+
+When transporting an intent over NFC, use the dedicated NDEF layouts described
+in [NHB Pay NFC intents](./nfc-ndef.md). Wallets MUST follow the signing
+instructions above prior to validating the payload carried in the NDEF record.
 
 ## Events
 

--- a/sdk/pos/examples/create_intent.go
+++ b/sdk/pos/examples/create_intent.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	posv1 "nhbchain/proto/pos"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// canonicalString builds the NHB Pay canonical string used for signing POS intents.
+func canonicalString(intentRef []byte, amount, currency string, expiry uint64, merchant, device, paymaster string) string {
+	base := fmt.Sprintf("nhbpay://intent/%s?amount=%s&currency=%s&expiry=%d&merchant=%s", hex.EncodeToString(intentRef), amount, currency, expiry, merchant)
+	if device != "" {
+		base += "&device=" + device
+	}
+	if paymaster != "" {
+		base += "&paymaster=" + paymaster
+	}
+	return base
+}
+
+// encodeURI assembles the QR/deep-link URI including the signature parameter.
+func encodeURI(intentRef []byte, amount, currency string, expiry uint64, merchant, device, paymaster string, signature []byte) string {
+	parts := []string{
+		"amount=" + urlEscape(amount),
+		"currency=" + urlEscape(currency),
+		fmt.Sprintf("expiry=%d", expiry),
+		"merchant=" + urlEscape(merchant),
+	}
+	if paymaster != "" {
+		parts = append(parts, "paymaster="+urlEscape(paymaster))
+	}
+	if device != "" {
+		parts = append(parts, "device="+urlEscape(device))
+	}
+	if len(signature) > 0 {
+		parts = append(parts, "sig="+hex.EncodeToString(signature))
+	}
+	return fmt.Sprintf("nhbpay://intent/%s?%s", hex.EncodeToString(intentRef), strings.Join(parts, "&"))
+}
+
+// urlEscape performs minimal URL escaping for query parameter values.
+func urlEscape(s string) string {
+	replacer := strings.NewReplacer(
+		" ", "%20",
+		"\"", "%22",
+		"#", "%23",
+		"%", "%25",
+		"&", "%26",
+		"+", "%2B",
+		"/", "%2F",
+		"=", "%3D",
+		"?", "%3F",
+	)
+	return replacer.Replace(s)
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, "localhost:9090", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("dial POS gateway: %v", err)
+	}
+	defer conn.Close()
+
+	client := posv1.NewTxClient(conn)
+
+	intentRef := make([]byte, 32)
+	if _, err := rand.Read(intentRef); err != nil {
+		log.Fatalf("generate intent ref: %v", err)
+	}
+
+	merchant := "nhb1m0ckmerchantaddre55"
+	amount := "15.25"
+	currency := "USD"
+	expiry := uint64(time.Now().Add(15 * time.Minute).Unix())
+	device := "kiosk-7"
+	paymaster := "nhb1sponsorship"
+
+	canonical := canonicalString(intentRef, amount, currency, expiry, merchant, device, paymaster)
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		log.Fatalf("generate ed25519 key: %v", err)
+	}
+
+	signature := ed25519.Sign(priv, []byte(canonical))
+	uri := encodeURI(intentRef, amount, currency, expiry, merchant, device, paymaster, signature)
+	fmt.Printf("Generated NHB Pay URI: %s\n", uri)
+
+	resp, err := client.AuthorizePayment(ctx, &posv1.MsgAuthorizePayment{
+		Payer:     "nhb1samplepayer",
+		Merchant:  merchant,
+		Amount:    amount,
+		Expiry:    expiry,
+		IntentRef: intentRef,
+	})
+	if err != nil {
+		log.Fatalf("authorize payment: %v", err)
+	}
+
+	fmt.Printf("Authorization reference: %s\n", resp.GetAuthorizationId())
+}

--- a/sdk/pos/examples/submit_and_watch.ts
+++ b/sdk/pos/examples/submit_and_watch.ts
@@ -1,0 +1,148 @@
+import { credentials } from "@grpc/grpc-js";
+import { createPrivateKey, randomBytes, sign as edSign } from "crypto";
+import { promisify } from "util";
+import { MsgAuthorizePayment, TxClient } from "../../../clients/ts/pos/tx";
+import {
+  FinalityStatus,
+  RealtimeClient,
+  SubscribeFinalityResponse,
+} from "../../../clients/ts/pos/realtime";
+
+const TX_ENDPOINT = process.env.POS_TX_GRPC ?? "localhost:9090";
+const REALTIME_ENDPOINT = process.env.POS_REALTIME_GRPC ?? "localhost:9090";
+const PRIVATE_KEY_PEM = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEICMcFMi4mUlFP5w0JIweUlBl7U8tpyrkJc7m+aaxPIKn
+-----END PRIVATE KEY-----`;
+
+interface IntentEnvelope {
+  intentRef: Buffer;
+  amount: string;
+  currency: string;
+  expiry: number;
+  merchant: string;
+  device?: string;
+  paymaster?: string;
+}
+
+const canonicalString = ({ intentRef, amount, currency, expiry, merchant, device, paymaster }: IntentEnvelope): string => {
+  const parts = [
+    `nhbpay://intent/${intentRef.toString("hex")}?amount=${amount}`,
+    `currency=${currency}`,
+    `expiry=${expiry}`,
+    `merchant=${merchant}`,
+  ];
+  if (device) {
+    parts.push(`device=${device}`);
+  }
+  if (paymaster) {
+    parts.push(`paymaster=${paymaster}`);
+  }
+  return parts.join("&");
+};
+
+const buildUri = (envelope: IntentEnvelope, signature: Buffer): string => {
+  const qp: string[] = [
+    `amount=${encodeURIComponent(envelope.amount)}`,
+    `currency=${encodeURIComponent(envelope.currency)}`,
+    `expiry=${envelope.expiry}`,
+    `merchant=${encodeURIComponent(envelope.merchant)}`,
+  ];
+  if (envelope.paymaster) {
+    qp.push(`paymaster=${encodeURIComponent(envelope.paymaster)}`);
+  }
+  if (envelope.device) {
+    qp.push(`device=${encodeURIComponent(envelope.device)}`);
+  }
+  if (signature.length > 0) {
+    qp.push(`sig=${signature.toString("hex")}`);
+  }
+  return `nhbpay://intent/${envelope.intentRef.toString("hex")}?${qp.join("&")}`;
+};
+
+const authorizePayment = async (envelope: IntentEnvelope, payer: string): Promise<string> => {
+  const txClient = new TxClient(TX_ENDPOINT, credentials.createInsecure());
+  const request: MsgAuthorizePayment = {
+    payer,
+    merchant: envelope.merchant,
+    amount: envelope.amount,
+    expiry: envelope.expiry,
+    intentRef: envelope.intentRef,
+  };
+  const unary = promisify(txClient.authorizePayment.bind(txClient));
+  try {
+    const response = await unary(request);
+    return response.authorizationId;
+  } finally {
+    txClient.close();
+  }
+};
+
+const watchFinality = async (intentRef: Buffer): Promise<void> => {
+  const realtime = new RealtimeClient(REALTIME_ENDPOINT, credentials.createInsecure());
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const hexRef = intentRef.toString("hex");
+      const stream = realtime.subscribeFinality({ cursor: "" });
+
+      const onData = (payload: SubscribeFinalityResponse): void => {
+        const update = payload.update;
+        if (!update) {
+          return;
+        }
+        const updateRef = update.intentRef ? Buffer.from(update.intentRef).toString("hex") : "";
+        console.log(
+          `status=${FinalityStatus[update.status] ?? "UNSPECIFIED"} cursor=${update.cursor} intent=${updateRef} tx=${
+            update.txHash ? Buffer.from(update.txHash).toString("hex") : ""
+          }`
+        );
+        if (updateRef === hexRef && update.status === FinalityStatus.FINALITY_STATUS_FINALIZED) {
+          stream.cancel();
+          resolve();
+        }
+      };
+
+      stream.on("data", onData);
+      stream.on("error", (err) => {
+        stream.cancel();
+        reject(err);
+      });
+      stream.on("end", () => {
+        resolve();
+      });
+    });
+  } finally {
+    realtime.close();
+  }
+};
+
+(async () => {
+  try {
+    const intentRef = randomBytes(32);
+    const envelope: IntentEnvelope = {
+      intentRef,
+      amount: "15.25",
+      currency: "USD",
+      expiry: Math.floor(Date.now() / 1000) + 15 * 60,
+      merchant: "nhb1m0ckmerchantaddre55",
+      device: "kiosk-7",
+      paymaster: "nhb1sponsorship",
+    };
+
+    const canonical = canonicalString(envelope);
+    const privateKey = createPrivateKey(PRIVATE_KEY_PEM);
+    const signature = edSign(null, Buffer.from(canonical, "utf8"), privateKey);
+    const uri = buildUri(envelope, signature);
+
+    console.log(`Generated NHB Pay URI: ${uri}`);
+
+    const authorizationId = await authorizePayment(envelope, "nhb1samplepayer");
+    console.log(`POS authorization id: ${authorizationId}`);
+
+    console.log("Watching finality updates...");
+    await watchFinality(intentRef);
+    console.log("Intent finalized.");
+  } catch (err) {
+    console.error("POS submit and watch example failed", err);
+    process.exitCode = 1;
+  }
+})();


### PR DESCRIPTION
## Summary
- document the NHB Pay POS URI fields, canonical signature string, and a full worked example
- add NFC NDEF intent layout guidance plus CBOR record and signing bytes documentation
- add Go and TypeScript POS SDK examples that create, sign, submit, and monitor intents via gRPC
- document the POS gateway HTTP submit/status endpoints and record the changes in the POS-SDK-9 changelog

## Testing
- go build ./pos/examples
- npx tsc --noEmit --skipLibCheck sdk/pos/examples/submit_and_watch.ts


------
https://chatgpt.com/codex/tasks/task_e_68e3ee655a48832d846fdd12694a78bf