### PR TITLE
DOCS-BUGCHECK-3: publish bugcheck reports to docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
         env:
           GOFLAGS: -buildvcs=false
         run: bash scripts/bugcheck.sh
+      - name: Publish bugcheck docs
+        if: always()
+        run: bash scripts/publish_bugcheck.sh
       - name: Upload bugcheck artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -65,6 +68,17 @@ jobs:
           path: |
             logs/
             artifacts/bugcheck-*
+          if-no-files-found: ignore
+      - name: Upload bugcheck docs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bugcheck-docs
+          path: |
+            docs/audit/index.md
+            docs/audit/latest.md
+            docs/audit/_meta.json
+            docs/audit/history/
           if-no-files-found: ignore
 
   audit-endpoints:

--- a/docs/audit/_meta.json
+++ b/docs/audit/_meta.json
@@ -1,0 +1,15 @@
+{
+  "overview": "Audit program overview",
+  "docs-quality": "Documentation quality checks",
+  "e2e-flows": "End-to-end flows",
+  "fuzzing": "Fuzzing coverage",
+  "recon": "Ledger reconciliation",
+  "static-analysis": "Static analysis",
+  "latest": "Latest bugcheck report",
+  "index": "Bugcheck history",
+  "history": {
+    "title": "Historical reports",
+    "type": "folder",
+    "items": {}
+  }
+}

--- a/docs/audit/index.md
+++ b/docs/audit/index.md
@@ -1,0 +1,22 @@
+# Bugcheck history
+
+The [latest bugcheck report](./latest.md) is automatically published after every pipeline run.
+
+## Reading the report
+
+Bugcheck gates must remain **PASS** to ship:
+
+- **Static security** – staticcheck, go vet, golangci-lint, gosec, govulncheck.
+- **Race tests** – `go test -race` across the full module graph.
+- **Fuzzing** – coverage-guided fuzzing on critical state transitions.
+- **Determinism** – multi-node determinism, state sync, and BFT safety checks.
+- **Chaos** – container, network, and process fault injection resilience.
+- **Performance** – proposer throughput and finality latency SLO verification.
+- **Protobuf** – Buf lint and breaking-change contracts for all APIs.
+- **Docs** – documentation linting, snippet verification, and example execution.
+
+## Past runs
+
+| Timestamp (UTC) | Report |
+| --- | --- |
+<!-- BUGCHECK_HISTORY -->

--- a/docs/audit/latest.md
+++ b/docs/audit/latest.md
@@ -1,0 +1,5 @@
+# Latest bugcheck report
+
+> ℹ️ This file is automatically updated by `scripts/publish_bugcheck.sh` after each CI run of the bugcheck pipeline.
+>
+> Run `bash scripts/publish_bugcheck.sh` locally once a bugcheck report exists in `audit/` to refresh this page.

--- a/docs/changelogs/DOCS-BUGCHECK-3.md
+++ b/docs/changelogs/DOCS-BUGCHECK-3.md
@@ -1,0 +1,5 @@
+# DOCS-BUGCHECK-3 — Publish bugcheck reports in docs site
+
+- add automated publication script that syncs the newest `audit/bugcheck-*.md` report into `docs/audit/latest.md`, archives history, and keeps navigation metadata current.
+- expose a bugcheck history page with PASS/FAIL gate guidance and append-only run index.
+- integrate the publication step into CI and ship generated docs as build artifacts.

--- a/scripts/publish_bugcheck.sh
+++ b/scripts/publish_bugcheck.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+AUDIT_DIR="${REPO_ROOT}/audit"
+DOCS_DIR="${REPO_ROOT}/docs/audit"
+HISTORY_DIR="${DOCS_DIR}/history"
+INDEX_FILE="${DOCS_DIR}/index.md"
+LATEST_FILE="${DOCS_DIR}/latest.md"
+META_FILE="${DOCS_DIR}/_meta.json"
+MARKER="<!-- BUGCHECK_HISTORY -->"
+
+mkdir -p "${DOCS_DIR}" "${HISTORY_DIR}"
+
+shopt -s nullglob
+reports=("${AUDIT_DIR}"/report-*.md "${AUDIT_DIR}"/bugcheck-*.md)
+shopt -u nullglob
+
+filtered_reports=()
+for report in "${reports[@]}"; do
+  if [[ -f "${report}" ]]; then
+    filtered_reports+=("${report}")
+  fi
+done
+
+if (( ${#filtered_reports[@]} == 0 )); then
+  echo "publish_bugcheck: no bugcheck markdown reports found under ${AUDIT_DIR}" >&2
+  exit 1
+fi
+
+latest_report=$(ls -1t "${filtered_reports[@]}" | head -n1)
+if [[ -z "${latest_report}" ]]; then
+  echo "publish_bugcheck: failed to determine latest report" >&2
+  exit 1
+fi
+
+latest_name="$(basename "${latest_report}")"
+latest_slug="${latest_name%.md}"
+if [[ -z "${latest_slug}" ]]; then
+  echo "publish_bugcheck: unable to derive slug from ${latest_name}" >&2
+  exit 1
+fi
+
+mapfile -t time_parts < <(python3 - "$latest_report" <<'PY'
+import datetime
+import os
+import sys
+path = sys.argv[1]
+try:
+    mtime = os.path.getmtime(path)
+    dt = datetime.datetime.utcfromtimestamp(mtime)
+except Exception:
+    dt = datetime.datetime.utcnow()
+print(dt.strftime('%Y-%m-%d %H:%M:%SZ'))
+print(dt.strftime('%Y-%m-%d %H:%M UTC'))
+PY
+)
+
+latest_timestamp="${time_parts[0]}"
+latest_display="${time_parts[1]}"
+
+history_markdown="${HISTORY_DIR}/${latest_slug}.md"
+cp "${latest_report}" "${history_markdown}"
+cp "${latest_report}" "${LATEST_FILE}"
+
+declare -a json_candidates=(
+  "${AUDIT_DIR}/${latest_slug}.json"
+  "${REPO_ROOT}/artifacts/${latest_slug}.json"
+)
+for candidate in "${json_candidates[@]}"; do
+  if [[ -f "${candidate}" ]]; then
+    cp "${candidate}" "${HISTORY_DIR}/${latest_slug}.json"
+    break
+  fi
+done
+
+if [[ ! -f "${INDEX_FILE}" ]]; then
+  cat <<'TEMPLATE' > "${INDEX_FILE}"
+# Bugcheck history
+
+The [latest bugcheck report](./latest.md) is automatically published after every pipeline run.
+
+## Reading the report
+
+Bugcheck gates must remain **PASS** to ship:
+
+- **Static security** – staticcheck, go vet, golangci-lint, gosec, govulncheck.
+- **Race tests** – `go test -race` across the full module graph.
+- **Fuzzing** – coverage-guided fuzzing on critical state transitions.
+- **Determinism** – multi-node determinism, state sync, and BFT safety checks.
+- **Chaos** – container, network, and process fault injection resilience.
+- **Performance** – proposer throughput and finality latency SLO verification.
+- **Protobuf** – Buf lint and breaking-change contracts for all APIs.
+- **Docs** – documentation linting, snippet verification, and example execution.
+
+## Past runs
+
+| Timestamp (UTC) | Report |
+| --- | --- |
+<!-- BUGCHECK_HISTORY -->
+TEMPLATE
+fi
+
+if ! grep -q "${MARKER}" "${INDEX_FILE}"; then
+  echo "${MARKER}" >> "${INDEX_FILE}" || true
+fi
+
+python3 - "$INDEX_FILE" "$MARKER" "$latest_timestamp" "$latest_slug" <<'PY'
+import sys
+from pathlib import Path
+
+index_path = Path(sys.argv[1])
+marker = sys.argv[2]
+timestamp = sys.argv[3]
+slug = sys.argv[4]
+link = f"| {timestamp} | [{slug}](./history/{slug}.md) |"
+
+lines = index_path.read_text().splitlines()
+try:
+    marker_idx = lines.index(marker)
+except ValueError:
+    lines.append(marker)
+    marker_idx = len(lines) - 1
+
+if link not in lines:
+    lines.insert(marker_idx + 1, link)
+
+index_path.write_text("\n".join(lines) + "\n")
+PY
+
+python3 - "$META_FILE" "$latest_slug" "$latest_display" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+meta_path = Path(sys.argv[1])
+slug = sys.argv[2]
+pretty = sys.argv[3]
+
+if meta_path.exists():
+    data = json.loads(meta_path.read_text())
+else:
+    data = {}
+
+# Ensure friendly titles for existing audit docs.
+def ensure_title(key, title):
+    if key not in data:
+        data[key] = title
+    elif isinstance(data[key], str):
+        if not data[key]:
+            data[key] = title
+    elif isinstance(data[key], dict):
+        data[key].setdefault("title", title)
+
+ensure_title("overview", "Audit program overview")
+ensure_title("docs-quality", "Documentation quality checks")
+ensure_title("e2e-flows", "End-to-end flows")
+ensure_title("fuzzing", "Fuzzing coverage")
+ensure_title("recon", "Ledger reconciliation")
+ensure_title("static-analysis", "Static analysis")
+ensure_title("latest", "Latest bugcheck report")
+ensure_title("index", "Bugcheck history")
+
+history = data.get("history")
+if not isinstance(history, dict):
+    history = {"title": "Historical reports", "type": "folder", "items": {}}
+    data["history"] = history
+
+items = history.setdefault("items", {})
+items[slug] = {"title": pretty}
+
+meta_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+PY
+
+echo "Published ${latest_name} to docs/audit." >&2


### PR DESCRIPTION
## Summary
- add a publication script that syncs the newest bugcheck markdown into the docs site, archives history, and updates metadata
- expose a bugcheck history page with guidance on interpreting PASS/FAIL gates and prepare a docs changelog entry
- wire the publication step into CI so generated docs are captured as artifacts after every bugcheck run

## Testing
- not run (requires bugcheck artifacts to exist)


------
https://chatgpt.com/codex/tasks/task_e_68e44a670d40832da4356a6ac764b742