### PR TITLE
Mark lendingd service as preview

### DIFF
--- a/deploy/helm/lendingd/values.yaml
+++ b/deploy/helm/lendingd/values.yaml
@@ -1,4 +1,5 @@
-replicaCount: 1
+# lendingd is shipped as a preview. Keep replicas at 0 until RPC handlers are ready.
+replicaCount: 0
 
 image:
   repository: ghcr.io/nhbchain/lendingd

--- a/deploy/helm/values/dev/lendingd.yaml
+++ b/deploy/helm/values/dev/lendingd.yaml
@@ -6,3 +6,4 @@ env:
 config:
   content: |
     listen: ":50053"
+# lendingd preview – override replicaCount to 1+ to enable once stable

--- a/deploy/helm/values/prod/lendingd.yaml
+++ b/deploy/helm/values/prod/lendingd.yaml
@@ -10,3 +10,4 @@ resources:
   limits:
     cpu: 1
     memory: 1Gi
+# lendingd preview – override replicaCount to 1+ to enable once stable

--- a/deploy/helm/values/staging/lendingd.yaml
+++ b/deploy/helm/values/staging/lendingd.yaml
@@ -10,3 +10,4 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+# lendingd preview – override replicaCount to 1+ to enable once stable

--- a/docs/deploy/kubernetes.md
+++ b/docs/deploy/kubernetes.md
@@ -5,7 +5,7 @@ runtime service required in a production NHB stack:
 
 - `p2pd`
 - `consensusd`
-- `lendingd`
+- `lendingd` (preview – disabled by default)
 - `swapd`
 - `governd`
 - `gateway`
@@ -16,6 +16,10 @@ Each chart packages:
 - a Service definition
 - optional Ingress (gateway) and ConfigMaps for application configuration
 - knobs for persistence, resources, and environment variables
+
+> **Preview:** `lendingd` is included for completeness but the default values
+> scale it to zero replicas. Override `replicaCount` only if you are testing the
+> preview service and accept that all RPCs return `UNIMPLEMENTED`.
 
 ## Pre-requisites
 
@@ -35,7 +39,9 @@ Example (staging):
 ```sh
 helm upgrade --install p2pd deploy/helm/p2pd -f deploy/helm/values/staging/p2pd.yaml
 helm upgrade --install consensusd deploy/helm/consensusd -f deploy/helm/values/staging/consensusd.yaml
-helm upgrade --install lendingd deploy/helm/lendingd -f deploy/helm/values/staging/lendingd.yaml
+# (Optional once RPCs are implemented)
+# helm upgrade --install lendingd deploy/helm/lendingd -f deploy/helm/values/staging/lendingd.yaml \
+#   --set replicaCount=1
 helm upgrade --install swapd deploy/helm/swapd -f deploy/helm/values/staging/swapd.yaml
 helm upgrade --install governd deploy/helm/governd -f deploy/helm/values/staging/governd.yaml \
   --set secrets.signerKey="$(kubectl get secret nhb-governance -o jsonpath='{.data.signer-key}' | base64 -d)"

--- a/docs/deploy/local.md
+++ b/docs/deploy/local.md
@@ -22,7 +22,7 @@ The target builds fresh images for:
 
 - `p2pd`
 - `consensusd`
-- `lendingd`
+- `lendingd` (preview – disabled by default in Helm)
 - `swapd`
 - `governd`
 - `gateway`
@@ -38,7 +38,7 @@ without losing state.
 | gateway      | 8080 | REST gateway |
 | swapd        | 7074 | HTTP oracle |
 | governd      | 50061 | gRPC |
-| lendingd     | 50053 | gRPC |
+| lendingd     | 50053 | gRPC (preview – returns UNIMPLEMENTED) |
 | consensusd   | 9090 | gRPC (public) |
 | consensusd   | 8081 | HTTP RPC |
 | p2pd         | 26656 | Tendermint-style P2P |

--- a/docs/lending/service.md
+++ b/docs/lending/service.md
@@ -1,9 +1,14 @@
 # Lending Service (`lendingd`)
 
+> **Preview notice:** `lendingd` is shipped as a **disabled preview** while the
+> supply/withdraw/borrow/repay/liquidate flows are still being integrated with
+> the on-chain lending engine. The binary starts and reserves the canonical
+> gRPC port (`50053`) but every RPC currently returns `UNIMPLEMENTED`. The
+> service remains opt-in until the API is fully wired up.
+
 The `lendingd` daemon exposes the `lending.v1` gRPC API described in
-`proto/lending/v1/lending.proto`. The service currently starts an empty gRPC
-server that reserves the canonical port (`50053`) and will be extended in future
-iterations to proxy requests into the on-chain lending module.
+`proto/lending/v1/lending.proto`. Future iterations will proxy requests into the
+core lending engine once the remaining RPC handlers are implemented.
 
 ## Configuration
 
@@ -21,4 +26,5 @@ go run ./services/lendingd -config services/lending/config.yaml
 ```
 
 The server responds on the configured address but, at this stage, returns
-`UNIMPLEMENTED` for all RPCs.
+`UNIMPLEMENTED` for all RPCs. Deployments SHOULD keep the service disabled (the
+default in Helm charts) until the handlers are available.


### PR DESCRIPTION
## Summary
- flag the standalone lendingd service as a disabled preview across docs
- default the Helm chart to zero replicas and annotate environment values with opt-in guidance

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e49f03e2d8832da82d60be510c6dbc