### PR TITLE
Add swap pause runbook guidance and inspection helper

### DIFF
--- a/docs/swap/service.md
+++ b/docs/swap/service.md
@@ -97,10 +97,21 @@ Two independent switches must be considered when enabling or disabling redemptio
 * **On-chain:** `global.pauses.swap` (set via governance) halts swap module execution. When paused, any redemption transactions
   submitted by `swapd` will fail even if the HTTP API is reachable.
 * **Service-side:** `swapd.stable.paused` (YAML `stable.paused`) keeps the `/v1/stable/*` endpoints disabled with a `501` response
-  to prevent new intents from being created.
+  to prevent new intents from being created. Keep this flag set to `true` during readiness phases so OTC desks cannot cash out until go-live.
 
 Production operations typically flip the service flag first to drain live traffic, then pause the on-chain module. Restoring
-redemptions requires clearing both toggles so `swapd` can submit transactions and consensus will execute them.
+redemptions requires clearing both toggles so `swapd` can submit transactions and consensus will execute them. Use the helper to
+inspect both switches in one command:
+
+```bash
+go run ./examples/docs/ops/swap_pause_inspect \
+  --db ./nhb-data \
+  --consensus localhost:9090 \
+  --swapd https://swapd.internal.nhb
+```
+
+The CLI prints the current `global.pauses.swap` value and whether `/v1/stable/status` is returning a `501 stable engine not enabled`
+payload (paused) or live counters (active).
 
 ### Rate limits
 

--- a/docs/swap/stable-api.md
+++ b/docs/swap/stable-api.md
@@ -1,6 +1,6 @@
 # Stable Funding API
 
-The stable swap engine powers voucher liquidity, reserves cash-out intents, and records receipts for downstream treasury teams. The engine now runs in production for OTC desks whenever `swapd` is started with `stable.paused = false`. A small number of guard rails remain (soft quotas and throttles are described below), but the HTTP surface is live and wired directly to the in-memory `stable.Engine`.
+The stable swap engine powers voucher liquidity, reserves cash-out intents, and records receipts for downstream treasury teams. The engine now runs in production for OTC desks whenever `swapd` is started with `stable.paused = false`. Keep the flag at `true` during readiness phases so cash-out requests fail fast with `501 stable engine not enabled` while governance finalises launch approvals. A small number of guard rails remain (soft quotas and throttles are described below), but the HTTP surface is live and wired directly to the in-memory `stable.Engine`.
 
 This document captures the HTTP surface for `/v1/stable/*`, expected request/response shapes, rate limits, and the transparency hooks that bind quotes to reservations, cash-out intents, and banking receipts. Where applicable we also call out the behaviour when the engine is disabled so that playbooks remain accurate for dry runs.
 

--- a/examples/docs/ops/swap_pause_inspect/main.go
+++ b/examples/docs/ops/swap_pause_inspect/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"nhbchain/config"
+	"nhbchain/examples/docs/ops/internal/stateutil"
+)
+
+type stableError struct {
+	Error string `json:"error"`
+}
+
+type stableStatus struct {
+	Quotes       int `json:"quotes"`
+	Reservations int `json:"reservations"`
+	Assets       int `json:"assets"`
+}
+
+func main() {
+	dbPath := flag.String("db", "./nhb-data", "path to the consensus data directory")
+	consensusEndpoint := flag.String("consensus", "localhost:9090", "consensus gRPC endpoint")
+	swapdBase := flag.String("swapd", "http://localhost:7074", "base URL for swapd (scheme://host:port)")
+	flag.Parse()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	snapshot, err := stateutil.Load(ctx, *dbPath, *consensusEndpoint)
+	if err != nil {
+		log.Fatalf("load state snapshot: %v", err)
+	}
+	defer snapshot.Close()
+
+	swapPaused := false
+	raw, ok, err := snapshot.Manager.ParamStoreGet("system/pauses")
+	if err != nil {
+		log.Fatalf("read pause configuration: %v", err)
+	}
+	if ok && len(bytes.TrimSpace(raw)) > 0 {
+		var pauses config.Pauses
+		if err := json.Unmarshal(raw, &pauses); err != nil {
+			log.Fatalf("decode pause payload: %v", err)
+		}
+		swapPaused = pauses.Swap
+	}
+
+	fmt.Printf("state height %d (%s)\n", snapshot.Height, snapshot.Timestamp.Format(time.RFC3339))
+	fmt.Printf("global.pauses.swap: %t\n", swapPaused)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	stableURL := strings.TrimRight(*swapdBase, "/") + "/v1/stable/status"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, stableURL, nil)
+	if err != nil {
+		log.Fatalf("build stable status request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("query swapd stable status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("read swapd response: %v", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var status stableStatus
+		if err := json.Unmarshal(body, &status); err != nil {
+			log.Fatalf("decode stable status payload: %v", err)
+		}
+		fmt.Printf("swapd.stable.paused: false (quotes=%d reservations=%d assets=%d)\n", status.Quotes, status.Reservations, status.Assets)
+	case http.StatusNotImplemented:
+		var payload stableError
+		if err := json.Unmarshal(body, &payload); err != nil {
+			log.Fatalf("decode stable error payload: %v", err)
+		}
+		if payload.Error == "" {
+			payload.Error = string(body)
+		}
+		fmt.Printf("swapd.stable.paused: true (%s)\n", payload.Error)
+	default:
+		log.Fatalf("unexpected status from swapd: %d %s", resp.StatusCode, string(body))
+	}
+}

--- a/services/swapd/config.yaml
+++ b/services/swapd/config.yaml
@@ -23,7 +23,7 @@ policy:
   redeem_limit: 5
   window: "1h"
 stable:
-  paused: true
+  paused: true # keep redemptions disabled in readiness phases; flip to false once governance approves go-live
   quote_ttl: "1m"
   max_slippage_bps: 50
   soft_inventory: 1000000


### PR DESCRIPTION
## Summary
- add explicit mint versus redemption pause instructions across swap documentation and runbooks
- surface the swapd stable-engine pause flag in configuration samples with readiness commentary
- add a swap_pause_inspect helper to report global.pauses.swap alongside the swapd stable status endpoint

## Testing
- go test ./examples/docs/ops/...

------
https://chatgpt.com/codex/tasks/task_e_68e4a149596c832db430a61bbe33b1bd