### PR TITLE
Add PoS readiness harness and automation

### DIFF
--- a/scripts/pos_readiness.sh
+++ b/scripts/pos_readiness.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$ROOT_DIR/logs/pos"
+mkdir -p "$LOG_DIR"
+
+cd "$ROOT_DIR"
+
+echo "[pos] building test binaries"
+make pos:build-tests | tee "$LOG_DIR/build.log"
+
+declare -a SUITES=(
+  "run-intent"
+  "run-paymaster"
+  "run-registry"
+  "run-realtime"
+  "run-security"
+  "run-fees"
+)
+
+for suite in "${SUITES[@]}"; do
+  target="pos:${suite}"
+  echo "[pos] running $target"
+  if ! make "$target"; then
+    echo "[pos] $target failed" >&2
+    exit 1
+  fi
+done
+
+echo "[pos] running pos:bench-qos"
+make pos:bench-qos
+
+echo "[pos] readiness profile completed"

--- a/tests/posreadiness/harness/minichain.go
+++ b/tests/posreadiness/harness/minichain.go
@@ -1,0 +1,145 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"nhbchain/core"
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	"nhbchain/rpc"
+	"nhbchain/storage"
+)
+
+// MiniChain bootstraps a lightweight in-memory NHB chain suitable for POS readiness tests.
+type MiniChain struct {
+	db        storage.Database
+	node      *core.Node
+	rpcServer *rpc.Server
+	rpcAddr   string
+
+	shutdownOnce sync.Once
+}
+
+// NewMiniChain constructs an in-memory chain with a stub finalizer and an in-process RPC server.
+func NewMiniChain() (*MiniChain, error) {
+	db := storage.NewMemDB()
+
+	validatorKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("generate validator key: %w", err)
+	}
+
+	node, err := core.NewNode(db, validatorKey, "", true)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("create node: %w", err)
+	}
+
+	server := rpc.NewServer(node, nil, rpc.ServerConfig{AllowInsecure: true})
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("listen for RPC: %w", err)
+	}
+
+	addr := listener.Addr().String()
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.Serve(listener)
+	}()
+
+	if err := waitForDial(addr, 2*time.Second, serveErr); err != nil {
+		_ = server.Shutdown(context.Background())
+		_ = listener.Close()
+		db.Close()
+		return nil, err
+	}
+
+	return &MiniChain{
+		db:        db,
+		node:      node,
+		rpcServer: server,
+		rpcAddr:   addr,
+	}, nil
+}
+
+// Node exposes the underlying core node.
+func (mc *MiniChain) Node() *core.Node {
+	if mc == nil {
+		return nil
+	}
+	return mc.node
+}
+
+// RPCAddr returns the listening address of the in-process RPC server.
+func (mc *MiniChain) RPCAddr() string {
+	if mc == nil {
+		return ""
+	}
+	return mc.rpcAddr
+}
+
+// FinalizeTxs builds and commits a block containing the supplied transactions.
+func (mc *MiniChain) FinalizeTxs(txs ...*types.Transaction) (*types.Block, error) {
+	if mc == nil || mc.node == nil {
+		return nil, fmt.Errorf("minichain not initialised")
+	}
+	block, err := mc.node.CreateBlock(txs)
+	if err != nil {
+		return nil, fmt.Errorf("create block: %w", err)
+	}
+	if err := mc.node.CommitBlock(block); err != nil {
+		return nil, fmt.Errorf("commit block: %w", err)
+	}
+	return block, nil
+}
+
+// Close releases all resources owned by the harness.
+func (mc *MiniChain) Close() error {
+	if mc == nil {
+		return nil
+	}
+	var err error
+	mc.shutdownOnce.Do(func() {
+		if mc.rpcServer != nil {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if shutdownErr := mc.rpcServer.Shutdown(shutdownCtx); shutdownErr != nil && !errors.Is(shutdownErr, context.Canceled) {
+				err = fmt.Errorf("shutdown rpc: %w", shutdownErr)
+			}
+		}
+		if mc.db != nil {
+			mc.db.Close()
+		}
+	})
+	return err
+}
+
+func waitForDial(addr string, timeout time.Duration, serveErr <-chan error) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		select {
+		case err := <-serveErr:
+			if err != nil && !errors.Is(err, net.ErrClosed) {
+				return fmt.Errorf("rpc server exited early: %w", err)
+			}
+			return nil
+		default:
+		}
+		conn, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("dial %s: %w", addr, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/tests/posreadiness/pos_profile.go
+++ b/tests/posreadiness/pos_profile.go
@@ -1,0 +1,50 @@
+//go:build posreadiness
+
+package posreadiness
+
+// Suite describes a single POS readiness check.
+type Suite struct {
+	Name string   // human-friendly identifier used for logs and targets
+	Args []string // go test binary arguments for this suite
+}
+
+const (
+	// BinaryName is the name of the compiled go test binary generated for the profile.
+	BinaryName = "posreadiness.test"
+	// ArtifactDir captures the directory used for readiness binaries.
+	ArtifactDir = "artifacts"
+	// LogDir captures the directory used for readiness logs.
+	LogDir = "logs/pos"
+)
+
+// Profile enumerates the suites included in the POS readiness profile.
+var Profile = []Suite{
+	{
+		Name: "intent",
+		Args: []string{"-test.v", "-test.run", "^TestIntentReadiness$"},
+	},
+	{
+		Name: "paymaster",
+		Args: []string{"-test.v", "-test.run", "^TestPaymasterReadiness$"},
+	},
+	{
+		Name: "registry",
+		Args: []string{"-test.v", "-test.run", "^TestRegistryReadiness$"},
+	},
+	{
+		Name: "realtime",
+		Args: []string{"-test.v", "-test.run", "^TestRealtimeReadiness$"},
+	},
+	{
+		Name: "security",
+		Args: []string{"-test.v", "-test.run", "^TestSecurityReadiness$"},
+	},
+	{
+		Name: "fees",
+		Args: []string{"-test.v", "-test.run", "^TestFeesReadiness$"},
+	},
+	{
+		Name: "bench-qos",
+		Args: []string{"-test.run", "^$", "-test.bench", "^BenchmarkPOSQOS$", "-test.benchmem"},
+	},
+}

--- a/tests/posreadiness/pos_profile_test.go
+++ b/tests/posreadiness/pos_profile_test.go
@@ -1,0 +1,214 @@
+//go:build posreadiness
+
+package posreadiness
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"nhbchain/core"
+	nhbstate "nhbchain/core/state"
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	"nhbchain/native/pos"
+	"nhbchain/tests/posreadiness/harness"
+)
+
+func newMiniChain(t *testing.T) *harness.MiniChain {
+	t.Helper()
+	chain, err := harness.NewMiniChain()
+	if err != nil {
+		t.Fatalf("new mini chain: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := chain.Close(); err != nil {
+			t.Fatalf("close minichain: %v", err)
+		}
+	})
+	return chain
+}
+
+func seedAccount(node *core.Node, key *crypto.PrivateKey, balance *big.Int) error {
+	return node.WithState(func(m *nhbstate.Manager) error {
+		account := &types.Account{BalanceNHB: new(big.Int).Set(balance), BalanceZNHB: big.NewInt(0)}
+		return m.PutAccount(key.PubKey().Address().Bytes(), account)
+	})
+}
+
+func buildTransferTx(key *crypto.PrivateKey, nonce uint64) (*types.Transaction, error) {
+	tx := &types.Transaction{
+		ChainID:  types.NHBChainID(),
+		Type:     types.TxTypeTransfer,
+		Nonce:    nonce,
+		GasLimit: 1,
+		GasPrice: big.NewInt(1),
+		Value:    big.NewInt(0),
+	}
+	if err := tx.Sign(key.PrivateKey); err != nil {
+		return nil, err
+	}
+	return tx, nil
+}
+
+func TestIntentReadiness(t *testing.T) {
+	chain := newMiniChain(t)
+	block, err := chain.FinalizeTxs()
+	if err != nil {
+		t.Fatalf("finalize empty block: %v", err)
+	}
+	if block == nil {
+		t.Fatalf("expected block")
+	}
+	if got := chain.Node().Chain().GetHeight(); got == 0 {
+		t.Fatalf("expected non-zero height after commit")
+	}
+}
+
+func TestPaymasterReadiness(t *testing.T) {
+	chain := newMiniChain(t)
+	node := chain.Node()
+	limits := core.PaymasterLimits{Global: big.NewInt(1)}
+	node.SetPaymasterLimits(limits)
+	snapshot := node.PaymasterLimits()
+	if snapshot.Global == nil || snapshot.Global.Cmp(limits.Global) != 0 {
+		t.Fatalf("unexpected limits snapshot: %+v", snapshot)
+	}
+}
+
+func TestRegistryReadiness(t *testing.T) {
+	chain := newMiniChain(t)
+	putErr := chain.Node().WithState(func(m *nhbstate.Manager) error {
+		return m.POSPutDevice(&pos.Device{DeviceID: "device-1", Merchant: "merchant-1"})
+	})
+	if putErr != nil {
+		t.Fatalf("put device: %v", putErr)
+	}
+	var fetched *pos.Device
+	var exists bool
+	getErr := chain.Node().WithState(func(m *nhbstate.Manager) error {
+		record, ok, err := m.POSGetDevice("device-1")
+		if err != nil {
+			return err
+		}
+		fetched = record
+		exists = ok
+		return nil
+	})
+	if getErr != nil {
+		t.Fatalf("get device: %v", getErr)
+	}
+	if !exists || fetched.DeviceID != "device-1" {
+		t.Fatalf("unexpected registry fetch: %#v exists=%v", fetched, exists)
+	}
+}
+
+func TestRealtimeReadiness(t *testing.T) {
+	chain := newMiniChain(t)
+	updates, cancel, backlog, err := chain.Node().POSFinalitySubscribe(context.Background(), "")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer cancel()
+	if len(backlog) != 0 {
+		t.Fatalf("expected empty backlog, got %d", len(backlog))
+	}
+	if _, err := chain.FinalizeTxs(); err != nil {
+		t.Fatalf("finalize block: %v", err)
+	}
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("expected finality update")
+	case update := <-updates:
+		if update.Status != core.POSFinalityStatusFinalized {
+			t.Fatalf("unexpected status: %s", update.Status)
+		}
+	}
+}
+
+func TestSecurityReadiness(t *testing.T) {
+	chain := newMiniChain(t)
+	node := chain.Node()
+	key, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	if err := seedAccount(node, key, big.NewInt(1_000_000)); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	tx, err := buildTransferTx(key, 0)
+	if err != nil {
+		t.Fatalf("build tx: %v", err)
+	}
+	if err := node.SubmitTransaction(tx); err != nil {
+		t.Fatalf("submit tx: %v", err)
+	}
+	mempool := node.GetMempool()
+	if len(mempool) == 0 {
+		t.Fatalf("expected mempool entry")
+	}
+}
+
+func TestFeesReadiness(t *testing.T) {
+	chain := newMiniChain(t)
+	node := chain.Node()
+	node.SetMempoolLimit(1)
+	node.SetTransactionSimulationEnabled(false)
+
+	key, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	if err := seedAccount(node, key, big.NewInt(1_000_000)); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	first, err := buildTransferTx(key, 0)
+	if err != nil {
+		t.Fatalf("build first tx: %v", err)
+	}
+	if err := node.SubmitTransaction(first); err != nil {
+		t.Fatalf("submit first tx: %v", err)
+	}
+	second, err := buildTransferTx(key, 1)
+	if err != nil {
+		t.Fatalf("build second tx: %v", err)
+	}
+	if err := node.SubmitTransaction(second); !errors.Is(err, core.ErrMempoolFull) {
+		t.Fatalf("expected mempool full error, got %v", err)
+	}
+}
+
+func BenchmarkPOSQOS(b *testing.B) {
+	chain, err := harness.NewMiniChain()
+	if err != nil {
+		b.Fatalf("new mini chain: %v", err)
+	}
+	defer chain.Close()
+	node := chain.Node()
+	node.SetTransactionSimulationEnabled(false)
+
+	key, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		b.Fatalf("generate key: %v", err)
+	}
+	if err := seedAccount(node, key, big.NewInt(1_000_000)); err != nil {
+		b.Fatalf("seed account: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tx, err := buildTransferTx(key, uint64(i))
+		if err != nil {
+			b.Fatalf("build tx: %v", err)
+		}
+		if err := node.SubmitTransaction(tx); err != nil && !errors.Is(err, core.ErrMempoolFull) {
+			b.Fatalf("submit tx: %v", err)
+		}
+		if _, err := chain.FinalizeTxs(); err != nil {
+			b.Fatalf("finalize: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a lightweight in-memory PoS mini-chain harness with RPC bootstrap helpers for readiness tests
- define a pos readiness test suite with focused smoke checks and benchmark coverage
- wire new pos targets and orchestration script for compiling and running the readiness profile

## Testing
- not run (existing Makefile target name scheme with colons fails to parse under GNU make in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e4505a4034832d8929480f88c29c6a