### PR TITLE
Raise default loyalty base reward to 50 percent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Documented the RPC trusted-proxy policy, per-source transaction quota, and timeout/TLS requirements across networking, overview, governance, and operations guides so operators know how to harden their nodes.
 - Updated example workspace materials (`README`, `.env.example`, Postman collection) to surface the new RPC configuration knobs and mempool guidance for local testing.
 - Added integration runbook notes and migration steps for SDK consumers to handle HTTP 429/`-32020` responses and align mempool limits.
+- Raised the loyalty base reward default to 5,000 bps (50%), highlighting the higher treasury burn rate and reminding operators to scale funding monitors accordingly.

--- a/docs/loyalty/loyalty.md
+++ b/docs/loyalty/loyalty.md
@@ -89,11 +89,11 @@ network-wide base reward. Operators can toggle or tune it through governance:
 
 * `Active` (`bool`): when `false`, base rewards are skipped entirely.
 * `Treasury` (`[20]byte`): address that funds base payouts.
-* `BaseBps` (`uint32`): network default is **50 bps (0.5%)**, minting 0.5 ZNHB for every 100 NHB of qualifying spend.
+* `BaseBps` (`uint32`): network default is **5,000 bps (50%)**, minting 0.5 ZNHB for every 1 NHB of qualifying spend.
 * `MinSpend`, `CapPerTx`, `DailyCapUser` (`*big.Int`): caps expressed in wei (18 decimal places).
 
-With the default 50 bps rate, a settlement of `100 NHB` (`100 * 10^18` wei) accrues
-`0.5 ZNHB` (`5 * 10^17` wei) so long as the treasury holds enough balance and the
+With the default 5,000 bps rate, a settlement of `100 NHB` (`100 * 10^18` wei) accrues
+`50 ZNHB` (`50 * 10^18` wei) so long as the treasury holds enough balance and the
 per-transaction and daily caps permit it.
 
 ### Deterministic meters

--- a/docs/loyalty/payouts.md
+++ b/docs/loyalty/payouts.md
@@ -6,15 +6,16 @@ program-specific payouts.
 
 ## Default Accrual Rate
 
-* The chain-wide default accrual rate is **50 basis points (0.5%)** as defined by
-  `loyalty.DefaultBaseRewardBps`.
+* The chain-wide default accrual rate is **5,000 basis points (50%)** as defined by
+  `loyalty.DefaultBaseRewardBps`, minting 0.5 ZNHB for every 1 NHB of qualifying
+  spend.
 * All basis-point math uses the `loyalty.BaseRewardBpsDenominator` constant of
   10,000.
 * Operators can toggle the engine with the `Active` flag, but when enabled an
   explicit reward rate is no longer required—the default is applied whenever the
   stored config omits `BaseBps`.
 
-For example, a 20,000 wei NHB payment mints 100 wei ZNHB: `20_000 * 50 / 10_000`.
+For example, a 20,000 wei NHB payment mints 10,000 wei ZNHB: `20_000 * 5_000 / 10_000`.
 Caps (per-transaction or daily) clamp the computed reward after the rate is
 applied.
 
@@ -27,7 +28,7 @@ via `state.Manager.SetLoyaltyGlobalConfig`. Relevant fields:
 |-------|-------------|
 | `Active` | Enables/disables base reward accrual. |
 | `Treasury` | 20-byte address that funds rewards. |
-| `BaseBps` | Optional basis-point override; defaults to 50 when zero. |
+| `BaseBps` | Optional basis-point override; defaults to 5,000 when zero. |
 | `MinSpend` | Minimum NHB spend required to earn the reward. |
 | `CapPerTx` | Hard cap (in ZNHB) per transaction. |
 | `DailyCapUser` | Daily cap (in ZNHB) per shopper. |

--- a/native/loyalty/engine_base_test.go
+++ b/native/loyalty/engine_base_test.go
@@ -120,7 +120,7 @@ func newConfig(baseBps uint32, minSpend, capPerTx, dailyCap int64, treasury []by
 func TestApplyBaseRewardHappyPath(t *testing.T) {
 	treasury := []byte("treasury")
 	from := []byte("from")
-	cfg := newConfig(50, 100, 500, 1000, treasury)
+	cfg := newConfig(5_000, 100, 500, 1000, treasury)
 	state := newMockState(cfg)
 	state.addAccount(treasury, &types.Account{BalanceZNHB: big.NewInt(1000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
 	fromAccount := &types.Account{BalanceNHB: big.NewInt(0), BalanceZNHB: big.NewInt(0), Stake: big.NewInt(0)}
@@ -136,29 +136,29 @@ func TestApplyBaseRewardHappyPath(t *testing.T) {
 	engine := NewEngine()
 	engine.ApplyBaseReward(state, ctx)
 
-	if got := ctx.FromAccount.BalanceZNHB.String(); got != "5" {
-		t.Fatalf("expected reward 5, got %s", got)
+	if got := ctx.FromAccount.BalanceZNHB.String(); got != "500" {
+		t.Fatalf("expected reward 500, got %s", got)
 	}
 	treasuryAcc, _ := state.GetAccount(treasury)
-	if got := treasuryAcc.BalanceZNHB.String(); got != "995" {
-		t.Fatalf("expected treasury balance 995, got %s", got)
+	if got := treasuryAcc.BalanceZNHB.String(); got != "500" {
+		t.Fatalf("expected treasury balance 500, got %s", got)
 	}
 	daily, _ := state.LoyaltyBaseDailyAccrued(from, "2024-01-02")
-	if daily.String() != "5" {
-		t.Fatalf("expected daily accrued 5, got %s", daily.String())
+	if daily.String() != "500" {
+		t.Fatalf("expected daily accrued 500, got %s", daily.String())
 	}
 	total, _ := state.LoyaltyBaseTotalAccrued(from)
-	if total.String() != "5" {
-		t.Fatalf("expected total accrued 5, got %s", total.String())
+	if total.String() != "500" {
+		t.Fatalf("expected total accrued 500, got %s", total.String())
 	}
 	if len(state.events) != 1 || state.events[0].Type != eventBaseAccrued {
 		t.Fatalf("expected accrued event, got %#v", state.events)
 	}
-	if state.events[0].Attributes["reward"] != "5" {
-		t.Fatalf("expected reward attribute 5, got %s", state.events[0].Attributes["reward"])
+	if state.events[0].Attributes["reward"] != "500" {
+		t.Fatalf("expected reward attribute 500, got %s", state.events[0].Attributes["reward"])
 	}
-	if got := state.events[0].Attributes["baseBps"]; got != "50" {
-		t.Fatalf("expected baseBps attribute 50, got %s", got)
+	if got := state.events[0].Attributes["baseBps"]; got != "5000" {
+		t.Fatalf("expected baseBps attribute 5000, got %s", got)
 	}
 }
 

--- a/native/loyalty/params.go
+++ b/native/loyalty/params.go
@@ -5,8 +5,8 @@ const (
 	// when computing base spend rewards.
 	BaseRewardBpsDenominator = 10_000
 	// DefaultBaseRewardBps configures the default base accrual rate expressed in
-	// basis points (0.5%).
-	DefaultBaseRewardBps = 50
+	// basis points (50%).
+	DefaultBaseRewardBps = 5_000
 )
 
 // ApplyDefaults ensures unset fields fall back to module defaults.

--- a/tests/loyalty/base_reward_test.go
+++ b/tests/loyalty/base_reward_test.go
@@ -79,7 +79,7 @@ func TestBaseRewardAccruesAtDefaultRate(t *testing.T) {
 		t.Fatalf("set global config: %v", err)
 	}
 
-	mustPutAccount(t, manager, treasury, &types.Account{BalanceZNHB: big.NewInt(1_000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
+	mustPutAccount(t, manager, treasury, &types.Account{BalanceZNHB: big.NewInt(20_000), BalanceNHB: big.NewInt(0), Stake: big.NewInt(0)})
 
 	var spender [20]byte
 	spender[19] = 0xBB
@@ -106,7 +106,7 @@ func TestBaseRewardAccruesAtDefaultRate(t *testing.T) {
 	}
 
 	treasuryAcc := mustAccount(t, manager, treasury)
-	wantTreasury := big.NewInt(1_000)
+	wantTreasury := big.NewInt(20_000)
 	wantTreasury.Sub(wantTreasury, expected)
 	if treasuryAcc.BalanceZNHB.Cmp(wantTreasury) != 0 {
 		t.Fatalf("expected treasury balance %s, got %s", wantTreasury.String(), treasuryAcc.BalanceZNHB.String())
@@ -129,8 +129,8 @@ func TestBaseRewardAccruesAtDefaultRate(t *testing.T) {
 	if evt.Attributes["reward"] != expected.String() {
 		t.Fatalf("expected reward attribute %s, got %s", expected.String(), evt.Attributes["reward"])
 	}
-	if evt.Attributes["baseBps"] != "50" {
-		t.Fatalf("expected baseBps attribute 50, got %s", evt.Attributes["baseBps"])
+	if evt.Attributes["baseBps"] != "5000" {
+		t.Fatalf("expected baseBps attribute 5000, got %s", evt.Attributes["baseBps"])
 	}
 }
 
@@ -223,7 +223,7 @@ func TestBaseRewardHonorsCapPerTx(t *testing.T) {
 	if evt.Attributes["reward"] != "50" {
 		t.Fatalf("expected reward attribute 50, got %s", evt.Attributes["reward"])
 	}
-	if evt.Attributes["baseBps"] != "50" {
-		t.Fatalf("expected baseBps attribute 50, got %s", evt.Attributes["baseBps"])
+	if evt.Attributes["baseBps"] != "5000" {
+		t.Fatalf("expected baseBps attribute 5000, got %s", evt.Attributes["baseBps"])
 	}
 }


### PR DESCRIPTION
## Summary
- raise the loyalty DefaultBaseRewardBps constant to 5,000 (50%) and keep guardrails aligned
- update loyalty engine and integration tests to assert the higher base payouts and treasury debits
- refresh loyalty documentation and changelog to explain the new 0.5 ZNHB per NHB rate and treasury impact

## Testing
- go test ./native/loyalty -run TestApplyBaseRewardHappyPath -count=1 -v
- go test ./tests/loyalty -run TestBaseRewardAccruesAtDefaultRate -count=1 -v

------
https://chatgpt.com/codex/tasks/task_e_68e4c329b538832d8dcc98221faa4b1b