### PR TITLE
Add reusable local genesis definition

### DIFF
--- a/config-local.toml
+++ b/config-local.toml
@@ -2,7 +2,7 @@ ListenAddress = "0.0.0.0:6002"
 RPCAddress = "0.0.0.0:8081"
 DataDir = "./nhb-data-local"
 # Required: point to the genesis file that defines your local dev network.
-GenesisFile = "./config/local-genesis.json"
+GenesisFile = "./config/genesis.local.json"
 # Set to true only if you intentionally want the node to fabricate an ephemeral genesis.
 AllowAutogenesis = false
 ValidatorKeystorePath = "./validator-local.keystore"

--- a/config/genesis.local.json
+++ b/config/genesis.local.json
@@ -1,0 +1,34 @@
+{
+  "genesisTime": "2024-09-01T00:00:00Z",
+  "chainId": 17381991232128513634,
+  "nativeTokens": [
+    {
+      "symbol": "NHB",
+      "name": "NHBCoin",
+      "decimals": 18,
+      "mintAuthority": "nhb1tctz3yvhrwztnp6ds3s48qp4jgfujcvhgxxpka"
+    },
+    {
+      "symbol": "ZNHB",
+      "name": "ZapNHB",
+      "decimals": 18,
+      "initialMintPaused": false
+    }
+  ],
+  "validators": [
+    {
+      "address": "nhb1tctz3yvhrwztnp6ds3s48qp4jgfujcvhgxxpka",
+      "power": 10,
+      "moniker": "local-validator"
+    }
+  ],
+  "alloc": {
+    "nhb1tctz3yvhrwztnp6ds3s48qp4jgfujcvhgxxpka": {
+      "NHB": "1000000"
+    },
+    "znhb19l75s7jkyzxp4z7lj3ddgn9r89y3kps54wpv0w": {
+      "ZNHB": "10000000"
+    }
+  },
+  "roles": {}
+}


### PR DESCRIPTION
## Summary
- add a committed genesis.local.json with NHB and ZNHB pre-mints for local usage
- point the sample local configuration at the new genesis file so nodes boot with the shared chain ID

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4c3decf14832dbf2b5d4667cf5e4c