### PR TITLE
Document reputation verifier authorization enforcement

### DIFF
--- a/docs/reputation/lifecycle.md
+++ b/docs/reputation/lifecycle.md
@@ -9,8 +9,10 @@ transitions.
 
 ## Issuance
 
-Verifiers call `Node.ReputationVerifySkill` to issue an attestation. The module
-normalizes the skill label, validates the payload and persists the record using
+Verifiers call `Node.ReputationVerifySkill` to issue an attestation. The node first
+confirms the caller holds `roleReputationVerifier`, returning
+`ErrReputationVerifierUnauthorized` if the membership check fails. Once authorized,
+the module normalizes the skill label, validates the payload and persists the record using
 an index keyed by `(subject, skill_hash, issuer)` for constant-time lookups.
 Optional expirations must be strictly after the issue time; attestations with an
 `expiresAt` in the past are rejected during validation.

--- a/docs/reputation/overview.md
+++ b/docs/reputation/overview.md
@@ -1,18 +1,26 @@
 # Reputation service overview
 
-The reputation module introduces a minimal skill verification primitive. Verifiers attest that a subject possesses a specific capability. The current release focuses on surfacing deterministic events while the on-chain role checks remain permissive stubs.
+The reputation module introduces a minimal skill verification primitive. Verifiers attest that a subject possesses a specific capability. The current release now enforces verifier authorization within the node; calls from wallets that do not hold the `roleReputationVerifier` assignment fail before any state transition.
 
 ## Verification flow
 
 1. A wallet with verifier privileges calls `reputation_verifySkill`.
 2. The RPC validates addresses, normalises skill strings and forwards the request to the core node.
-3. The node will, in a future update, enforce role membership, persist the verification and emit `reputation.skillVerified`.
+3. The node enforces role membership, persists the verification and emits `reputation.skillVerified`.
 
 The RPC returns the canonical payload comprising the subject, verifier, skill, issuance timestamp and optional expiry.
 
 ### Error semantics
 
 Validation failures return `codeInvalidParams` (`-32602`) with the specific guard encoded in the `message`/`data` pair (for example `"invalid_params"` + `"invalid bech32 string"` or `"skill required"`). Calls from wallets that lack the verifier role surface `codeUnauthorized` with HTTP `403`, while infrastructure failures fall back to `codeServerError` (`-32000`).
+
+### Authorization
+
+`Node.ReputationVerifySkill` checks that the caller holds `roleReputationVerifier` and returns `ErrReputationVerifierUnauthorized` when the role is missing. The RPC layer surfaces the error as `codeUnauthorized` (`403`) with the canonical message and `data` payload so client SDKs can present actionable guidance. Follow the [role allow-list governance workflow](../governance/overview.md#supported-proposal-kinds) to grant or revoke verifier privileges; operators running private networks can edit the genesis role map or submit equivalent `role.allowlist` proposals during rollout.
+
+### Migration considerations
+
+Earlier previews only emitted warnings when the caller lacked the verifier role. Integrations that relied on that soft enforcement must now ensure every attesting wallet holds `roleReputationVerifier` before submitting RPC calls. Update automated test fixtures, back-office runbooks, and multisig or KMS policies to cover the stricter requirement; failing to do so will result in `ErrReputationVerifierUnauthorized` responses and no attestation being recorded.
 
 ## Responsibilities of verifiers
 


### PR DESCRIPTION
## Summary
- update the reputation overview to describe the enforced role check, error semantics, and migration notes
- note in the lifecycle guide that `Node.ReputationVerifySkill` now returns `ErrReputationVerifierUnauthorized` when the caller lacks `roleReputationVerifier`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e49c6e98c0832da4a418c26212efe6