### PR TITLE
Adjust loyalty base reward defaults to 50bps

### DIFF
--- a/core/loyalty_integration_test.go
+++ b/core/loyalty_integration_test.go
@@ -43,7 +43,7 @@ func TestLoyaltyEngineAppliesBaseAndProgramRewards(t *testing.T) {
 	cfg := (&loyalty.GlobalConfig{
 		Active:       true,
 		Treasury:     treasury[:],
-		BaseBps:      500,
+		BaseBps:      50,
 		MinSpend:     big.NewInt(100),
 		CapPerTx:     big.NewInt(500),
 		DailyCapUser: big.NewInt(1_000),
@@ -117,7 +117,7 @@ func TestLoyaltyEngineAppliesBaseAndProgramRewards(t *testing.T) {
 	testState := &testLoyaltyState{StateProcessor: sp}
 	sp.LoyaltyEngine.OnTransactionSuccess(testState, ctx)
 
-	expectedBase := big.NewInt(100)    // 2000 * 500 / 10000
+	expectedBase := big.NewInt(10)     // 2000 * 50 / 10000
 	expectedProgram := big.NewInt(240) // 2000 * 1200 / 10000 capped by 400 -> 240
 	totalExpected := new(big.Int).Add(expectedBase, expectedProgram)
 	if ctx.FromAccount.BalanceZNHB.Cmp(totalExpected) != 0 {
@@ -128,8 +128,8 @@ func TestLoyaltyEngineAppliesBaseAndProgramRewards(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load treasury: %v", err)
 	}
-	if treasuryAcc.BalanceZNHB.String() != "900" {
-		t.Fatalf("expected treasury balance 900, got %s", treasuryAcc.BalanceZNHB.String())
+	if treasuryAcc.BalanceZNHB.String() != "990" {
+		t.Fatalf("expected treasury balance 990, got %s", treasuryAcc.BalanceZNHB.String())
 	}
 
 	paymasterAcc, err := sp.getAccount(paymaster[:])

--- a/docs/loyalty/loyalty.md
+++ b/docs/loyalty/loyalty.md
@@ -82,6 +82,20 @@ Programs are stored as structured data within the chain’s state. Typical field
 * `includeP2P` (`bool`): include P2P escrow releases; default `false`.
 * `metadata` (`map[string]string`): optional key/value data surfaced via analytics.
 
+### Global base reward
+
+The chain stores a single `loyalty.GlobalConfig` record that governs the optional
+network-wide base reward. Operators can toggle or tune it through governance:
+
+* `Active` (`bool`): when `false`, base rewards are skipped entirely.
+* `Treasury` (`[20]byte`): address that funds base payouts.
+* `BaseBps` (`uint32`): network default is **50 bps (0.5%)**, minting 0.5 ZNHB for every 100 NHB of qualifying spend.
+* `MinSpend`, `CapPerTx`, `DailyCapUser` (`*big.Int`): caps expressed in wei (18 decimal places).
+
+With the default 50 bps rate, a settlement of `100 NHB` (`100 * 10^18` wei) accrues
+`0.5 ZNHB` (`5 * 10^17` wei) so long as the treasury holds enough balance and the
+per-transaction and daily caps permit it.
+
 ### Deterministic meters
 
 Meters are ledger entries that enforce daily caps and provide fast analytics queries:

--- a/docs/runbooks/pause-and-quotas.md
+++ b/docs/runbooks/pause-and-quotas.md
@@ -43,6 +43,12 @@ the latest block root, decodes `system/pauses`, and prints the module map.【F:e
 3. Re-run the inspection command to verify the pause state propagated. To resume
    a module replace `--state pause` with `--state resume`.
 
+> **ZNHB redemption tip:** Disabling cash-outs cleanly requires pausing both the on-chain
+> swap module (`global.pauses.swap`) and the `swapd` stable engine (`stable.paused` in
+> the YAML). Pause the service first to drain in-flight requests, then toggle the
+> on-chain flag. When restoring service, unpause `swapd` only after the governance
+> update clears the module pause so submitted redemptions will execute successfully.
+
 ## Inspect quota usage for an address
 
 1. Determine the module, target address, and quota epoch window. The helper

--- a/docs/swap/service.md
+++ b/docs/swap/service.md
@@ -90,6 +90,18 @@ The `/v1/stable/*` endpoints are published alongside the admin API and are curre
 `{"error": "stable engine not enabled"}`. The [Stable Funding API reference](stable-api.md) documents the success-path
 contracts that will activate once the engine is unpaused.
 
+### Pausing ZNHB redemption
+
+Two independent switches must be considered when enabling or disabling redemptions:
+
+* **On-chain:** `global.pauses.swap` (set via governance) halts swap module execution. When paused, any redemption transactions
+  submitted by `swapd` will fail even if the HTTP API is reachable.
+* **Service-side:** `swapd.stable.paused` (YAML `stable.paused`) keeps the `/v1/stable/*` endpoints disabled with a `501` response
+  to prevent new intents from being created.
+
+Production operations typically flip the service flag first to drain live traffic, then pause the on-chain module. Restoring
+redemptions requires clearing both toggles so `swapd` can submit transactions and consensus will execute them.
+
 ### Rate limits
 
 The following soft limits apply per account in preview and production mode:


### PR DESCRIPTION
## Summary
- update loyalty integration fixture and base engine unit tests to use a 50 bps base reward and add a precision test that proves a 100 NHB spend mints 0.5 ZNHB
- refresh documentation to describe the 0.5% default base reward and the interaction between global swap pauses and `swapd.stable.paused`

## Testing
- go test -v ./native/loyalty -run TestApplyBaseRewardDefaultRatePrecision -count=1
- go test -v ./core -run TestLoyaltyEngineAppliesBaseAndProgramRewards -count=1

------
https://chatgpt.com/codex/tasks/task_e_68e49771702c832db733b7be5313b915