### PR TITLE
Secure swapd and payoutd admin endpoints

### DIFF
--- a/services/payoutd/auth.go
+++ b/services/payoutd/auth.go
@@ -1,0 +1,102 @@
+package payoutd
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// AuthConfig describes admin authentication options.
+type AuthConfig struct {
+	BearerToken string
+	AllowMTLS   bool
+}
+
+// Authenticator validates incoming admin requests.
+type Authenticator struct {
+	bearerToken string
+	allowBearer bool
+	allowMTLS   bool
+}
+
+// NewAuthenticator constructs an Authenticator from configuration.
+func NewAuthenticator(cfg AuthConfig) (*Authenticator, error) {
+	token := strings.TrimSpace(cfg.BearerToken)
+	allowBearer := token != ""
+	allowMTLS := cfg.AllowMTLS
+	if !allowBearer && !allowMTLS {
+		return nil, fmt.Errorf("at least one authentication mechanism must be configured")
+	}
+	return &Authenticator{bearerToken: token, allowBearer: allowBearer, allowMTLS: allowMTLS}, nil
+}
+
+// Middleware enforces authentication for admin handlers.
+func (a *Authenticator) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if a == nil {
+			http.Error(w, "authentication unavailable", http.StatusInternalServerError)
+			return
+		}
+		if a.authenticate(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+	})
+}
+
+func (a *Authenticator) authenticate(r *http.Request) bool {
+	if a == nil {
+		return false
+	}
+	if a.allowBearer && a.authenticateByBearer(r) {
+		return true
+	}
+	if a.allowMTLS && a.authenticateByMTLS(r) {
+		return true
+	}
+	return false
+}
+
+func (a *Authenticator) authenticateByBearer(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	token := parseBearerToken(r.Header.Get("Authorization"))
+	if token == "" {
+		return false
+	}
+	return token == a.bearerToken
+}
+
+func (a *Authenticator) authenticateByMTLS(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	state := r.TLS
+	if state == nil {
+		return false
+	}
+	if len(state.VerifiedChains) > 0 {
+		return true
+	}
+	if len(state.PeerCertificates) > 0 && state.HandshakeComplete {
+		return true
+	}
+	return false
+}
+
+func parseBearerToken(header string) string {
+	trimmed := strings.TrimSpace(header)
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.SplitN(trimmed, " ", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	if !strings.EqualFold(strings.TrimSpace(parts[0]), "bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}

--- a/services/payoutd/auth_test.go
+++ b/services/payoutd/auth_test.go
@@ -1,0 +1,78 @@
+package payoutd
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthenticatorAllowsBearer(t *testing.T) {
+	auth, err := NewAuthenticator(AuthConfig{BearerToken: "secret"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/pause", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	called := false
+	handler := auth.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	handler.ServeHTTP(recorder, request)
+	if !called {
+		t.Fatalf("expected handler to be called")
+	}
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("unexpected status: %d", recorder.Code)
+	}
+}
+
+func TestAuthenticatorAllowsMTLS(t *testing.T) {
+	auth, err := NewAuthenticator(AuthConfig{AllowMTLS: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/status", nil)
+	request.TLS = &tls.ConnectionState{
+		HandshakeComplete: true,
+		PeerCertificates:  []*x509.Certificate{{}},
+	}
+	called := false
+	handler := auth.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	handler.ServeHTTP(recorder, request)
+	if !called {
+		t.Fatalf("expected handler to be called")
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", recorder.Code)
+	}
+}
+
+func TestAuthenticatorRejectsUnauthenticated(t *testing.T) {
+	auth, err := NewAuthenticator(AuthConfig{BearerToken: "secret"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/status", nil)
+	handler := auth.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("handler should not be called")
+	}))
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", recorder.Code)
+	}
+}
+
+func TestNewAuthenticatorRequiresConfig(t *testing.T) {
+	if _, err := NewAuthenticator(AuthConfig{}); err == nil {
+		t.Fatalf("expected error when no authentication configured")
+	}
+}

--- a/services/swapd/server/auth.go
+++ b/services/swapd/server/auth.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// AuthConfig configures bearer token and mTLS authentication options.
+type AuthConfig struct {
+	BearerToken string
+	AllowMTLS   bool
+}
+
+// Authenticator verifies admin requests before they reach handlers.
+type Authenticator struct {
+	bearerToken string
+	allowBearer bool
+	allowMTLS   bool
+}
+
+// NewAuthenticator constructs an authenticator from configuration.
+func NewAuthenticator(cfg AuthConfig) (*Authenticator, error) {
+	token := strings.TrimSpace(cfg.BearerToken)
+	allowBearer := token != ""
+	allowMTLS := cfg.AllowMTLS
+	if !allowBearer && !allowMTLS {
+		return nil, fmt.Errorf("at least one authentication mechanism must be configured")
+	}
+	return &Authenticator{bearerToken: token, allowBearer: allowBearer, allowMTLS: allowMTLS}, nil
+}
+
+// Middleware enforces authentication for admin endpoints.
+func (a *Authenticator) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if a == nil {
+			http.Error(w, "authentication unavailable", http.StatusInternalServerError)
+			return
+		}
+		if a.authenticate(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+	})
+}
+
+func (a *Authenticator) authenticate(r *http.Request) bool {
+	if a == nil {
+		return false
+	}
+	if a.allowBearer && a.authenticateByBearer(r) {
+		return true
+	}
+	if a.allowMTLS && a.authenticateByMTLS(r) {
+		return true
+	}
+	return false
+}
+
+func (a *Authenticator) authenticateByBearer(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	header := r.Header.Get("Authorization")
+	token := parseBearerToken(header)
+	if token == "" {
+		return false
+	}
+	return token == a.bearerToken
+}
+
+func (a *Authenticator) authenticateByMTLS(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	state := r.TLS
+	if state == nil {
+		return false
+	}
+	if len(state.VerifiedChains) > 0 {
+		return true
+	}
+	if len(state.PeerCertificates) > 0 && state.HandshakeComplete {
+		return true
+	}
+	return false
+}
+
+func parseBearerToken(header string) string {
+	trimmed := strings.TrimSpace(header)
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.SplitN(trimmed, " ", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	if !strings.EqualFold(strings.TrimSpace(parts[0]), "bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}

--- a/services/swapd/server/auth_test.go
+++ b/services/swapd/server/auth_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthenticatorAllowsBearer(t *testing.T) {
+	auth, err := NewAuthenticator(AuthConfig{BearerToken: "secret"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	request.Header.Set("Authorization", "Bearer secret")
+	called := false
+	handler := auth.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	handler.ServeHTTP(recorder, request)
+	if !called {
+		t.Fatalf("expected handler to be called")
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", recorder.Code)
+	}
+}
+
+func TestAuthenticatorAllowsMTLS(t *testing.T) {
+	auth, err := NewAuthenticator(AuthConfig{AllowMTLS: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/admin", nil)
+	request.TLS = &tls.ConnectionState{
+		HandshakeComplete: true,
+		PeerCertificates:  []*x509.Certificate{{}},
+	}
+	called := false
+	handler := auth.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	handler.ServeHTTP(recorder, request)
+	if !called {
+		t.Fatalf("expected handler to be called")
+	}
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("unexpected status: %d", recorder.Code)
+	}
+}
+
+func TestAuthenticatorRejectsUnauthenticated(t *testing.T) {
+	auth, err := NewAuthenticator(AuthConfig{BearerToken: "secret"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	handler := auth.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("handler should not be called")
+	}))
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", recorder.Code)
+	}
+}
+
+func TestNewAuthenticatorRequiresConfig(t *testing.T) {
+	if _, err := NewAuthenticator(AuthConfig{}); err == nil {
+		t.Fatalf("expected error when no auth mechanisms configured")
+	}
+}

--- a/services/swapd/server/stable_handlers_test.go
+++ b/services/swapd/server/stable_handlers_test.go
@@ -40,13 +40,17 @@ func TestStableHandlersFlow(t *testing.T) {
 		MaxSlippageBps: 50,
 		SoftInventory:  1_000_000,
 	}
+	auth, err := NewAuthenticator(AuthConfig{BearerToken: "test-token"})
+	if err != nil {
+		t.Fatalf("new authenticator: %v", err)
+	}
 	srv, err := New(Config{ListenAddress: ":0", PolicyID: "default"}, store, log.New(io.Discard, "", 0), StableRuntime{
 		Enabled: true,
 		Engine:  engine,
 		Limits:  limits,
 		Assets:  []stable.Asset{asset},
 		Now:     func() time.Time { return base.Add(10 * time.Second) },
-	})
+	}, auth)
 	if err != nil {
 		t.Fatalf("new server: %v", err)
 	}
@@ -95,7 +99,11 @@ func TestStableHandlersDisabled(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 
-	srv, err := New(Config{ListenAddress: ":0", PolicyID: "default"}, store, log.New(io.Discard, "", 0), StableRuntime{})
+	auth, err := NewAuthenticator(AuthConfig{BearerToken: "test-token"})
+	if err != nil {
+		t.Fatalf("new authenticator: %v", err)
+	}
+	srv, err := New(Config{ListenAddress: ":0", PolicyID: "default"}, store, log.New(io.Discard, "", 0), StableRuntime{}, auth)
 	if err != nil {
 		t.Fatalf("new server: %v", err)
 	}


### PR DESCRIPTION
## Summary
- extend swapd and payoutd configs with admin security options, TLS certificate paths, and optional mTLS client CA material
- enforce bearer-token or mTLS authentication on admin handlers while requiring TLS unless explicitly disabled
- add unit tests for the new middleware and document deployment guidance for the secured endpoints

## Testing
- time GOWORK=off go test ./services/swapd/server -run Authenticator -count=1 -v
- time go test ./services/payoutd -run Authenticator -count=1 -v

------
https://chatgpt.com/codex/tasks/task_e_68e491ccc860832db8fa985570970fc4