### PR TITLE
Implement monthly fee free tier accounting

### DIFF
--- a/clients/ts/fees/v1/events.ts
+++ b/clients/ts/fees/v1/events.ts
@@ -17,7 +17,13 @@ export interface FeeApplied {
   feeWei: string;
   netWei: string;
   policyVersion: number;
-  routeWallet: Buffer;
+  ownerWallet: Buffer;
+  freeTierApplied: boolean;
+  freeTierLimit: number;
+  freeTierRemaining: number;
+  usageCount: number;
+  windowStartUnix: number;
+  feeBps: number;
 }
 
 function createBaseFeeApplied(): FeeApplied {
@@ -28,7 +34,13 @@ function createBaseFeeApplied(): FeeApplied {
     feeWei: "",
     netWei: "",
     policyVersion: 0,
-    routeWallet: Buffer.alloc(0),
+    ownerWallet: Buffer.alloc(0),
+    freeTierApplied: false,
+    freeTierLimit: 0,
+    freeTierRemaining: 0,
+    usageCount: 0,
+    windowStartUnix: 0,
+    feeBps: 0,
   };
 }
 
@@ -52,8 +64,26 @@ export const FeeApplied: MessageFns<FeeApplied> = {
     if (message.policyVersion !== 0) {
       writer.uint32(48).uint64(message.policyVersion);
     }
-    if (message.routeWallet.length !== 0) {
-      writer.uint32(58).bytes(message.routeWallet);
+    if (message.ownerWallet.length !== 0) {
+      writer.uint32(58).bytes(message.ownerWallet);
+    }
+    if (message.freeTierApplied === true) {
+      writer.uint32(64).bool(message.freeTierApplied);
+    }
+    if (message.freeTierLimit !== 0) {
+      writer.uint32(72).uint64(message.freeTierLimit);
+    }
+    if (message.freeTierRemaining !== 0) {
+      writer.uint32(80).uint64(message.freeTierRemaining);
+    }
+    if (message.usageCount !== 0) {
+      writer.uint32(88).uint64(message.usageCount);
+    }
+    if (message.windowStartUnix !== 0) {
+      writer.uint32(96).int64(message.windowStartUnix);
+    }
+    if (message.feeBps !== 0) {
+      writer.uint32(104).uint32(message.feeBps);
     }
     return writer;
   },
@@ -118,7 +148,55 @@ export const FeeApplied: MessageFns<FeeApplied> = {
             break;
           }
 
-          message.routeWallet = Buffer.from(reader.bytes());
+          message.ownerWallet = Buffer.from(reader.bytes());
+          continue;
+        }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.freeTierApplied = reader.bool();
+          continue;
+        }
+        case 9: {
+          if (tag !== 72) {
+            break;
+          }
+
+          message.freeTierLimit = longToNumber(reader.uint64());
+          continue;
+        }
+        case 10: {
+          if (tag !== 80) {
+            break;
+          }
+
+          message.freeTierRemaining = longToNumber(reader.uint64());
+          continue;
+        }
+        case 11: {
+          if (tag !== 88) {
+            break;
+          }
+
+          message.usageCount = longToNumber(reader.uint64());
+          continue;
+        }
+        case 12: {
+          if (tag !== 96) {
+            break;
+          }
+
+          message.windowStartUnix = longToNumber(reader.int64());
+          continue;
+        }
+        case 13: {
+          if (tag !== 104) {
+            break;
+          }
+
+          message.feeBps = reader.uint32();
           continue;
         }
       }
@@ -138,7 +216,13 @@ export const FeeApplied: MessageFns<FeeApplied> = {
       feeWei: isSet(object.feeWei) ? globalThis.String(object.feeWei) : "",
       netWei: isSet(object.netWei) ? globalThis.String(object.netWei) : "",
       policyVersion: isSet(object.policyVersion) ? globalThis.Number(object.policyVersion) : 0,
-      routeWallet: isSet(object.routeWallet) ? Buffer.from(bytesFromBase64(object.routeWallet)) : Buffer.alloc(0),
+      ownerWallet: isSet(object.ownerWallet) ? Buffer.from(bytesFromBase64(object.ownerWallet)) : Buffer.alloc(0),
+      freeTierApplied: isSet(object.freeTierApplied) ? globalThis.Boolean(object.freeTierApplied) : false,
+      freeTierLimit: isSet(object.freeTierLimit) ? globalThis.Number(object.freeTierLimit) : 0,
+      freeTierRemaining: isSet(object.freeTierRemaining) ? globalThis.Number(object.freeTierRemaining) : 0,
+      usageCount: isSet(object.usageCount) ? globalThis.Number(object.usageCount) : 0,
+      windowStartUnix: isSet(object.windowStartUnix) ? globalThis.Number(object.windowStartUnix) : 0,
+      feeBps: isSet(object.feeBps) ? globalThis.Number(object.feeBps) : 0,
     };
   },
 
@@ -162,8 +246,26 @@ export const FeeApplied: MessageFns<FeeApplied> = {
     if (message.policyVersion !== 0) {
       obj.policyVersion = Math.round(message.policyVersion);
     }
-    if (message.routeWallet.length !== 0) {
-      obj.routeWallet = base64FromBytes(message.routeWallet);
+    if (message.ownerWallet.length !== 0) {
+      obj.ownerWallet = base64FromBytes(message.ownerWallet);
+    }
+    if (message.freeTierApplied === true) {
+      obj.freeTierApplied = message.freeTierApplied;
+    }
+    if (message.freeTierLimit !== 0) {
+      obj.freeTierLimit = Math.round(message.freeTierLimit);
+    }
+    if (message.freeTierRemaining !== 0) {
+      obj.freeTierRemaining = Math.round(message.freeTierRemaining);
+    }
+    if (message.usageCount !== 0) {
+      obj.usageCount = Math.round(message.usageCount);
+    }
+    if (message.windowStartUnix !== 0) {
+      obj.windowStartUnix = Math.round(message.windowStartUnix);
+    }
+    if (message.feeBps !== 0) {
+      obj.feeBps = Math.round(message.feeBps);
     }
     return obj;
   },
@@ -179,7 +281,13 @@ export const FeeApplied: MessageFns<FeeApplied> = {
     message.feeWei = object.feeWei ?? "";
     message.netWei = object.netWei ?? "";
     message.policyVersion = object.policyVersion ?? 0;
-    message.routeWallet = object.routeWallet ?? Buffer.alloc(0);
+    message.ownerWallet = object.ownerWallet ?? Buffer.alloc(0);
+    message.freeTierApplied = object.freeTierApplied ?? false;
+    message.freeTierLimit = object.freeTierLimit ?? 0;
+    message.freeTierRemaining = object.freeTierRemaining ?? 0;
+    message.usageCount = object.usageCount ?? 0;
+    message.windowStartUnix = object.windowStartUnix ?? 0;
+    message.feeBps = object.feeBps ?? 0;
     return message;
   },
 };

--- a/config/config.go
+++ b/config/config.go
@@ -21,20 +21,20 @@ import (
 )
 
 type Config struct {
-        ListenAddress         string          `toml:"ListenAddress"`
-        RPCAddress            string          `toml:"RPCAddress"`
-        RPCTrustedProxies     []string        `toml:"RPCTrustedProxies"`
-        RPCTrustProxyHeaders  bool            `toml:"RPCTrustProxyHeaders"`
-        RPCReadHeaderTimeout  int             `toml:"RPCReadHeaderTimeout"`
-        RPCReadTimeout        int             `toml:"RPCReadTimeout"`
-        RPCWriteTimeout       int             `toml:"RPCWriteTimeout"`
-        RPCIdleTimeout        int             `toml:"RPCIdleTimeout"`
-        RPCAllowInsecure      bool            `toml:"RPCAllowInsecure"`
-        RPCTLSCertFile        string          `toml:"RPCTLSCertFile"`
-        RPCTLSKeyFile         string          `toml:"RPCTLSKeyFile"`
-        RPCTLSClientCAFile    string          `toml:"RPCTLSClientCAFile"`
-        DataDir               string          `toml:"DataDir"`
-        GenesisFile           string          `toml:"GenesisFile"`
+	ListenAddress         string          `toml:"ListenAddress"`
+	RPCAddress            string          `toml:"RPCAddress"`
+	RPCTrustedProxies     []string        `toml:"RPCTrustedProxies"`
+	RPCTrustProxyHeaders  bool            `toml:"RPCTrustProxyHeaders"`
+	RPCReadHeaderTimeout  int             `toml:"RPCReadHeaderTimeout"`
+	RPCReadTimeout        int             `toml:"RPCReadTimeout"`
+	RPCWriteTimeout       int             `toml:"RPCWriteTimeout"`
+	RPCIdleTimeout        int             `toml:"RPCIdleTimeout"`
+	RPCAllowInsecure      bool            `toml:"RPCAllowInsecure"`
+	RPCTLSCertFile        string          `toml:"RPCTLSCertFile"`
+	RPCTLSKeyFile         string          `toml:"RPCTLSKeyFile"`
+	RPCTLSClientCAFile    string          `toml:"RPCTLSClientCAFile"`
+	DataDir               string          `toml:"DataDir"`
+	GenesisFile           string          `toml:"GenesisFile"`
 	AllowAutogenesis      bool            `toml:"AllowAutogenesis"`
 	ValidatorKeystorePath string          `toml:"ValidatorKeystorePath"`
 	ValidatorKMSURI       string          `toml:"ValidatorKMSURI"`
@@ -141,6 +141,10 @@ func defaultGlobalConfig() Global {
 		Paymaster: Paymaster{
 			MerchantDailyCapWei: "0",
 			GlobalDailyCapWei:   "0",
+		},
+		Fees: Fees{
+			FreeTierTxPerMonth: DefaultFreeTierTxPerMonth,
+			MDRBasisPoints:     DefaultMDRBasisPoints,
 		},
 	}
 }
@@ -525,6 +529,15 @@ func (cfg *Config) ensureGlobalDefaults(meta toml.MetaData) {
 	}
 	if !meta.IsDefined("global", "paymaster", "DeviceDailyTxCap") {
 		cfg.Global.Paymaster.DeviceDailyTxCap = defaults.Paymaster.DeviceDailyTxCap
+	}
+	if !meta.IsDefined("global", "fees", "FreeTierTxPerMonth") {
+		cfg.Global.Fees.FreeTierTxPerMonth = defaults.Fees.FreeTierTxPerMonth
+	}
+	if !meta.IsDefined("global", "fees", "MDRBasisPoints") {
+		cfg.Global.Fees.MDRBasisPoints = defaults.Fees.MDRBasisPoints
+	}
+	if !meta.IsDefined("global", "fees", "OwnerWallet") {
+		cfg.Global.Fees.OwnerWallet = defaults.Fees.OwnerWallet
 	}
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -2,6 +2,11 @@ package config
 
 import "time"
 
+const (
+	DefaultFreeTierTxPerMonth = uint64(100)
+	DefaultMDRBasisPoints     = uint32(150)
+)
+
 // Governance captures global governance policy knobs that must be validated
 // before applying runtime configuration updates.
 type Governance struct {
@@ -32,6 +37,13 @@ type Paymaster struct {
 	MerchantDailyCapWei string
 	DeviceDailyTxCap    uint64
 	GlobalDailyCapWei   string
+}
+
+// Fees captures default fee policy settings applied across domains.
+type Fees struct {
+	FreeTierTxPerMonth uint64
+	MDRBasisPoints     uint32
+	OwnerWallet        string
 }
 
 // Consensus controls the BFT round timeouts.
@@ -77,4 +89,5 @@ type Global struct {
 	Pauses     Pauses
 	Quotas     Quotas
 	Paymaster  Paymaster
+	Fees       Fees
 }

--- a/core/node.go
+++ b/core/node.go
@@ -334,6 +334,10 @@ func NewNode(db storage.Database, key *crypto.PrivateKey, genesisPath string, al
 			},
 			Mempool: config.Mempool{MaxBytes: 1, POSReservationBPS: consensus.DefaultPOSReservationBPS},
 			Blocks:  config.Blocks{MaxTxs: 1},
+			Fees: config.Fees{
+				FreeTierTxPerMonth: config.DefaultFreeTierTxPerMonth,
+				MDRBasisPoints:     config.DefaultMDRBasisPoints,
+			},
 		},
 		posStreamSubs:    make(map[uint64]chan POSFinalityUpdate),
 		posStreamHistory: make([]POSFinalityUpdate, 0, posFinalityHistoryLimit),
@@ -652,6 +656,11 @@ func (n *Node) globalConfigSnapshot() config.Global {
 			Trade:   n.globalCfg.Quotas.Trade,
 			Loyalty: n.globalCfg.Quotas.Loyalty,
 			POTSO:   n.globalCfg.Quotas.POTSO,
+		},
+		Fees: config.Fees{
+			FreeTierTxPerMonth: n.globalCfg.Fees.FreeTierTxPerMonth,
+			MDRBasisPoints:     n.globalCfg.Fees.MDRBasisPoints,
+			OwnerWallet:        n.globalCfg.Fees.OwnerWallet,
 		},
 	}
 	return snapshot

--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -42,3 +42,5 @@ toc:
         path: fees/routing.md
       - name: Governance parameters
         path: governance/fee-params.md
+      - name: Operations runbook
+        path: ops/fees.md

--- a/docs/api/fees-query.md
+++ b/docs/api/fees-query.md
@@ -31,6 +31,23 @@ curl -s -X POST https://rpc.nhbchain.dev \
 Each event includes the transaction hash, domain, merchant identifier, and both native and USD fee
 components. Persist the response to object storage before loading it into your analytics database.
 
+### Event attribute reference
+
+The `fees.applied` payload now exposes additional fields to help downstream systems
+reason about the free-tier window and revenue routing:
+
+| Attribute | Description |
+| --- | --- |
+| `ownerWallet` | Hex-encoded 20-byte address that accrued the fee. |
+| `freeTierApplied` | `true` when the transaction consumed the free tier rather than paying MDR. |
+| `freeTierLimit` | Monthly allowance in transactions for the payer's domain. |
+| `freeTierRemaining` | Transactions remaining in the current UTC month after processing the event. |
+| `usageCount` | Post-increment counter for the payer within the active month. |
+| `windowStartUnix` | Unix timestamp (seconds) for the start of the billing month applied to the event. |
+| `feeBps` | Effective MDR basis points applied when a fee was charged. |
+
+Older attributes (`payer`, `grossWei`, `feeWei`, `netWei`, etc.) remain unchanged.
+
 ## Streaming with gRPC
 
 ```bash

--- a/docs/fees/policy.md
+++ b/docs/fees/policy.md
@@ -7,9 +7,10 @@ be tuned through parameter proposals.
 
 ## Free tier
 
-Wallets receive a **monthly allowance of 1,000 NHB-sponsored transactions**.
+Wallets receive a **monthly allowance of 100 NHB-sponsored transactions**.
 Transactions that qualify for the free tier are debited against the sender's
-rolling 30-day count. Once the allowance is exhausted the standard fee schedule
+usage for the current UTC calendar month. Balances reset automatically at the
+start of each month. Once the allowance is exhausted the standard fee schedule
 applies. The allowance can be reconfigured via governance (see
 [fee parameters](../governance/fee-params.md)).
 

--- a/docs/ops/fees.md
+++ b/docs/ops/fees.md
@@ -1,0 +1,41 @@
+# Fee operations runbook
+
+This playbook outlines how to monitor and adjust the fee policy after the
+introduction of monthly free-tier windows.
+
+## Configuration knobs
+
+Fee settings live under the `global.fees` section of the runtime configuration
+and support the following fields:
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `freeTierTxPerMonth` | Number of transactions each payer receives per UTC calendar month before MDR applies. | `100` |
+| `mdrBasisPoints` | Merchant discount rate assessed on the paid leg once the free tier is exhausted. | `150` |
+| `ownerWallet` | Hex-encoded address that accrues routed MDR fees for the domain. | `""` |
+
+Updates should be proposed via the governance parameter pipeline. Nodes log a
+warning if the free-tier allowance is missing when a policy is loaded; this
+backfill is expected for legacy records and can be ignored once the policy has
+been resubmitted with the new fields populated.
+
+## Monitoring
+
+* **Free-tier depletion:** subscribe to `fees.applied` events and watch the
+  `freeTierRemaining` attribute. Alerts should fire when large merchants fall
+  below 10 remaining transactions to allow proactive top-ups.
+* **Owner wallet accrual:** the `ownerWallet` field on each event identifies the
+  treasury receiving MDR. Reconcile the balance against treasury statements at
+  the end of each month.
+* **Window resets:** the `windowStartUnix` attribute marks the beginning of the
+  billing month. Confirm that events emitted after UTC midnight on the first of
+  each month advertise the new window and reset usage counts back to one.
+
+## Rollout checklist
+
+1. Deploy nodes with the updated binary.
+2. Resubmit the fee policy via governance to explicitly set
+   `freeTierTxPerMonth`, `mdrBasisPoints`, and `ownerWallet` for each domain.
+3. Verify that warning logs disappear after the policy update propagates.
+4. Confirm that event consumers and dashboards ingest the new attributes before
+   switching alert thresholds to the 100-transaction monthly limit.

--- a/native/fees/apply.go
+++ b/native/fees/apply.go
@@ -1,18 +1,49 @@
 package fees
 
 import (
+	"log"
 	"math/big"
 	"strings"
+	"sync"
+	"time"
 )
 
 // DomainPOS identifies point-of-sale payment flows.
 const DomainPOS = "pos"
 
+// Default configuration values applied when policies omit explicit settings.
+const (
+	DefaultFreeTierTxPerMonth = uint64(100)
+	DefaultMDRBasisPoints     = uint32(150)
+)
+
+var freeTierDefaultWarned sync.Map
+
 // DomainPolicy captures the configuration applied to a specific fee domain.
 type DomainPolicy struct {
-	FreeTierAllowance uint64
-	MDRBps            uint32
-	RouteWallet       [20]byte
+	FreeTierTxPerMonth uint64
+	MDRBasisPoints     uint32
+	OwnerWallet        [20]byte
+}
+
+func (p DomainPolicy) normalized(domain string) DomainPolicy {
+	normalized := p
+	if normalized.FreeTierTxPerMonth == 0 {
+		normalized.FreeTierTxPerMonth = DefaultFreeTierTxPerMonth
+		if domain = strings.TrimSpace(domain); domain != "" {
+			if _, logged := freeTierDefaultWarned.LoadOrStore(strings.ToLower(domain), struct{}{}); !logged {
+				log.Printf("fees: domain %s missing FreeTierTxPerMonth, defaulting to %d", domain, DefaultFreeTierTxPerMonth)
+			}
+		} else {
+			if _, logged := freeTierDefaultWarned.LoadOrStore("", struct{}{}); !logged {
+				log.Printf("fees: missing FreeTierTxPerMonth, defaulting to %d", DefaultFreeTierTxPerMonth)
+			}
+		}
+	}
+	if normalized.MDRBasisPoints == 0 {
+		normalized.MDRBasisPoints = DefaultMDRBasisPoints
+	}
+	return normalized
 }
 
 // Policy enumerates the configured fee domains and the policy version.
@@ -32,7 +63,7 @@ func (p Policy) Clone() Policy {
 	clone.Domains = make(map[string]DomainPolicy, len(p.Domains))
 	for domain, cfg := range p.Domains {
 		normalized := NormalizeDomain(domain)
-		clone.Domains[normalized] = cfg
+		clone.Domains[normalized] = cfg.normalized(normalized)
 	}
 	return clone
 }
@@ -60,24 +91,37 @@ type ApplyInput struct {
 	UsageCount    uint64
 	PolicyVersion uint64
 	Config        DomainPolicy
+	WindowStart   time.Time
 }
 
 // ApplyResult summarises the computed fee, resulting net amount, and updated
 // usage counter after evaluating the provided input against the policy.
 type ApplyResult struct {
-	Fee             *big.Int
-	Net             *big.Int
-	Counter         uint64
-	RouteWallet     [20]byte
-	PolicyVersion   uint64
-	FreeTierApplied bool
+	Fee               *big.Int
+	Net               *big.Int
+	Counter           uint64
+	OwnerWallet       [20]byte
+	PolicyVersion     uint64
+	FreeTierApplied   bool
+	FreeTierLimit     uint64
+	FreeTierRemaining uint64
+	FeeBasisPoints    uint32
+	WindowStart       time.Time
 }
 
 // Apply evaluates the policy for the supplied domain and returns the resulting
 // fee metrics. The caller is responsible for persisting the incremented counter
 // and routing balances.
 func Apply(input ApplyInput) ApplyResult {
-	result := ApplyResult{Counter: input.UsageCount + 1, PolicyVersion: input.PolicyVersion, RouteWallet: input.Config.RouteWallet}
+	policy := input.Config.normalized(input.Domain)
+	result := ApplyResult{
+		Counter:        input.UsageCount + 1,
+		PolicyVersion:  input.PolicyVersion,
+		OwnerWallet:    policy.OwnerWallet,
+		FreeTierLimit:  policy.FreeTierTxPerMonth,
+		FeeBasisPoints: policy.MDRBasisPoints,
+		WindowStart:    input.WindowStart,
+	}
 	result.Fee = big.NewInt(0)
 	if input.Gross != nil {
 		result.Net = new(big.Int).Set(input.Gross)
@@ -87,14 +131,20 @@ func Apply(input ApplyInput) ApplyResult {
 	if result.Net.Sign() <= 0 {
 		return result
 	}
-	if input.Config.FreeTierAllowance > input.UsageCount {
+	limit := policy.FreeTierTxPerMonth
+	if limit > 0 && input.UsageCount < limit {
 		result.FreeTierApplied = true
+		if limit > result.Counter {
+			result.FreeTierRemaining = limit - result.Counter
+		} else {
+			result.FreeTierRemaining = 0
+		}
 		return result
 	}
-	if input.Config.MDRBps == 0 {
+	if policy.MDRBasisPoints == 0 {
 		return result
 	}
-	fee := new(big.Int).Mul(result.Net, big.NewInt(int64(input.Config.MDRBps)))
+	fee := new(big.Int).Mul(result.Net, big.NewInt(int64(policy.MDRBasisPoints)))
 	fee = fee.Div(fee, big.NewInt(10_000))
 	if fee.Sign() <= 0 {
 		return result
@@ -106,6 +156,9 @@ func Apply(input ApplyInput) ApplyResult {
 	}
 	result.Fee = fee
 	result.Net = new(big.Int).Sub(result.Net, fee)
+	if limit > result.Counter {
+		result.FreeTierRemaining = limit - result.Counter
+	}
 	return result
 }
 

--- a/native/gov/validate.go
+++ b/native/gov/validate.go
@@ -29,6 +29,7 @@ type Baseline struct {
 	Slashing   SlashingBaseline
 	Mempool    MempoolBaseline
 	Blocks     BlocksBaseline
+	Fees       FeesBaseline
 }
 
 // GovernanceBaseline mirrors config.Governance using primitive types.
@@ -52,6 +53,13 @@ type MempoolBaseline struct {
 // BlocksBaseline mirrors config.Blocks using primitive types.
 type BlocksBaseline struct {
 	MaxTxs int64
+}
+
+// FeesBaseline mirrors config.Fees using primitive types.
+type FeesBaseline struct {
+	FreeTierTxPerMonth uint64
+	MDRBasisPoints     uint32
+	OwnerWallet        string
 }
 
 // GovernanceDelta represents proposed changes to governance thresholds and
@@ -105,6 +113,11 @@ func PreflightBaselineApply(cur Baseline, delta PolicyDelta) error {
 		},
 		Mempool: config.Mempool{MaxBytes: cur.Mempool.MaxBytes},
 		Blocks:  config.Blocks{MaxTxs: cur.Blocks.MaxTxs},
+		Fees: config.Fees{
+			FreeTierTxPerMonth: cur.Fees.FreeTierTxPerMonth,
+			MDRBasisPoints:     cur.Fees.MDRBasisPoints,
+			OwnerWallet:        cur.Fees.OwnerWallet,
+		},
 	}, delta)
 }
 

--- a/proto/fees/v1/events.pb.go
+++ b/proto/fees/v1/events.pb.go
@@ -23,16 +23,22 @@ const (
 
 // FeeApplied captures telemetry for a fee assessment.
 type FeeApplied struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Payer         []byte                 `protobuf:"bytes,1,opt,name=payer,proto3" json:"payer,omitempty"`
-	Domain        string                 `protobuf:"bytes,2,opt,name=domain,proto3" json:"domain,omitempty"`
-	GrossWei      string                 `protobuf:"bytes,3,opt,name=gross_wei,json=grossWei,proto3" json:"gross_wei,omitempty"`
-	FeeWei        string                 `protobuf:"bytes,4,opt,name=fee_wei,json=feeWei,proto3" json:"fee_wei,omitempty"`
-	NetWei        string                 `protobuf:"bytes,5,opt,name=net_wei,json=netWei,proto3" json:"net_wei,omitempty"`
-	PolicyVersion uint64                 `protobuf:"varint,6,opt,name=policy_version,json=policyVersion,proto3" json:"policy_version,omitempty"`
-	RouteWallet   []byte                 `protobuf:"bytes,7,opt,name=route_wallet,json=routeWallet,proto3" json:"route_wallet,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Payer             []byte                 `protobuf:"bytes,1,opt,name=payer,proto3" json:"payer,omitempty"`
+	Domain            string                 `protobuf:"bytes,2,opt,name=domain,proto3" json:"domain,omitempty"`
+	GrossWei          string                 `protobuf:"bytes,3,opt,name=gross_wei,json=grossWei,proto3" json:"gross_wei,omitempty"`
+	FeeWei            string                 `protobuf:"bytes,4,opt,name=fee_wei,json=feeWei,proto3" json:"fee_wei,omitempty"`
+	NetWei            string                 `protobuf:"bytes,5,opt,name=net_wei,json=netWei,proto3" json:"net_wei,omitempty"`
+	PolicyVersion     uint64                 `protobuf:"varint,6,opt,name=policy_version,json=policyVersion,proto3" json:"policy_version,omitempty"`
+	OwnerWallet       []byte                 `protobuf:"bytes,7,opt,name=owner_wallet,json=ownerWallet,proto3" json:"owner_wallet,omitempty"`
+	FreeTierApplied   bool                   `protobuf:"varint,8,opt,name=free_tier_applied,json=freeTierApplied,proto3" json:"free_tier_applied,omitempty"`
+	FreeTierLimit     uint64                 `protobuf:"varint,9,opt,name=free_tier_limit,json=freeTierLimit,proto3" json:"free_tier_limit,omitempty"`
+	FreeTierRemaining uint64                 `protobuf:"varint,10,opt,name=free_tier_remaining,json=freeTierRemaining,proto3" json:"free_tier_remaining,omitempty"`
+	UsageCount        uint64                 `protobuf:"varint,11,opt,name=usage_count,json=usageCount,proto3" json:"usage_count,omitempty"`
+	WindowStartUnix   int64                  `protobuf:"varint,12,opt,name=window_start_unix,json=windowStartUnix,proto3" json:"window_start_unix,omitempty"`
+	FeeBps            uint32                 `protobuf:"varint,13,opt,name=fee_bps,json=feeBps,proto3" json:"fee_bps,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *FeeApplied) Reset() {
@@ -107,27 +113,58 @@ func (x *FeeApplied) GetPolicyVersion() uint64 {
 	return 0
 }
 
-func (x *FeeApplied) GetRouteWallet() []byte {
+func (x *FeeApplied) GetOwnerWallet() []byte {
 	if x != nil {
-		return x.RouteWallet
+		return x.OwnerWallet
 	}
 	return nil
 }
 
+func (x *FeeApplied) GetFreeTierApplied() bool {
+	if x != nil {
+		return x.FreeTierApplied
+	}
+	return false
+}
+
+func (x *FeeApplied) GetFreeTierLimit() uint64 {
+	if x != nil {
+		return x.FreeTierLimit
+	}
+	return 0
+}
+
+func (x *FeeApplied) GetFreeTierRemaining() uint64 {
+	if x != nil {
+		return x.FreeTierRemaining
+	}
+	return 0
+}
+
+func (x *FeeApplied) GetUsageCount() uint64 {
+	if x != nil {
+		return x.UsageCount
+	}
+	return 0
+}
+
+func (x *FeeApplied) GetWindowStartUnix() int64 {
+	if x != nil {
+		return x.WindowStartUnix
+	}
+	return 0
+}
+
+func (x *FeeApplied) GetFeeBps() uint32 {
+	if x != nil {
+		return x.FeeBps
+	}
+	return 0
+}
+
 var File_fees_v1_events_proto protoreflect.FileDescriptor
 
-const file_fees_v1_events_proto_rawDesc = "" +
-	"\n" +
-	"\x14fees/v1/events.proto\x12\vnhb.fees.v1\"\xd3\x01\n" +
-	"\n" +
-	"FeeApplied\x12\x14\n" +
-	"\x05payer\x18\x01 \x01(\fR\x05payer\x12\x16\n" +
-	"\x06domain\x18\x02 \x01(\tR\x06domain\x12\x1b\n" +
-	"\tgross_wei\x18\x03 \x01(\tR\bgrossWei\x12\x17\n" +
-	"\afee_wei\x18\x04 \x01(\tR\x06feeWei\x12\x17\n" +
-	"\anet_wei\x18\x05 \x01(\tR\x06netWei\x12%\n" +
-	"\x0epolicy_version\x18\x06 \x01(\x04R\rpolicyVersion\x12!\n" +
-	"\froute_wallet\x18\a \x01(\fR\vrouteWalletB\x1fZ\x1dnhbchain/proto/fees/v1;feesv1b\x06proto3"
+const file_fees_v1_events_proto_rawDesc = "\n\x92\x04\n\x1aproto/fees/v1/events.proto\x12\vnhb.fees.v1\"\xbd\x03\n\nFeeApplied\x12\x14\n\x05payer\x18\x01 \x01(\fR\x05payer\x12\x16\n\x06domain\x18\x02 \x01(\tR\x06domain\x12\x1b\n\tgross_wei\x18\x03 \x01(\tR\bgrossWei\x12\x17\n\afee_wei\x18\x04 \x01(\tR\x06feeWei\x12\x17\n\anet_wei\x18\x05 \x01(\tR\x06netWei\x12%\n\x0epolicy_version\x18\x06 \x01(\x04R\rpolicyVersion\x12!\n\fowner_wallet\x18\a \x01(\fR\vownerWallet\x12*\n\x11free_tier_applied\x18\b \x01(\bR\x0ffreeTierApplied\x12&\n\x0ffree_tier_limit\x18\t \x01(\x04R\rfreeTierLimit\x12.\n\x13free_tier_remaining\x18\n \x01(\x04R\x11freeTierRemaining\x12\x1f\n\vusage_count\x18\v \x01(\x04R\nusageCount\x12*\n\x11window_start_unix\x18\f \x01(\x03R\x0fwindowStartUnix\x12\x17\n\afee_bps\x18\r \x01(\rR\x06feeBpsB\x1fZ\x1dnhbchain/proto/fees/v1;feesv1b\x06proto3"
 
 var (
 	file_fees_v1_events_proto_rawDescOnce sync.Once

--- a/proto/fees/v1/events.proto
+++ b/proto/fees/v1/events.proto
@@ -12,6 +12,12 @@ message FeeApplied {
   string fee_wei = 4;
   string net_wei = 5;
   uint64 policy_version = 6;
-  bytes route_wallet = 7;
+  bytes owner_wallet = 7;
+  bool free_tier_applied = 8;
+  uint64 free_tier_limit = 9;
+  uint64 free_tier_remaining = 10;
+  uint64 usage_count = 11;
+  int64 window_start_unix = 12;
+  uint32 fee_bps = 13;
 }
 

--- a/tests/fees/free_tier_test.go
+++ b/tests/fees/free_tier_test.go
@@ -1,0 +1,149 @@
+package fees_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	nhbstate "nhbchain/core/state"
+	"nhbchain/native/fees"
+	"nhbchain/storage"
+	statetrie "nhbchain/storage/trie"
+)
+
+func TestApplyFreeTierThreshold(t *testing.T) {
+	value := big.NewInt(1_000)
+	var owner [20]byte
+	for i := range owner {
+		owner[i] = byte(i + 1)
+	}
+	policy := fees.DomainPolicy{
+		FreeTierTxPerMonth: 100,
+		MDRBasisPoints:     150,
+		OwnerWallet:        owner,
+	}
+	monthStart := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	usage := uint64(0)
+	for i := 0; i < 102; i++ {
+		result := fees.Apply(fees.ApplyInput{
+			Domain:        fees.DomainPOS,
+			Gross:         value,
+			UsageCount:    usage,
+			PolicyVersion: 1,
+			Config:        policy,
+			WindowStart:   monthStart,
+		})
+		usage = result.Counter
+		if i < 100 {
+			if !result.FreeTierApplied {
+				t.Fatalf("expected free tier for tx %d", i)
+			}
+			if result.Fee.Sign() != 0 {
+				t.Fatalf("expected zero fee during free tier")
+			}
+		} else {
+			if result.FreeTierApplied {
+				t.Fatalf("expected fee to apply after free tier exhaustion")
+			}
+			expectedFee := new(big.Int).Mul(value, big.NewInt(int64(policy.MDRBasisPoints)))
+			expectedFee.Div(expectedFee, big.NewInt(10_000))
+			if result.Fee.Cmp(expectedFee) != 0 {
+				t.Fatalf("unexpected fee amount: got %s want %s", result.Fee, expectedFee)
+			}
+			if result.OwnerWallet != owner {
+				t.Fatalf("unexpected owner wallet: %x", result.OwnerWallet)
+			}
+			if result.FreeTierRemaining != 0 {
+				t.Fatalf("expected free tier to be exhausted, remaining=%d", result.FreeTierRemaining)
+			}
+		}
+	}
+}
+
+func TestMonthlyCounterReset(t *testing.T) {
+	db := storage.NewMemDB()
+	trie, err := statetrie.NewTrie(db, nil)
+	if err != nil {
+		t.Fatalf("new trie: %v", err)
+	}
+	manager := nhbstate.NewManager(trie)
+
+	var payer [20]byte
+	for i := range payer {
+		payer[i] = 0xAA
+	}
+	jan := time.Date(2024, time.January, 10, 0, 0, 0, 0, time.UTC)
+	janStart := monthStartUTC(jan)
+	if err := manager.FeesPutCounter(fees.DomainPOS, payer, 50, janStart); err != nil {
+		t.Fatalf("seed counter: %v", err)
+	}
+	count, windowStart, ok, err := manager.FeesGetCounter(fees.DomainPOS, payer)
+	if err != nil || !ok {
+		t.Fatalf("load counter: %v (ok=%v)", err, ok)
+	}
+	if count != 50 {
+		t.Fatalf("unexpected count: %d", count)
+	}
+	if !windowStart.Equal(janStart) {
+		t.Fatalf("unexpected window start: %s", windowStart)
+	}
+
+	feb := time.Date(2024, time.February, 2, 0, 0, 0, 0, time.UTC)
+	febStart := monthStartUTC(feb)
+	usage := count
+	if !sameMonth(windowStart, febStart) {
+		usage = 0
+		windowStart = febStart
+	}
+
+	policy := fees.DomainPolicy{
+		FreeTierTxPerMonth: 100,
+		MDRBasisPoints:     150,
+	}
+	result := fees.Apply(fees.ApplyInput{
+		Domain:        fees.DomainPOS,
+		Gross:         big.NewInt(500),
+		UsageCount:    usage,
+		PolicyVersion: 2,
+		Config:        policy,
+		WindowStart:   windowStart,
+	})
+	if !result.FreeTierApplied {
+		t.Fatalf("expected free tier to apply after rollover")
+	}
+	if result.Counter != 1 {
+		t.Fatalf("expected counter 1 after rollover, got %d", result.Counter)
+	}
+	if result.FreeTierRemaining != 99 {
+		t.Fatalf("expected 99 remaining, got %d", result.FreeTierRemaining)
+	}
+	if !result.WindowStart.Equal(febStart) {
+		t.Fatalf("unexpected window start in result: %s", result.WindowStart)
+	}
+
+	if err := manager.FeesPutCounter(fees.DomainPOS, payer, result.Counter, result.WindowStart); err != nil {
+		t.Fatalf("update counter: %v", err)
+	}
+	stored, newWindow, ok, err := manager.FeesGetCounter(fees.DomainPOS, payer)
+	if err != nil || !ok {
+		t.Fatalf("reload counter: %v (ok=%v)", err, ok)
+	}
+	if stored != 1 {
+		t.Fatalf("unexpected stored count: %d", stored)
+	}
+	if !newWindow.Equal(febStart) {
+		t.Fatalf("unexpected stored window start: %s", newWindow)
+	}
+}
+
+func monthStartUTC(ts time.Time) time.Time {
+	utc := ts.UTC()
+	return time.Date(utc.Year(), utc.Month(), 1, 0, 0, 0, 0, time.UTC)
+}
+
+func sameMonth(a, b time.Time) bool {
+	ua := a.UTC()
+	ub := b.UTC()
+	return ua.Year() == ub.Year() && ua.Month() == ub.Month()
+}

--- a/tests/fuzz/gov_policy_fuzz.go
+++ b/tests/fuzz/gov_policy_fuzz.go
@@ -22,6 +22,7 @@ func FuzzGovernancePolicyDeltas(f *testing.F) {
 			Slashing: govcfg.SlashingBaseline{MinWindowSecs: 60, MaxWindowSecs: 600},
 			Mempool:  govcfg.MempoolBaseline{MaxBytes: 16 << 20},
 			Blocks:   govcfg.BlocksBaseline{MaxTxs: 5000},
+			Fees:     govcfg.FeesBaseline{FreeTierTxPerMonth: config.DefaultFreeTierTxPerMonth, MDRBasisPoints: config.DefaultMDRBasisPoints},
 		}
 
 		delta := govcfg.PolicyDelta{}
@@ -106,6 +107,11 @@ func FuzzGovernancePolicyDeltas(f *testing.F) {
 			},
 			Mempool: config.Mempool{MaxBytes: baseline.Mempool.MaxBytes},
 			Blocks:  config.Blocks{MaxTxs: baseline.Blocks.MaxTxs},
+			Fees: config.Fees{
+				FreeTierTxPerMonth: baseline.Fees.FreeTierTxPerMonth,
+				MDRBasisPoints:     baseline.Fees.MDRBasisPoints,
+				OwnerWallet:        baseline.Fees.OwnerWallet,
+			},
 		}
 
 		if govDelta != nil {

--- a/tests/gov/invariants_test.go
+++ b/tests/gov/invariants_test.go
@@ -21,6 +21,10 @@ func testBaseline() govcfg.Baseline {
 		},
 		Mempool: govcfg.MempoolBaseline{MaxBytes: 1},
 		Blocks:  govcfg.BlocksBaseline{MaxTxs: 1},
+		Fees: govcfg.FeesBaseline{
+			FreeTierTxPerMonth: config.DefaultFreeTierTxPerMonth,
+			MDRBasisPoints:     config.DefaultMDRBasisPoints,
+		},
 	}
 }
 

--- a/tests/posreadiness/fees/fees_test.go
+++ b/tests/posreadiness/fees/fees_test.go
@@ -52,9 +52,9 @@ func TestSponsorshipCapsAndRouting(t *testing.T) {
 		Version: 1,
 		Domains: map[string]fees.DomainPolicy{
 			fees.DomainPOS: {
-				FreeTierAllowance: 2,
-				MDRBps:            150,
-				RouteWallet:       routeWallet,
+				FreeTierTxPerMonth: 2,
+				MDRBasisPoints:     150,
+				OwnerWallet:        routeWallet,
 			},
 		},
 	}

--- a/tests/posreadiness/fees/reconcile_test.go
+++ b/tests/posreadiness/fees/reconcile_test.go
@@ -72,9 +72,9 @@ func TestFeeEventReconciliation(t *testing.T) {
 		Version: 1,
 		Domains: map[string]fees.DomainPolicy{
 			fees.DomainPOS: {
-				FreeTierAllowance: 0,
-				MDRBps:            200,
-				RouteWallet:       routeWallet,
+				FreeTierTxPerMonth: 0,
+				MDRBasisPoints:     200,
+				OwnerWallet:        routeWallet,
 			},
 		},
 	}
@@ -100,7 +100,7 @@ func TestFeeEventReconciliation(t *testing.T) {
 			if evt.Attributes == nil {
 				continue
 			}
-			if evt.Attributes["routeWallet"] != expectedRouteHex {
+			if evt.Attributes["ownerWallet"] != expectedRouteHex {
 				continue
 			}
 			feeStr, ok := evt.Attributes["feeWei"]


### PR DESCRIPTION
## Summary
- extend fee configuration defaults to cover monthly free-tier allowances, MDR BPS, and owner routing targets across config, governance, and generated clients
- meter fees against UTC-month windows, apply the free tier before MDR, enrich fee events, and accumulate routed balances on the configured owner wallet
- document the operational rollout and add regression/posreadiness coverage for free-tier thresholds, routing, and monthly rollover

## Testing
- go test ./tests/fees
- go test ./config
- go test ./native/gov ./tests/gov ./tests/fuzz
- go test ./... *(fails: TestLendingRPCEndpoints / TestPotsoHeartbeatRateLimitAndMetrics require integration setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a41631ec832d8dc2c26174f8477b