### PR TITLE
docs: add fee policy and routing governance guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ pages should appear in the rendered sidebar. Group related content under the
 Point of Sale sections so that operators can discover the specifications,
 reference APIs, and runbooks in a single place.
 
+For fee policy specifics, see the new [fee policy](./fees/policy.md) and [fee routing](./fees/routing.md) guides.
+
 ## Verification workflow
 
 Two automated checks keep the docs healthy:

--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -33,3 +33,12 @@ toc:
             path: runbooks/paymaster-budgets.md
           - name: SLA monitoring
             path: runbooks/pos-slas.md
+
+  - name: Fees
+    toc:
+      - name: Policy
+        path: fees/policy.md
+      - name: Routing
+        path: fees/routing.md
+      - name: Governance parameters
+        path: governance/fee-params.md

--- a/docs/api/gateway-pos.md
+++ b/docs/api/gateway-pos.md
@@ -6,6 +6,9 @@ status. The gateway accepts the canonical NHB Pay URI payload described in
 [the POS intent spec](../specs/nhb-pay.md) and proxies submissions to the node's
 gRPC transaction service.
 
+For MDR, free-tier, and routing expectations that apply to these endpoints, see
+[fee policy](../fees/policy.md) and [fee routing](../fees/routing.md).
+
 All endpoints live under the `/api/pos` prefix and require TLS in production.
 Unless stated otherwise the gateway returns JSON responses and the standard
 `Content-Type: application/json` header.

--- a/docs/changelogs/DOCS-FEES-1.md
+++ b/docs/changelogs/DOCS-FEES-1.md
@@ -1,0 +1,8 @@
+# DOCS-FEES-1: Fee policy narrative + governance + routing
+
+* Documented the end-to-end fee policy, including free-tier allowances, MDR, and
+domain matrix.
+* Added fee routing diagrams and wallet descriptions.
+* Published governance references, parameter lists, and worked proposal
+  examples for adjusting the fee policy and routing targets.
+* Linked the new documentation from the docs README and POS API guide.

--- a/docs/examples/gov/fee-policy-proposal.json
+++ b/docs/examples/gov/fee-policy-proposal.json
@@ -1,0 +1,19 @@
+{
+  "module": "feepolicy",
+  "changes": {
+    "pos_mdr_bps": 175,
+    "min_fee": 50,
+    "exemptions": [
+      {
+        "domain": "POS",
+        "address": "nhb1publicgoodscampaign00000000000000000000",
+        "tag": "public_goods_q4",
+        "expires_at": "2025-12-31T23:59:59Z"
+      }
+    ]
+  },
+  "metadata": {
+    "reason": "Seasonal MDR uplift and subsidy carve-out",
+    "effective_epoch": 482
+  }
+}

--- a/docs/examples/gov/fee-routing-proposal.json
+++ b/docs/examples/gov/fee-routing-proposal.json
@@ -1,0 +1,12 @@
+{
+  "module": "feepolicy",
+  "changes": {
+    "owner_fee_wallet_nhb": "nhb1ownerwalletrotatedxxxxxxxxxxxxxxxxxxxx",
+    "znhb_proceeds_wallet": "nhb1stablewalletrotatedxxxxxxxxxxxxxxxxxx",
+    "owner_fee_wallet_usdc": "usdc1custodyvaultrotatedxxxxxxxxxxxxxxxx"
+  },
+  "metadata": {
+    "reason": "Treasury wallet rotation for FY25",
+    "effective_epoch": 490
+  }
+}

--- a/docs/fees/policy.md
+++ b/docs/fees/policy.md
@@ -1,0 +1,81 @@
+# Fee policy
+
+The NHB fee stack balances affordability for low-volume users with predictable
+merchant pricing and safety guardrails. This page summarises the default policy
+that the network governance committee stewards and enumerates the knobs that can
+be tuned through parameter proposals.
+
+## Free tier
+
+Wallets receive a **monthly allowance of 1,000 NHB-sponsored transactions**.
+Transactions that qualify for the free tier are debited against the sender's
+rolling 30-day count. Once the allowance is exhausted the standard fee schedule
+applies. The allowance can be reconfigured via governance (see
+[fee parameters](../governance/fee-params.md)).
+
+### Eligibility
+
+* **Retail wallets:** always accrue against the free tier for POS and P2P flows.
+* **Developer/test accounts:** can be marked as *exempt* to preserve sandbox
+  behaviour. Exemptions are tracked on-chain and audited during governance
+  reviews.
+* **High-volume merchants and OTC desks:** do not consume free-tier capacity;
+  their fees are charged according to the MDR schedule below.
+
+### Exhaustion handling
+
+The gateway and node expose the current allowance and trailing usage so clients
+can warn users before the cutoff. Once exhausted, the transaction estimator
+quotes the paid rate and the intent must include sufficient balance to cover the
+fee.
+
+## Merchant discount rate (MDR)
+
+Point-of-sale payments are charged an **ad valorem fee of 1.5%** of the payment
+amount (`pos_mdr_bps = 150`). The MDR applies after any free-tier exemption is
+processed. Governance may adjust the basis points value and the protocol
+propagates the new rate in the next epoch.
+
+* **Split settlements:** When MDR applies, the paymaster withholds the fee from
+the merchant leg before settlement. The withheld amount is routed according to
+the [fee routing policy](./routing.md).
+* **Pass-through sponsorship:** If a merchant funds the transaction directly,
+the MDR still applies unless the merchant wallet is on the *exemptions* list.
+
+## Minimum and maximum fee guards
+
+To keep fee collection predictable at the extremes the policy enforces both a
+floor and a ceiling:
+
+* `min_fee`: the absolute minimum charged when MDR × amount would fall below the
+  threshold (e.g. micro-payments).
+* `max_fee_bps`: the upper bound expressed in basis points. For large tickets
+  the effective fee is `min(MDR, max_fee_bps)`.
+
+Governance can adjust either guard alongside the MDR value. All parameters are
+covered in [governance controls](../governance/fee-params.md).
+
+## Exemptions
+
+The exemptions list enumerates wallet addresses or classification tags that are
+not charged the default fees. Exemptions can be scoped by domain (POS, P2P, OTC)
+or by program (e.g. public-goods campaign). Operators should keep the list short
+and justify each entry in governance discussions. Changes are enacted through a
+parameter proposal that updates the on-chain `FeePolicy` record.
+
+## Domain matrix
+
+| Domain | Default payer | Fee schedule | Notes |
+| --- | --- | --- | --- |
+| POS | Merchant paymaster | 1.5% MDR with min/max guards | Free tier applies to sponsored consumer wallets. Merchant exemptions override MDR. |
+| P2P | Sender wallet | Flat fee derived from `nhb_payment_fee_bps`; free tier applies to wallets under allowance. | OTC desks can be exempted from the free tier to avoid subsidy abuse. |
+| OTC | Desk operator | MDR or fixed quote depending on deal leg; honours min/max guards. | Desk exemptions apply when governance designates regulated partners. |
+
+## Governance and monitoring
+
+* The parameter set is audited quarterly; deltas require governance approval.
+* Fee metrics are exported via the observability stack and surfaced in the POS
+  and OTC dashboards. Monitoring alerts operators when the free-tier utilisation
+  exceeds 80% or MDR revenue drifts outside forecast bands.
+* Refer to [fee routing](./routing.md) for the distribution of collected fees
+  across the NHB ecosystem wallets.

--- a/docs/fees/routing.md
+++ b/docs/fees/routing.md
@@ -1,0 +1,76 @@
+# Fee routing
+
+Collected fees are split across the ecosystem to fund operations, reserves, and
+stability programs. This document describes the current routing logic and the
+on-chain accounts that receive the proceeds.
+
+## Destination wallets
+
+| Target | Description |
+| --- | --- |
+| `owner_fee_wallet_nhb` | NHB-denominated wallet that accrues operator fees from retail transactions and POS MDR collections. |
+| `znhb_proceeds_wallet` | Receives the ZNHB (stablecoin) portion of collected fees and routes it to the treasury stabilisation program. |
+| `owner_fee_wallet_usdc` | Off-chain custody wallet that buffers USDC-denominated inflows before sweeping to banking rails. |
+
+Each wallet address is stored in the `FeePolicy` module parameters. Governance
+proposals can rotate the addresses or adjust the split ratios when treasury
+requirements change.
+
+## Routing flow
+
+The runtime enforces deterministic routing whenever a transaction includes a fee
+component. The high-level flow is illustrated below.
+
+```mermaid
+description Top-level routing flow for POS payments
+sequenceDiagram
+  participant POS as POS Paymaster
+  participant Router as Fee Router Module
+  participant NHB as owner_fee_wallet_nhb
+  participant ZNHB as znhb_proceeds_wallet
+  POS->>Router: Submit settlement (gross amount, fee quote)
+  Router->>Router: Evaluate domain (POS/P2P/OTC), exemptions
+  Router->>NHB: Transfer NHB fee share
+  alt Stablecoin component present
+    Router->>ZNHB: Transfer ZNHB fee share
+  end
+  Router-->>POS: Confirm net settlement amount
+```
+
+### Domain-specific logic
+
+* **POS transactions:** Apply MDR split first, then deliver the net settlement to
+the merchant. NHB denominated fees route to `owner_fee_wallet_nhb`; any stablecoin portion uses `znhb_proceeds_wallet`.
+* **P2P transfers:** Charge against the sender's balance. Free-tier coverage sets
+the fee to zero; otherwise the NHB share is deposited into `owner_fee_wallet_nhb`.
+* **OTC deals:** Support mixed legs. NHB flows target `owner_fee_wallet_nhb`
+while off-chain settlement instructions are signed for `owner_fee_wallet_usdc`.
+
+### Implementation hooks
+
+```mermaid
+description Fee router hook ordering
+flowchart TD
+  A[Tx execution] --> B[Calculate fee obligation]
+  B --> C{Exemption?}
+  C -- Yes --> D[Bypass routing]
+  C -- No --> E[Split by currency]
+  E --> F[route_nhb(owner_fee_wallet_nhb)]
+  E --> G[route_znhb(znhb_proceeds_wallet)]
+  E --> H[route_offchain(owner_fee_wallet_usdc)]
+  F --> I[Record telemetry]
+  G --> I
+  H --> I
+  I --> J[Emit events for analytics stream]
+```
+
+The node emits `FeeRouted` events tagged with the domain, payer, and destination
+wallet. Observability pipelines consume the events to power revenue dashboards
+and reconciliation reports.
+
+## Governance controls
+
+Routing targets and split ratios are governed parameters. Refer to
+[fee parameters](../governance/fee-params.md) for the full list and proposal
+workflow. When updating wallet addresses always include a dry-run query of the
+new configuration and confirm the receiving account has been initialised.

--- a/docs/governance/fee-params.md
+++ b/docs/governance/fee-params.md
@@ -1,0 +1,133 @@
+# Fee policy governance parameters
+
+The network stores the fee configuration in the `feepolicy` module. Governance
+proposals can adjust the knobs below without a code upgrade. Use this page as a
+reference when drafting parameter-change or fee-routing proposals.
+
+## Adjustable parameters
+
+| Key | Description |
+| --- | --- |
+| `free_tier_tx_count` | Monthly allowance of NHB-sponsored transactions per wallet (default `1000`). |
+| `nhb_payment_fee_bps` | Basis points applied to non-POS payments once a wallet exhausts the free tier. |
+| `pos_mdr_bps` | Merchant discount rate for POS payments, expressed in basis points (default `150`). |
+| `min_fee` | Absolute minimum fee (in NHB) charged when ad valorem calculations fall below the threshold. |
+| `max_fee_bps` | Upper bound on fees, capped as a basis-points multiple of the transaction amount. |
+| `exemptions` | Address or tag list that bypasses standard fees. Entries can be scoped per domain (POS, P2P, OTC). |
+| `owner_fee_wallet_nhb` | NHB-denominated wallet receiving the network fee share. |
+| `znhb_proceeds_wallet` | Stablecoin wallet for routing ZNHB fee proceeds. |
+| `owner_fee_wallet_usdc` | Off-chain custody wallet referenced for USDC settlements. |
+
+Parameter values live under the `feepolicy.params` path. The governance service
+validates changes before accepting a proposal.
+
+## Inspecting the current policy
+
+Use the governance CLI to inspect the active parameters. The command prints the
+full JSON configuration, which you can diff locally before staging an update.
+
+```bash
+nhbctl gov query params --module feepolicy
+```
+
+To extract a single field (e.g. the POS MDR) pipe the output through `jq`:
+
+```bash
+nhbctl gov query params --module feepolicy | jq '.pos_mdr_bps'
+```
+
+## Drafting a fee policy update
+
+The example below raises the POS MDR to 1.75%, increases the minimum fee to 50
+micros, and adds a temporary exemption for a public-goods campaign wallet. Save
+the payload to `docs/examples/gov/fee-policy-proposal.json` and submit it with
+`nhbctl`.
+
+```bash
+nhbctl gov propose param \
+  --title "Adjust POS MDR" \
+  --summary "Raise MDR to 175 bps, bump min fee, add campaign exemption" \
+  --deposit 1000000znhb \
+  --module feepolicy \
+  --param-file docs/examples/gov/fee-policy-proposal.json
+```
+
+The referenced JSON file contains the following structure:
+
+<!-- embed:docs/examples/gov/fee-policy-proposal.json -->
+```json
+{
+  "module": "feepolicy",
+  "changes": {
+    "pos_mdr_bps": 175,
+    "min_fee": 50,
+    "exemptions": [
+      {
+        "domain": "POS",
+        "address": "nhb1publicgoodscampaign00000000000000000000",
+        "tag": "public_goods_q4",
+        "expires_at": "2025-12-31T23:59:59Z"
+      }
+    ]
+  },
+  "metadata": {
+    "reason": "Seasonal MDR uplift and subsidy carve-out",
+    "effective_epoch": 482
+  }
+}
+```
+
+Before submitting, fetch the current parameters to capture a "before" snapshot:
+
+```bash
+nhbctl gov query params --module feepolicy > /tmp/feepolicy-before.json
+```
+
+After the proposal executes, re-run the query and compare:
+
+```bash
+nhbctl gov query params --module feepolicy > /tmp/feepolicy-after.json
+jq -s '.[0], .[1]' /tmp/feepolicy-before.json /tmp/feepolicy-after.json
+```
+
+## Drafting a fee routing update
+
+Routing targets use the same module. When rotating treasury wallets or adjusting
+splits, create a proposal similar to the example stored in
+`docs/examples/gov/fee-routing-proposal.json`.
+
+```bash
+nhbctl gov propose param \
+  --title "Rotate fee wallets" \
+  --summary "Update owner and ZNHB proceeds wallets" \
+  --deposit 1000000znhb \
+  --module feepolicy \
+  --param-file docs/examples/gov/fee-routing-proposal.json
+```
+
+The payload looks like:
+
+<!-- embed:docs/examples/gov/fee-routing-proposal.json -->
+```json
+{
+  "module": "feepolicy",
+  "changes": {
+    "owner_fee_wallet_nhb": "nhb1ownerwalletrotatedxxxxxxxxxxxxxxxxxxxx",
+    "znhb_proceeds_wallet": "nhb1stablewalletrotatedxxxxxxxxxxxxxxxxxx",
+    "owner_fee_wallet_usdc": "usdc1custodyvaultrotatedxxxxxxxxxxxxxxxx"
+  },
+  "metadata": {
+    "reason": "Treasury wallet rotation for FY25",
+    "effective_epoch": 490
+  }
+}
+```
+
+Query the addresses before and after execution:
+
+```bash
+nhbctl gov query params --module feepolicy | jq '{owner_fee_wallet_nhb, znhb_proceeds_wallet, owner_fee_wallet_usdc}'
+```
+
+For additional context on how each parameter affects runtime behaviour see the
+[fee policy](../fees/policy.md) and [fee routing](../fees/routing.md) guides.


### PR DESCRIPTION
## Summary
- document the fee policy, free-tier allowances, MDR, and domain coverage in new fees docs
- capture fee routing flows, wallet targets, and governance-controlled parameters with worked CLI/JSON examples
- surface the fee references in the navigation, docs README, POS API guide, and changelog entry

## Testing
- go run ./scripts/verify_docs_snippets.go

------
https://chatgpt.com/codex/tasks/task_e_68e4475cebf8832d8fad6163f86abb64