### PR TITLE
Default loyalty base rate at 50 bps and expose basis points

### DIFF
--- a/core/genesis/spec.go
+++ b/core/genesis/spec.go
@@ -295,14 +295,14 @@ func (l *LoyaltyGlobalSpec) Config() (*loyalty.GlobalConfig, *big.Int, error) {
 	if l.treasuryAddr == nil {
 		return nil, nil, fmt.Errorf("loyalty global spec not validated")
 	}
-	cfg := &loyalty.GlobalConfig{
+	cfg := (&loyalty.GlobalConfig{
 		Active:       l.Active,
 		Treasury:     append([]byte(nil), l.treasuryAddr...),
 		BaseBps:      l.BaseBps,
 		MinSpend:     new(big.Int).Set(l.minSpendAmt),
 		CapPerTx:     new(big.Int).Set(l.capPerTxAmt),
 		DailyCapUser: new(big.Int).Set(l.dailyCapAmt),
-	}
+	}).Normalize()
 	return cfg, new(big.Int).Set(l.seedZNHB), nil
 }
 

--- a/docs/loyalty/payouts.md
+++ b/docs/loyalty/payouts.md
@@ -1,0 +1,67 @@
+# Base Spend Rewards
+
+The base spend reward mints ZapNHB (ZNHB) to shoppers for every qualifying NHB
+transaction. Rewards are sourced from the loyalty treasury and accrue alongside
+program-specific payouts.
+
+## Default Accrual Rate
+
+* The chain-wide default accrual rate is **50 basis points (0.5%)** as defined by
+  `loyalty.DefaultBaseRewardBps`.
+* All basis-point math uses the `loyalty.BaseRewardBpsDenominator` constant of
+  10,000.
+* Operators can toggle the engine with the `Active` flag, but when enabled an
+  explicit reward rate is no longer required—the default is applied whenever the
+  stored config omits `BaseBps`.
+
+For example, a 20,000 wei NHB payment mints 100 wei ZNHB: `20_000 * 50 / 10_000`.
+Caps (per-transaction or daily) clamp the computed reward after the rate is
+applied.
+
+## Configuration Surface
+
+The global configuration lives at `loyalty.GlobalConfig` and is stored on-chain
+via `state.Manager.SetLoyaltyGlobalConfig`. Relevant fields:
+
+| Field | Description |
+|-------|-------------|
+| `Active` | Enables/disables base reward accrual. |
+| `Treasury` | 20-byte address that funds rewards. |
+| `BaseBps` | Optional basis-point override; defaults to 50 when zero. |
+| `MinSpend` | Minimum NHB spend required to earn the reward. |
+| `CapPerTx` | Hard cap (in ZNHB) per transaction. |
+| `DailyCapUser` | Daily cap (in ZNHB) per shopper. |
+
+`Normalize()` now applies the default basis points before enforcing non-negative
+caps and thresholds. Governance tooling and genesis loaders automatically apply
+these defaults so nodes ingest consistent settings.
+
+## Event Stream
+
+Base rewards emit `loyalty.base.accrued` events with attributes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `day` | UTC day (`YYYY-MM-DD`). |
+| `token` | Always `NHB`. |
+| `amount` | Spend amount (wei). |
+| `from` | Hex sender address. |
+| `to` | Hex recipient address. |
+| `reward` | Minted ZNHB (wei). |
+| `baseBps` | Basis points used for the reward computation. |
+
+When rewards are skipped (due to pauses, caps, treasury balance, etc.)
+`loyalty.base.skipped` events continue to carry the `reason` and contextual
+metadata to aid observability.
+
+## Pauses and Caps
+
+* `gov.v1.MsgSetPauses` toggles module-wide pauses; when active no base rewards
+  are minted and no events are produced.
+* `CapPerTx` truncates the computed reward before persistence.
+* `DailyCapUser` clamps the total minted amount per shopper per UTC day; the
+  remaining allowance is calculated with on-chain meters.
+
+Operators should ensure the treasury maintains sufficient ZNHB liquidity. The
+engine refuses to mint when the treasury balance falls below the requested
+reward and emits a `treasury_insufficient` skip event.

--- a/docs/runbooks/loyalty-ops.md
+++ b/docs/runbooks/loyalty-ops.md
@@ -1,0 +1,74 @@
+# Loyalty Operations Runbook
+
+This runbook documents common operational workflows for the loyalty base reward
+engine. It focuses on the global configuration that powers the 0.5% default
+reward and the observability hooks operators rely on to confirm payouts.
+
+## Verify Current Configuration
+
+1. Query the chain via JSON-RPC:
+   ```bash
+   curl -s http://localhost:8080/nhb_getLoyaltyGlobalConfig | jq
+   ```
+2. Ensure the response includes:
+   * `active: true`
+   * `baseBps: 50` unless a custom override is required.
+   * `treasury` pointing at the funded ZNHB wallet.
+3. Cross-check meters when investigating user reports:
+   ```bash
+   curl -s http://localhost:8080/nhb_getLoyaltyBaseMeters \
+     -d '{"address":"nhb1...","day":"2024-02-01"}' | jq
+   ```
+
+The state processor automatically injects `baseBps: 50` when the stored config
+leaves the field empty, so older genesis files remain compatible.
+
+## Adjust the Reward Rate
+
+1. Draft a governance proposal updating `loyalty.GlobalConfig` via
+   `gov.v1.MsgSetGlobalConfig` (or the relevant multisig workflow).
+2. Specify the desired `baseBps`. Use 50 for the 0.5% baseline; values above
+   10,000 will be rejected during validation.
+3. Submit and monitor the proposal lifecycle. Once applied, the next qualifying
+   transaction will emit a `loyalty.base.accrued` event reflecting the new
+   `baseBps` attribute.
+
+## Pause or Resume Loyalty Rewards
+
+1. Stage a `gov.v1.MsgSetPauses` transaction with `pauses.loyalty = true` to
+   freeze payouts. When paused, the engine short-circuits before computing the
+   reward and no events are emitted.
+2. Resume by sending another `MsgSetPauses` request with `pauses.loyalty = false`.
+3. Confirm behaviour by tailing events:
+   ```bash
+   nhbcli events --type loyalty.base.accrued
+   ```
+   Lack of new events during the pause window confirms the module halt.
+
+## Monitor Treasury Health
+
+* Use `nhb_getAccount` (or Prometheus metrics) to confirm the loyalty treasury
+  maintains sufficient ZNHB. The engine emits `loyalty.base.skipped` events with
+  `reason=treasury_insufficient` when balances drop below the computed reward.
+* Configure alerts on the treasury balance threshold that matches projected
+  earn volume and caps.
+
+## Respond to Cap-Related Questions
+
+* `CapPerTx` constrains rewards for large individual purchases. The event stream
+  still reports the full `baseBps` so downstream systems can distinguish capped
+  payouts.
+* `DailyCapUser` limits aggregate earnings per shopper per UTC day. Investigate
+  by querying the meters via `nhb_getLoyaltyBaseMeters`.
+* Remind support teams that the 0.5% rate applies before caps; communications
+  should phrase limits accordingly (e.g., “Earn 0.5% back up to 50 ZNHB per
+  purchase”).
+
+## Troubleshooting Checklist
+
+1. **No rewards minted** – confirm the module is not paused and `Active` remains
+   true.
+2. **Rewards lower than expected** – check per-tx or daily caps, then inspect the
+   treasury balance for insufficiencies.
+3. **Events missing `baseBps`** – ensure nodes are running the updated binaries;
+   the attribute now accompanies every `loyalty.base.accrued` event.

--- a/native/loyalty/engine_base_test.go
+++ b/native/loyalty/engine_base_test.go
@@ -157,6 +157,9 @@ func TestApplyBaseRewardHappyPath(t *testing.T) {
 	if state.events[0].Attributes["reward"] != "5" {
 		t.Fatalf("expected reward attribute 5, got %s", state.events[0].Attributes["reward"])
 	}
+	if got := state.events[0].Attributes["baseBps"]; got != "50" {
+		t.Fatalf("expected baseBps attribute 50, got %s", got)
+	}
 }
 
 func TestApplyBaseRewardPerTxCap(t *testing.T) {
@@ -183,6 +186,9 @@ func TestApplyBaseRewardPerTxCap(t *testing.T) {
 	}
 	if state.events[0].Attributes["reward"] != "30" {
 		t.Fatalf("expected reward attribute 30, got %s", state.events[0].Attributes["reward"])
+	}
+	if got := state.events[0].Attributes["baseBps"]; got != "2000" {
+		t.Fatalf("expected baseBps attribute 2000, got %s", got)
 	}
 }
 
@@ -316,7 +322,7 @@ func TestApplyBaseRewardDefaultRatePrecision(t *testing.T) {
 	engine := NewEngine()
 	engine.ApplyBaseReward(state, ctx)
 
-	want := new(big.Int).Quo(new(big.Int).Mul(new(big.Int).Set(amount), big.NewInt(50)), big.NewInt(10_000))
+	want := new(big.Int).Quo(new(big.Int).Mul(new(big.Int).Set(amount), big.NewInt(50)), big.NewInt(int64(BaseRewardBpsDenominator)))
 	if ctx.FromAccount.BalanceZNHB.Cmp(want) != 0 {
 		t.Fatalf("expected reward %s, got %s", want.String(), ctx.FromAccount.BalanceZNHB.String())
 	}

--- a/native/loyalty/global.go
+++ b/native/loyalty/global.go
@@ -48,6 +48,7 @@ func (c *GlobalConfig) Normalize() *GlobalConfig {
 	if c == nil {
 		return nil
 	}
+	c.ApplyDefaults()
 	if c.MinSpend == nil {
 		c.MinSpend = big.NewInt(0)
 	}

--- a/native/loyalty/params.go
+++ b/native/loyalty/params.go
@@ -1,0 +1,21 @@
+package loyalty
+
+const (
+	// BaseRewardBpsDenominator defines the scaling factor used for basis point math
+	// when computing base spend rewards.
+	BaseRewardBpsDenominator = 10_000
+	// DefaultBaseRewardBps configures the default base accrual rate expressed in
+	// basis points (0.5%).
+	DefaultBaseRewardBps = 50
+)
+
+// ApplyDefaults ensures unset fields fall back to module defaults.
+func (c *GlobalConfig) ApplyDefaults() *GlobalConfig {
+	if c == nil {
+		return nil
+	}
+	if c.BaseBps == 0 {
+		c.BaseBps = DefaultBaseRewardBps
+	}
+	return c
+}

--- a/tests/loyalty/base_reward_test.go
+++ b/tests/loyalty/base_reward_test.go
@@ -1,0 +1,229 @@
+package loyalty_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"nhbchain/core"
+	nhbstate "nhbchain/core/state"
+	"nhbchain/core/types"
+	"nhbchain/native/loyalty"
+)
+
+type staticPauseView struct {
+	modules map[string]bool
+}
+
+func (s staticPauseView) IsPaused(module string) bool {
+	if s.modules == nil {
+		return false
+	}
+	return s.modules[module]
+}
+
+func mustPutAccount(t *testing.T, manager *nhbstate.Manager, addr [20]byte, account *types.Account) {
+	t.Helper()
+	if err := manager.PutAccount(addr[:], account); err != nil {
+		t.Fatalf("put account: %v", err)
+	}
+}
+
+func mustAccount(t *testing.T, manager *nhbstate.Manager, addr [20]byte) *types.Account {
+	t.Helper()
+	account, err := manager.GetAccount(addr[:])
+	if err != nil {
+		t.Fatalf("get account: %v", err)
+	}
+	return account
+}
+
+func findEvent(events []types.Event, eventType string) *types.Event {
+	for i := range events {
+		if events[i].Type == eventType {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+func setupLoyaltyState(t *testing.T) (*core.StateProcessor, *nhbstate.Manager) {
+	t.Helper()
+	sp := newStateProcessor(t)
+	manager := nhbstate.NewManager(sp.Trie)
+	if err := manager.RegisterToken("NHB", "Native", 18); err != nil {
+		t.Fatalf("register NHB: %v", err)
+	}
+	if err := manager.RegisterToken("ZNHB", "ZapNHB", 18); err != nil {
+		t.Fatalf("register ZNHB: %v", err)
+	}
+	return sp, manager
+}
+
+func TestBaseRewardAccruesAtDefaultRate(t *testing.T) {
+	sp, manager := setupLoyaltyState(t)
+
+	var treasury [20]byte
+	treasury[19] = 0xAA
+	cfg := (&loyalty.GlobalConfig{
+		Active:       true,
+		Treasury:     treasury[:],
+		MinSpend:     big.NewInt(0),
+		CapPerTx:     big.NewInt(0),
+		DailyCapUser: big.NewInt(0),
+	}).Normalize()
+	if cfg.BaseBps != loyalty.DefaultBaseRewardBps {
+		t.Fatalf("expected default base bps %d, got %d", loyalty.DefaultBaseRewardBps, cfg.BaseBps)
+	}
+	if err := manager.SetLoyaltyGlobalConfig(cfg); err != nil {
+		t.Fatalf("set global config: %v", err)
+	}
+
+	mustPutAccount(t, manager, treasury, &types.Account{BalanceZNHB: big.NewInt(1_000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	var spender [20]byte
+	spender[19] = 0xBB
+	mustPutAccount(t, manager, spender, &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	fromAcc := mustAccount(t, manager, spender)
+	toAcc := &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)}
+	ctx := &loyalty.BaseRewardContext{
+		From:        append([]byte(nil), spender[:]...),
+		To:          []byte("merchant-address"),
+		Token:       "NHB",
+		Amount:      big.NewInt(20_000),
+		Timestamp:   time.Date(2024, 2, 1, 12, 0, 0, 0, time.UTC),
+		FromAccount: fromAcc,
+		ToAccount:   toAcc,
+	}
+
+	sp.LoyaltyEngine.OnTransactionSuccess(sp, ctx)
+
+	expected := big.NewInt(0).Mul(big.NewInt(20_000), big.NewInt(int64(loyalty.DefaultBaseRewardBps)))
+	expected = expected.Quo(expected, big.NewInt(int64(loyalty.BaseRewardBpsDenominator)))
+	if ctx.FromAccount.BalanceZNHB.Cmp(expected) != 0 {
+		t.Fatalf("expected reward %s, got %s", expected.String(), ctx.FromAccount.BalanceZNHB.String())
+	}
+
+	treasuryAcc := mustAccount(t, manager, treasury)
+	wantTreasury := big.NewInt(1_000)
+	wantTreasury.Sub(wantTreasury, expected)
+	if treasuryAcc.BalanceZNHB.Cmp(wantTreasury) != 0 {
+		t.Fatalf("expected treasury balance %s, got %s", wantTreasury.String(), treasuryAcc.BalanceZNHB.String())
+	}
+
+	dayKey := ctx.Timestamp.UTC().Format("2006-01-02")
+	accrued, err := sp.LoyaltyBaseDailyAccrued(spender[:], dayKey)
+	if err != nil {
+		t.Fatalf("daily accrued: %v", err)
+	}
+	if accrued.Cmp(expected) != 0 {
+		t.Fatalf("expected daily accrued %s, got %s", expected.String(), accrued.String())
+	}
+
+	events := sp.Events()
+	evt := findEvent(events, "loyalty.base.accrued")
+	if evt == nil {
+		t.Fatalf("expected base accrued event, got %#v", events)
+	}
+	if evt.Attributes["reward"] != expected.String() {
+		t.Fatalf("expected reward attribute %s, got %s", expected.String(), evt.Attributes["reward"])
+	}
+	if evt.Attributes["baseBps"] != "50" {
+		t.Fatalf("expected baseBps attribute 50, got %s", evt.Attributes["baseBps"])
+	}
+}
+
+func TestBaseRewardRespectsPause(t *testing.T) {
+	sp, manager := setupLoyaltyState(t)
+
+	var treasury [20]byte
+	treasury[18] = 0xCC
+	cfg := (&loyalty.GlobalConfig{
+		Active:       true,
+		Treasury:     treasury[:],
+		MinSpend:     big.NewInt(0),
+		CapPerTx:     big.NewInt(0),
+		DailyCapUser: big.NewInt(0),
+	}).Normalize()
+	if err := manager.SetLoyaltyGlobalConfig(cfg); err != nil {
+		t.Fatalf("set global config: %v", err)
+	}
+
+	mustPutAccount(t, manager, treasury, &types.Account{BalanceZNHB: big.NewInt(500), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	var spender [20]byte
+	spender[17] = 0x01
+	mustPutAccount(t, manager, spender, &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	fromAcc := mustAccount(t, manager, spender)
+	ctx := &loyalty.BaseRewardContext{
+		From:        append([]byte(nil), spender[:]...),
+		To:          []byte("merchant"),
+		Token:       "NHB",
+		Amount:      big.NewInt(40_000),
+		Timestamp:   time.Date(2024, 2, 2, 9, 0, 0, 0, time.UTC),
+		FromAccount: fromAcc,
+	}
+
+	sp.LoyaltyEngine.SetPauses(staticPauseView{modules: map[string]bool{"loyalty": true}})
+	sp.LoyaltyEngine.OnTransactionSuccess(sp, ctx)
+
+	if ctx.FromAccount.BalanceZNHB.Sign() != 0 {
+		t.Fatalf("expected no reward when paused")
+	}
+	events := sp.Events()
+	if len(events) != 0 {
+		t.Fatalf("expected no events when paused, got %d", len(events))
+	}
+}
+
+func TestBaseRewardHonorsCapPerTx(t *testing.T) {
+	sp, manager := setupLoyaltyState(t)
+
+	var treasury [20]byte
+	treasury[16] = 0xDD
+	cfg := (&loyalty.GlobalConfig{
+		Active:       true,
+		Treasury:     treasury[:],
+		MinSpend:     big.NewInt(0),
+		CapPerTx:     big.NewInt(50),
+		DailyCapUser: big.NewInt(0),
+	}).Normalize()
+	if err := manager.SetLoyaltyGlobalConfig(cfg); err != nil {
+		t.Fatalf("set global config: %v", err)
+	}
+
+	mustPutAccount(t, manager, treasury, &types.Account{BalanceZNHB: big.NewInt(5_000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	var spender [20]byte
+	spender[15] = 0xEE
+	mustPutAccount(t, manager, spender, &types.Account{BalanceZNHB: big.NewInt(0), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+
+	fromAcc := mustAccount(t, manager, spender)
+	ctx := &loyalty.BaseRewardContext{
+		From:        append([]byte(nil), spender[:]...),
+		To:          []byte("merchant"),
+		Token:       "NHB",
+		Amount:      big.NewInt(20_000),
+		Timestamp:   time.Date(2024, 2, 3, 18, 30, 0, 0, time.UTC),
+		FromAccount: fromAcc,
+	}
+
+	sp.LoyaltyEngine.OnTransactionSuccess(sp, ctx)
+
+	if ctx.FromAccount.BalanceZNHB.Cmp(big.NewInt(50)) != 0 {
+		t.Fatalf("expected reward capped at 50, got %s", ctx.FromAccount.BalanceZNHB.String())
+	}
+	events := sp.Events()
+	evt := findEvent(events, "loyalty.base.accrued")
+	if evt == nil {
+		t.Fatalf("expected base accrued event, got %#v", events)
+	}
+	if evt.Attributes["reward"] != "50" {
+		t.Fatalf("expected reward attribute 50, got %s", evt.Attributes["reward"])
+	}
+	if evt.Attributes["baseBps"] != "50" {
+		t.Fatalf("expected baseBps attribute 50, got %s", evt.Attributes["baseBps"])
+	}
+}


### PR DESCRIPTION
## Summary
- add a loyalty params helper that defaults BaseBps to 50 bps and ensure normalization applies it across config and genesis
- emit the applied basis points with base reward events while keeping reward math tied to the shared denominator
- document the 0.5% default, pause/cap semantics, and add integration tests covering earn, pause, and cap flows

## Testing
- `go test ./native/loyalty`
- `go test ./tests/loyalty`


------
https://chatgpt.com/codex/tasks/task_e_68e4acececc4832d9b8a5d7fbe49a61a