### PR TITLE
Allow insecure RPC on unspecified addresses

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -456,7 +456,14 @@ func isLoopback(addr net.Addr) bool {
 	}
 	ip := tcpAddr.IP
 	if ip == nil {
-		return false
+		// net.Listen("tcp", "0.0.0.0:port") produces a nil IP, which corresponds to the
+		// unspecified address. Treat it as loopback so local development environments that
+		// expose ports via container port-forwarding can run without TLS when AllowInsecure
+		// is explicitly enabled.
+		return true
+	}
+	if ip.IsUnspecified() {
+		return true
 	}
 	if ip.IsLoopback() {
 		return true
@@ -716,17 +723,17 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.handleStableRequestSwapApproval(recorder, r, req)
 	case "nhb_swapMint":
 		s.handleStableSwapMint(recorder, r, req)
-        case "nhb_swapBurn":
-                s.handleStableSwapBurn(recorder, r, req)
-        case "nhb_getSwapStatus":
-                s.handleStableGetSwapStatus(recorder, r, req)
-        case "fees_listTotals":
-                s.handleFeesListTotals(recorder, r, req)
-        case "swap_limits":
-                if authErr := s.requireAuth(r); authErr != nil {
-                        writeError(recorder, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
-                        return
-                }
+	case "nhb_swapBurn":
+		s.handleStableSwapBurn(recorder, r, req)
+	case "nhb_getSwapStatus":
+		s.handleStableGetSwapStatus(recorder, r, req)
+	case "fees_listTotals":
+		s.handleFeesListTotals(recorder, r, req)
+	case "swap_limits":
+		if authErr := s.requireAuth(r); authErr != nil {
+			writeError(recorder, http.StatusUnauthorized, req.ID, authErr.Code, authErr.Message, authErr.Data)
+			return
+		}
 		s.handleSwapLimits(recorder, r, req)
 	case "swap_provider_status":
 		if authErr := s.requireAuth(r); authErr != nil {


### PR DESCRIPTION
## Summary
- treat unspecified RPC listener addresses as loopback when AllowInsecure is enabled
- update RPC server tests to cover unspecified bindings and preserve non-loopback safeguards

## Testing
- go test ./rpc -count=1

------
https://chatgpt.com/codex/tasks/task_e_68e4e92f7b34832d8ffdc7488e1c8f32