### PR TITLE
Add POS readiness QoS load harness and SLA test

### DIFF
--- a/bench/posloader/main.go
+++ b/bench/posloader/main.go
@@ -1,0 +1,323 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"nhbchain/core/types"
+	nhbcrypto "nhbchain/crypto"
+
+	"nhooyr.io/websocket"
+)
+
+const (
+	defaultDuration = 2 * time.Minute
+	defaultRate     = 600 // transactions per minute
+)
+
+type rpcRequest struct {
+	JSONRPC string        `json:"jsonrpc"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+	ID      int           `json:"id"`
+}
+
+type rpcError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Result  json.RawMessage `json:"result"`
+	Error   *rpcError       `json:"error"`
+	ID      int             `json:"id"`
+}
+
+type finalityPayload struct {
+	Type      string `json:"type"`
+	Cursor    string `json:"cursor"`
+	IntentRef string `json:"intentRef"`
+	TxHash    string `json:"txHash"`
+	Status    string `json:"status"`
+	Timestamp int64  `json:"ts"`
+}
+
+type latencyTracker struct {
+	mu        sync.Mutex
+	pending   map[string]time.Time
+	latencies []time.Duration
+}
+
+func newLatencyTracker() *latencyTracker {
+	return &latencyTracker{pending: make(map[string]time.Time)}
+}
+
+func (lt *latencyTracker) track(hash string, at time.Time) {
+	lt.mu.Lock()
+	lt.pending[strings.ToLower(hash)] = at
+	lt.mu.Unlock()
+}
+
+func (lt *latencyTracker) finalize(hash string, at time.Time) {
+	key := strings.ToLower(hash)
+	lt.mu.Lock()
+	start, ok := lt.pending[key]
+	if ok {
+		lt.latencies = append(lt.latencies, at.Sub(start))
+		delete(lt.pending, key)
+	}
+	lt.mu.Unlock()
+}
+
+func (lt *latencyTracker) snapshot() (latencies []time.Duration, pending int) {
+	lt.mu.Lock()
+	defer lt.mu.Unlock()
+	latencies = append([]time.Duration(nil), lt.latencies...)
+	pending = len(lt.pending)
+	return latencies, pending
+}
+
+func (lt *latencyTracker) waitForEmpty(ctx context.Context) bool {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		lt.mu.Lock()
+		remaining := len(lt.pending)
+		lt.mu.Unlock()
+		if remaining == 0 {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
+func main() {
+	var (
+		rpcURL       string
+		privateHex   string
+		txRate       int
+		durationFlag time.Duration
+		intentPrefix string
+	)
+	flag.StringVar(&rpcURL, "rpc", "http://127.0.0.1:8545", "RPC endpoint for submitting transactions")
+	flag.StringVar(&privateHex, "key", "", "hex-encoded secp256k1 private key for funding account (overrides POSLOADER_KEY)")
+	flag.IntVar(&txRate, "rate", defaultRate, "target rate of POS-tagged transactions per minute")
+	flag.DurationVar(&durationFlag, "duration", defaultDuration, "load duration")
+	flag.StringVar(&intentPrefix, "intent-prefix", "pos-load", "prefix for generated intent references")
+	flag.Parse()
+
+	if privateHex == "" {
+		privateHex = os.Getenv("POSLOADER_KEY")
+	}
+	privateHex = strings.TrimSpace(privateHex)
+	if privateHex == "" {
+		log.Fatal("missing private key: provide --key or POSLOADER_KEY")
+	}
+
+	keyBytes, err := hex.DecodeString(strings.TrimPrefix(privateHex, "0x"))
+	if err != nil {
+		log.Fatalf("decode private key: %v", err)
+	}
+	signer, err := nhbcrypto.PrivateKeyFromBytes(keyBytes)
+	if err != nil {
+		log.Fatalf("load private key: %v", err)
+	}
+
+	token := strings.TrimSpace(os.Getenv("NHB_RPC_TOKEN"))
+	if token == "" {
+		log.Fatal("missing NHB_RPC_TOKEN for RPC authentication")
+	}
+	parsed, err := url.Parse(rpcURL)
+	if err != nil {
+		log.Fatalf("parse rpc url: %v", err)
+	}
+	if parsed.Scheme == "" {
+		parsed.Scheme = "http"
+	}
+
+	if txRate <= 0 {
+		log.Fatalf("rate must be positive, got %d", txRate)
+	}
+	if durationFlag <= 0 {
+		durationFlag = defaultDuration
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	tracker := newLatencyTracker()
+
+	wsURL := *parsed
+	switch strings.ToLower(parsed.Scheme) {
+	case "https":
+		wsURL.Scheme = "wss"
+	default:
+		wsURL.Scheme = "ws"
+	}
+	wsURL.Path = "/ws/pos/finality"
+	wsURL.RawQuery = ""
+
+	wsCtx, wsCancel := context.WithTimeout(ctx, 5*time.Second)
+	conn, _, err := websocket.Dial(wsCtx, wsURL.String(), nil)
+	wsCancel()
+	if err != nil {
+		log.Fatalf("connect finality stream: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "load complete")
+
+	finalityCtx, finalityCancel := context.WithCancel(ctx)
+	defer finalityCancel()
+	go consumeFinality(finalityCtx, conn, tracker)
+
+	interval := time.Minute / time.Duration(txRate)
+	if interval <= 0 {
+		interval = time.Millisecond
+	}
+	deadline := time.Now().Add(durationFlag)
+	var nonce uint64
+	var submitted int
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			log.Printf("context cancelled: %v", ctx.Err())
+			return
+		default:
+		}
+		hash, err := submitPOSTransaction(ctx, httpClient, parsed, token, signer, intentPrefix, nonce)
+		if err != nil {
+			log.Printf("submit tx %d failed: %v", nonce, err)
+		} else {
+			tracker.track(hash, time.Now())
+			submitted++
+		}
+		nonce++
+		time.Sleep(interval)
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer waitCancel()
+	if !tracker.waitForEmpty(waitCtx) {
+		log.Printf("pending finality for %d transactions", trackerPending(tracker))
+	}
+
+	finalityCancel()
+
+	latencies, pending := tracker.snapshot()
+	reportLoadSummary(latencies, pending, submitted)
+}
+
+func submitPOSTransaction(ctx context.Context, client *http.Client, rpcURL *url.URL, token string, signer *nhbcrypto.PrivateKey, prefix string, nonce uint64) (string, error) {
+	tx := &types.Transaction{
+		ChainID:         types.NHBChainID(),
+		Type:            types.TxTypeTransfer,
+		Nonce:           nonce,
+		GasLimit:        53_000,
+		GasPrice:        big.NewInt(1),
+		IntentRef:       []byte(fmt.Sprintf("%s-%d", prefix, nonce)),
+		IntentExpiry:    uint64(time.Now().Add(5 * time.Minute).Unix()),
+		MerchantAddress: "pos-qos",
+		DeviceID:        "loader",
+		Value:           big.NewInt(0),
+	}
+	if err := tx.Sign(signer.PrivateKey); err != nil {
+		return "", fmt.Errorf("sign tx: %w", err)
+	}
+	hash, err := tx.Hash()
+	if err != nil {
+		return "", fmt.Errorf("hash tx: %w", err)
+	}
+
+	payload := rpcRequest{
+		JSONRPC: "2.0",
+		Method:  "nhb_sendTransaction",
+		Params:  []interface{}{tx},
+		ID:      1,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rpcURL.String(), bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("rpc call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var decoded rpcResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+	if decoded.Error != nil {
+		return "", fmt.Errorf("rpc error %d: %s", decoded.Error.Code, decoded.Error.Message)
+	}
+	return "0x" + hex.EncodeToString(hash), nil
+}
+
+func consumeFinality(ctx context.Context, conn *websocket.Conn, tracker *latencyTracker) {
+	for {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		var payload finalityPayload
+		if err := json.Unmarshal(data, &payload); err != nil {
+			log.Printf("decode finality payload: %v", err)
+			continue
+		}
+		if strings.EqualFold(payload.Status, "finalized") {
+			tracker.finalize(payload.TxHash, time.Now())
+		}
+	}
+}
+
+func trackerPending(t *latencyTracker) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.pending)
+}
+
+func reportLoadSummary(latencies []time.Duration, pending int, submitted int) {
+	var max time.Duration
+	var total time.Duration
+	for _, latency := range latencies {
+		if latency > max {
+			max = latency
+		}
+		total += latency
+	}
+	avg := time.Duration(0)
+	if len(latencies) > 0 {
+		avg = time.Duration(int64(total) / int64(len(latencies)))
+	}
+	log.Printf("POS loader submitted %d transactions", submitted)
+	log.Printf("Finalized %d transactions (pending: %d)", len(latencies), pending)
+	log.Printf("Latency avg=%s max=%s", avg, max)
+}

--- a/docs/slas/finality-and-qos.md
+++ b/docs/slas/finality-and-qos.md
@@ -1,0 +1,39 @@
+# POS Finality and QoS SLA Validation
+
+The `POS-READINESS-3` initiative introduces an automated readiness harness that verifies the
+priority lane remains healthy under sustained load. The goal is to ensure that POS-tagged
+transactions finalize within five seconds (p95) while the reserved lane does not saturate.
+
+## Load Harness (`bench/posloader`)
+
+The `bench/posloader` utility produces a stream of POS-tagged transactions against a JSON-RPC
+endpoint. Transactions are emitted at a configurable rate and the loader consumes the POS finality
+websocket stream to capture end-to-end latency. Usage:
+
+```bash
+go run ./bench/posloader \
+  --rpc http://127.0.0.1:8545 \
+  --rate 600 \
+  --duration 2m \
+  --intent-prefix pos-qos
+```
+
+Required environment variables:
+
+- `NHB_RPC_TOKEN` – bearer token for RPC authentication.
+- `POSLOADER_KEY` – hex-encoded secp256k1 private key seeded with gas funds.
+
+The loader logs submission totals, observed finality counts, and latency statistics to help diagnose
+violations.
+
+## Readiness Test (`TestPosQosSla`)
+
+`tests/posreadiness/qos/qos_test.go` boots an in-memory chain via the POS readiness harness,
+executes the load harness for a short burst, and then inspects Prometheus metrics:
+
+- `nhb_mempool_pos_lane_fill` must remain ≤ 1.0 to confirm the reserved lane does not saturate.
+- `nhb_mempool_pos_p95_finality_ms` must report a p95 latency ≤ 5,000 ms.
+- `nhb_mempool_pos_tx_enqueued_total` must match the number of finalized samples to guard against
+  starvation.
+
+The test fails if the SLA thresholds are exceeded or if finality events lag behind enqueue events.

--- a/tests/posreadiness/qos/qos_test.go
+++ b/tests/posreadiness/qos/qos_test.go
@@ -1,0 +1,236 @@
+//go:build posreadiness
+
+package posreadiness
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"math/big"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"nhbchain/core"
+	nhbstate "nhbchain/core/state"
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+	"nhbchain/tests/posreadiness/harness"
+)
+
+func TestPosQosSla(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("NHB_RPC_TOKEN", "pos-loader-token")
+
+	chain := newMiniChain(t)
+	node := chain.Node()
+	node.SetTransactionSimulationEnabled(false)
+	node.SetMempoolLimit(0)
+
+	key, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	if err := seedAccount(node, key, big.NewInt(10_000_000)); err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+	if _, err := chain.FinalizeTxs(); err != nil {
+		t.Fatalf("finalize seed block: %v", err)
+	}
+
+	duration := 25 * time.Second
+	loaderCtx, loaderCancel := context.WithTimeout(context.Background(), duration+45*time.Second)
+	defer loaderCancel()
+
+	rpcURL := fmt.Sprintf("http://%s", chain.RPCAddr())
+	privHex := hex.EncodeToString(key.Bytes())
+	rate := 3 // conservative to avoid RPC throttling
+
+	cmd := exec.CommandContext(loaderCtx, "go", "run", "./bench/posloader",
+		"--rpc", rpcURL,
+		"--rate", fmt.Sprintf("%d", rate),
+		"--duration", duration.String(),
+		"--intent-prefix", "pos-qos",
+	)
+	cmd.Dir = filepath.Join("..", "..", "..")
+	cmd.Env = append(os.Environ(),
+		"POSLOADER_KEY="+privHex,
+		"NHB_RPC_TOKEN="+os.Getenv("NHB_RPC_TOKEN"),
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- cmd.Run()
+	}()
+
+	drainCtx, drainCancel := context.WithCancel(context.Background())
+	defer drainCancel()
+	drainErrs := make(chan error, 1)
+	go func() {
+		ticker := time.NewTicker(200 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-drainCtx.Done():
+				return
+			case <-ticker.C:
+				if err := drainMempoolOnce(chain); err != nil {
+					select {
+					case drainErrs <- err:
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	if err := <-runErr; err != nil {
+		drainCancel()
+		t.Fatalf("pos loader failed: %v\nstdout:%s\nstderr:%s", err, stdout.String(), stderr.String())
+	}
+	drainCancel()
+	select {
+	case err := <-drainErrs:
+		t.Fatalf("mempool drain error: %v", err)
+	default:
+	}
+	t.Logf("posloader stdout:\n%s", stdout.String())
+	t.Logf("posloader stderr:\n%s", stderr.String())
+
+	time.Sleep(500 * time.Millisecond)
+	drainMempool(t, chain, 5*time.Second)
+
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+
+	var (
+		laneFill float64
+		enqueued float64
+		finality *dto.Histogram
+	)
+	for _, family := range metrics {
+		switch family.GetName() {
+		case "nhb_mempool_pos_lane_fill":
+			if len(family.Metric) > 0 && family.Metric[0].Gauge != nil {
+				laneFill = family.Metric[0].Gauge.GetValue()
+			}
+		case "nhb_mempool_pos_tx_enqueued_total":
+			if len(family.Metric) > 0 && family.Metric[0].Counter != nil {
+				enqueued = family.Metric[0].Counter.GetValue()
+			}
+		case "nhb_mempool_pos_p95_finality_ms":
+			if len(family.Metric) > 0 {
+				finality = family.Metric[0].Histogram
+			}
+		}
+	}
+
+	if finality == nil {
+		t.Fatalf("finality histogram not recorded")
+	}
+	t.Logf("lane fill %.3f, enqueued %.0f, finality samples %d", laneFill, enqueued, finality.GetSampleCount())
+	if finality.GetSampleCount() == 0 {
+		t.Fatalf("no finality samples captured")
+	}
+
+	p95 := histogramPercentile(finality, 0.95)
+	if p95 > 5_000 {
+		t.Fatalf("p95 finality exceeded SLA: %.2fms", p95)
+	}
+
+	if laneFill > 1.0 {
+		t.Fatalf("pos lane saturated: %.2f", laneFill)
+	}
+
+	enqueuedCount := uint64(math.Round(enqueued))
+	if enqueuedCount == 0 {
+		t.Fatalf("no POS transactions enqueued")
+	}
+	if finality.GetSampleCount() < enqueuedCount {
+		t.Fatalf("starvation detected: enqueued=%d finalized=%d", enqueuedCount, finality.GetSampleCount())
+	}
+}
+
+func histogramPercentile(hist *dto.Histogram, quantile float64) float64 {
+	if hist == nil {
+		return 0
+	}
+	total := hist.GetSampleCount()
+	if total == 0 {
+		return 0
+	}
+	rank := uint64(math.Ceil(float64(total) * quantile))
+	if rank == 0 {
+		rank = 1
+	}
+	var cumulative uint64
+	for _, bucket := range hist.Bucket {
+		cumulative = bucket.GetCumulativeCount()
+		if cumulative >= rank {
+			return bucket.GetUpperBound()
+		}
+	}
+	return hist.GetSampleSum() / float64(total)
+}
+
+func newMiniChain(t *testing.T) *harness.MiniChain {
+	t.Helper()
+	chain, err := harness.NewMiniChain()
+	if err != nil {
+		t.Fatalf("new mini chain: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := chain.Close(); err != nil {
+			t.Fatalf("close minichain: %v", err)
+		}
+	})
+	return chain
+}
+
+func seedAccount(node *core.Node, key *crypto.PrivateKey, balance *big.Int) error {
+	return node.WithState(func(m *nhbstate.Manager) error {
+		account := &types.Account{BalanceNHB: new(big.Int).Set(balance), BalanceZNHB: big.NewInt(0)}
+		return m.PutAccount(key.PubKey().Address().Bytes(), account)
+	})
+}
+
+func drainMempool(t *testing.T, chain *harness.MiniChain, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		node := chain.Node()
+		txs := node.GetMempool()
+		if len(txs) == 0 {
+			return
+		}
+		if _, err := chain.FinalizeTxs(txs...); err != nil {
+			t.Fatalf("finalize mempool: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("mempool drain timed out")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func drainMempoolOnce(chain *harness.MiniChain) error {
+	node := chain.Node()
+	txs := node.GetMempool()
+	if len(txs) == 0 {
+		return nil
+	}
+	_, err := chain.FinalizeTxs(txs...)
+	return err
+}


### PR DESCRIPTION
## Summary
- add a POS loader CLI that submits intent-backed transfers at a configurable rate and records finality latency via the websocket stream
- add a POS readiness quality-of-service test that runs the loader against the in-memory harness and enforces lane fill and p95 finality thresholds
- document the finality SLA validation workflow and loader usage under docs/slas

## Testing
- go test -tags posreadiness ./tests/posreadiness/qos -run TestPosQosSla -v

------
https://chatgpt.com/codex/tasks/task_e_68e4684d2e74832da947400a1851bec7