### PR TITLE
Add fee transparency dashboard docs and assets

### DIFF
--- a/docs/api/fees-query.md
+++ b/docs/api/fees-query.md
@@ -1,0 +1,86 @@
+# Fees Query API Examples
+
+This guide demonstrates how to export fee settlement data for the network-wide transparency
+reporting pipeline. Use these snippets to hydrate the SQL queries documented in
+[`docs/queries/fees.sql`](../queries/fees.sql).
+
+## Prerequisites
+
+- Access to an NHB archival RPC endpoint (`https://rpc.nhbchain.dev` or your self-hosted replica).
+- API token with `fee.read` scope.
+- `jq` or a similar JSON processor for command-line examples.
+
+## Fetch Fee Events (JSON-RPC)
+
+```bash
+curl -s -X POST https://rpc.nhbchain.dev \
+  -H "Authorization: Bearer $NHB_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "jsonrpc": "2.0",
+        "id": "fees",
+        "method": "fee_getSettledEvents",
+        "params": {
+          "from_block": "0x" + toHex($START_BLOCK),
+          "to_block": "latest",
+          "page_size": 1000
+        }
+      }' | jq '.result.events[]'
+```
+
+Each event includes the transaction hash, domain, merchant identifier, and both native and USD fee
+components. Persist the response to object storage before loading it into your analytics database.
+
+## Streaming with gRPC
+
+```bash
+grpcurl -H "authorization: Bearer $NHB_API_TOKEN" \
+  -import-path proto \
+  -proto fees.proto \
+  nhbchain.dev:7443 nhb.fees.v1.FeesService/StreamSettlements \
+  | jq -c '.event'
+```
+
+The gRPC stream emits settlements in ledger order and is recommended for ClickHouse pipelines.
+
+## Loading into SQLite
+
+```bash
+sqlite3 fees.db <<'SQL'
+CREATE TABLE IF NOT EXISTS fee_events (
+  tx_id TEXT PRIMARY KEY,
+  block_timestamp DATETIME,
+  domain TEXT,
+  merchant_id TEXT,
+  merchant_name TEXT,
+  fee_amount_native REAL,
+  fee_amount_usdc REAL,
+  fee_amount_usd REAL
+);
+.mode json
+.import fee-events.json fee_events
+SQL
+```
+
+## Loading into ClickHouse
+
+```bash
+clickhouse-client --secure --query "
+CREATE TABLE IF NOT EXISTS fee_events (
+  tx_id String,
+  block_timestamp DateTime64(3, 'UTC'),
+  domain LowCardinality(String),
+  merchant_id String,
+  merchant_name String,
+  fee_amount_native Decimal(38, 18),
+  fee_amount_usdc Decimal(38, 6),
+  fee_amount_usd Decimal(38, 6)
+) ENGINE = MergeTree()
+ORDER BY (block_timestamp, domain);
+"
+
+clickhouse-client --secure --query "INSERT INTO fee_events FORMAT JSONEachRow" < fee-events.ndjson
+```
+
+Once ingested, you can run the transparency queries directly or drive the Grafana dashboard via the
+`clickhouse-datasource` plugin.

--- a/docs/changelogs/DOCS-FEES-2.md
+++ b/docs/changelogs/DOCS-FEES-2.md
@@ -1,0 +1,13 @@
+# DOCS-FEES-2
+
+## Summary
+
+- Added the network-wide fee transparency dashboard reference document with methodology, metrics, and reconciliation checklist.
+- Published reusable SQL queries and API collection examples for exporting fee data into SQLite and ClickHouse.
+- Shipped a Grafana dashboard definition covering domain totals, fee p95, free-tier burn down, and treasury route balances.
+
+## Release Notes
+
+This update introduces a consolidated transparency surface area for finance and operations teams.
+Follow the ingestion steps in `docs/api/fees-query.md` to hydrate the queries powering
+`docs/transparency/fees-dashboard.md` and the Grafana dashboard stored in `ops/grafana/dashboards/fees.json`.

--- a/docs/queries/fees.sql
+++ b/docs/queries/fees.sql
@@ -1,0 +1,87 @@
+-- Fee transparency canonical queries
+-- Export settlement events into your analytical store (SQLite, ClickHouse) using the
+-- ingestion recipe in docs/api/fees-query.md.
+
+-- =============================================
+-- Daily totals (SQLite)
+-- =============================================
+WITH fee_events AS (
+    SELECT
+        date(block_timestamp) AS fee_date,
+        domain,
+        fee_amount_native AS fee_native,
+        fee_amount_usdc AS fee_usdc
+    FROM fee_events
+)
+SELECT
+    fee_date,
+    SUM(fee_native) AS total_fee_native,
+    SUM(fee_usdc) AS total_fee_usdc,
+    SUM(fee_native + fee_usdc) AS total_fee_all
+FROM fee_events
+GROUP BY fee_date
+ORDER BY fee_date DESC
+LIMIT 30;
+
+-- =============================================
+-- Fee totals by domain (ClickHouse)
+-- =============================================
+SELECT
+    toStartOfDay(block_timestamp) AS fee_day,
+    domain,
+    sum(fee_amount_usd) AS fee_total_by_domain
+FROM fee_events
+WHERE block_timestamp >= now() - INTERVAL 30 DAY
+GROUP BY fee_day, domain
+ORDER BY fee_day DESC, fee_total_by_domain DESC;
+
+-- =============================================
+-- Top merchants last 7 days
+-- =============================================
+SELECT
+    merchant_id,
+    anyLast(merchant_name) AS merchant_name,
+    countDistinct(tx_id) AS tx_count,
+    sum(fee_amount_usd) AS fee_total_usd,
+    quantileExactWeighted(0.95)(fee_amount_usd, 1) AS fee_p95_usd,
+    avg(fee_amount_usd) AS fee_avg_usd
+FROM fee_events
+WHERE block_timestamp >= now() - INTERVAL 7 DAY
+GROUP BY merchant_id
+ORDER BY fee_total_usd DESC
+LIMIT 20;
+
+-- =============================================
+-- Free-tier burn down (ClickHouse)
+-- =============================================
+WITH grants AS (
+    SELECT
+        sum(grant_amount) AS total_granted
+    FROM free_tier_grants
+), burns AS (
+    SELECT
+        toStartOfHour(block_timestamp) AS burn_hour,
+        sum(burn_amount) AS burned_amount
+    FROM free_tier_burns
+    WHERE block_timestamp >= now() - INTERVAL 30 DAY
+    GROUP BY burn_hour
+)
+SELECT
+    burn_hour,
+    burned_amount,
+    (SELECT total_granted FROM grants) - sum(burned_amount) OVER (ORDER BY burn_hour ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS remaining_allocation
+FROM burns
+ORDER BY burn_hour ASC;
+
+-- =============================================
+-- Route balance reconciliation (ClickHouse)
+-- =============================================
+SELECT
+    toStartOfHour(snapshot_at) AS hour_bucket,
+    wallet_label,
+    sum(balance_usd) AS balance_usd
+FROM wallet_balance_snapshots
+WHERE wallet_label IN ('owner_nhb', 'znhb_proceeds', 'owner_usdc')
+  AND snapshot_at >= now() - INTERVAL 14 DAY
+GROUP BY hour_bucket, wallet_label
+ORDER BY hour_bucket DESC;

--- a/docs/transparency/fees-dashboard.md
+++ b/docs/transparency/fees-dashboard.md
@@ -1,0 +1,68 @@
+# Network-wide Fee Transparency Dashboard
+
+The fees dashboard is the canonical reference for understanding how network fees accrue, are
+recognized, and ultimately settle into the Network Hub Bank (NHB) treasury accounts. It combines
+on-chain event data with custodied wallet balances to deliver a reconciled view of fee revenue and
+free-tier consumption.
+
+## Methodology
+
+The dashboard is composed of two data lenses that are reconciled on a daily basis:
+
+1. **On-chain events** &mdash; Streaming the `FeeCharged` and `FeeSettled` events emitted by
+   the settlement contracts. These events are used to calculate per-transaction fees, domain-level
+   aggregates, and free-tier burns. All examples use the SQL and RPC snippets published in
+   [`docs/queries/fees.sql`](../queries/fees.sql) and [`docs/api/fees-query.md`](../api/fees-query.md).
+2. **Wallet balances** &mdash; Tracking the NHB owner multi-sig, ZNHB proceeds wallet, and USDC
+   payout wallet across the supported L2 networks. Balance snapshots are ingested hourly and rolled
+   up to daily closing positions.
+
+The delta between event-derived fees and wallet balance movements is surfaced in the
+**Reconciliation Checklist** panel so finance teams can investigate variances quickly.
+
+## Core Panels
+
+The dashboard publishes the following top-level widgets:
+
+- **Daily Fee Totals** &mdash; Total fees collected in the last 24h with a trendline overlay for the
+  last 14 days. This panel is backed by the `daily_fee_totals` query and highlights the split between
+  protocol fees and passthrough network fees.
+- **30-Day Moving Window** &mdash; A cumulative sum of daily fees over a rolling 30-day period to reveal
+  gross revenue momentum.
+- **Fee by Domain** &mdash; Bar chart comparing fee realization by domain (e.g. `gateway`, `swap`,
+  `loyalty`). The Grafana panel uses the `fee_total_by_domain` series produced by the ClickHouse
+  query in `docs/queries/fees.sql`.
+- **Top Merchants** &mdash; Table of the top 20 merchants by fees charged over the selected time range,
+  including transaction counts and average fee per transaction.
+- **Free-tier Utilization** &mdash; Combines the `free_tier_burn_down` series and remaining allocation
+  to highlight how much of the subsidized quota remains. Alerting is configured at 80% consumption.
+
+## Drill-down Metrics
+
+For deeper analysis, use the following interactive panels:
+
+- **Fee p95 per Transaction** &mdash; P95, median, and minimum per-transaction fees to identify outlier
+  routing costs.
+- **Route Balances** &mdash; Wallet balance spark-lines for the NHB routing accounts (owner NHB wallet,
+  ZNHB proceeds wallet, owner USDC wallet) with annotations for manual adjustments.
+- **Free-tier Event Log** &mdash; Filterable table of free-tier grant issuances and burns for support
+  teams investigating customer questions.
+
+## Reconciliation Checklist
+
+Finance should complete this checklist as part of daily close:
+
+1. **Owner NHB wallet** &mdash; Confirm balance change matches the net of fees routed into NHB. Expected
+   delta: `fee_total_by_domain` minus passthrough network reimbursements.
+2. **ZNHB proceeds wallet** &mdash; Validate inflows align with fee settlements earmarked for ZNHB
+   buybacks. Expected delta: 0 after accounting for pending swaps queued in the bridge contract.
+3. **Owner USDC wallet** &mdash; Verify payouts to treasury match the USDC portion of collected fees.
+   Expected delta: pending merchant reimbursements < 2% of prior-day fees.
+
+Any discrepancies should be logged in the finance recon issue template and investigated within 24h.
+
+## Operational Notes
+
+- Dashboard auto-refresh interval is 5 minutes; p95 panels require 24h backfill after deployment.
+- Queries are versioned alongside these docs. Update both the SQL and RPC references when modifying
+  metrics to keep data consumers aligned.

--- a/ops/grafana/dashboards/fees.json
+++ b/ops/grafana/dashboards/fees.json
@@ -1,0 +1,225 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1717100000000,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-fees"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "query": "SELECT $timeSeries as t, domain, sum(fee_total_by_domain) AS value FROM fee_total_by_domain WHERE t >= now() - INTERVAL 30 DAY GROUP BY t, domain ORDER BY t",
+          "rawQuery": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Fee Total by Domain",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-fees"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "hidden"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "query": "SELECT $timeSeries as t, quantileExactWeighted(0.95)(fee_per_tx, 1) AS value FROM fee_p95_per_tx WHERE t >= now() - INTERVAL 30 DAY GROUP BY t ORDER BY t",
+          "rawQuery": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Fee p95 per Transaction",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-fees"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": ""
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "format": "table",
+          "query": "SELECT $timeSeries as t, burned_ratio FROM free_tier_burn_down WHERE t >= now() - INTERVAL 30 DAY ORDER BY t",
+          "rawQuery": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Free Tier Burn Down",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse-fees"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "format": "time_series",
+          "query": "SELECT $timeSeries as t, wallet_label, balance_usd FROM route_balances WHERE t >= now() - INTERVAL 14 DAY ORDER BY t",
+          "rawQuery": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Route Balances",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "fees",
+    "transparency"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "NHB Fee Transparency",
+  "uid": "fee-transparency",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary
- document the network-wide fee transparency dashboard methodology and reconciliation process
- publish SQL and API examples for exporting fee settlements into analytics stores
- add Grafana panels for fee totals, p95 per transaction, free-tier burn down, and route balances

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e449814c98832d8295af880de5690a