### PR TITLE
feat: auto-populate validator info from local key

### DIFF
--- a/config/genesis.local.json
+++ b/config/genesis.local.json
@@ -17,9 +17,9 @@
   ],
   "validators": [
     {
-      "address": "nhb1tctz3yvhrwztnp6ds3s48qp4jgfujcvhgxxpka",
       "power": 10,
-      "moniker": "local-validator"
+      "moniker": "local-validator",
+      "autoPopulateLocal": true
     }
   ],
   "alloc": {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -316,7 +316,7 @@ func genesisFromSource(path string, allowAutogenesis bool, db storage.Database) 
 		if err != nil {
 			return nil, nil, err
 		}
-		block, finalize, err := genesis.BuildGenesisFromSpec(spec, db)
+		block, finalize, err := genesis.BuildGenesisFromSpec(spec, db, nil)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -359,7 +359,7 @@ func rebuildGenesisState(db storage.Database, genesisPath string) error {
 		return fmt.Errorf("load genesis spec: %w", err)
 	}
 
-	block, finalize, err := genesis.BuildGenesisFromSpec(spec, db)
+	block, finalize, err := genesis.BuildGenesisFromSpec(spec, db, nil)
 	if err != nil {
 		return fmt.Errorf("rebuild genesis block: %w", err)
 	}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -263,7 +263,7 @@ func TestNewBlockchainChainIDMismatchDoesNotPersistState(t *testing.T) {
 
 	tempDB := storage.NewMemDB()
 	defer tempDB.Close()
-	block, finalize, err := genesis.BuildGenesisFromSpec(&spec, tempDB)
+	block, finalize, err := genesis.BuildGenesisFromSpec(&spec, tempDB, nil)
 	if err != nil {
 		t.Fatalf("build genesis for derived chain id: %v", err)
 	}

--- a/core/genesis/loader.go
+++ b/core/genesis/loader.go
@@ -19,12 +19,22 @@ import (
 	"nhbchain/storage/trie"
 )
 
-func BuildGenesisFromSpec(spec *GenesisSpec, db storage.Database) (*types.Block, func() error, error) {
+func BuildGenesisFromSpec(spec *GenesisSpec, db storage.Database, info *ValidatorAutoPopulateInfo) (*types.Block, func() error, error) {
 	if spec == nil {
 		return nil, nil, fmt.Errorf("genesis spec must not be nil")
 	}
 	if db == nil {
 		return nil, nil, fmt.Errorf("database must not be nil")
+	}
+
+	if _, err := spec.ResolveValidatorAutoPopulate(info); err != nil {
+		return nil, nil, fmt.Errorf("resolve validator auto-populate: %w", err)
+	}
+
+	for i := range spec.Validators {
+		if spec.Validators[i].AutoPopulateLocal {
+			return nil, nil, fmt.Errorf("validator[%d]: autoPopulateLocal unresolved", i)
+		}
 	}
 
 	ts := spec.GenesisTimestamp()

--- a/core/node_leveldb_test.go
+++ b/core/node_leveldb_test.go
@@ -107,7 +107,7 @@ func TestNewNodeRebuildsMissingGenesisState(t *testing.T) {
 		t.Fatalf("create leveldb: %v", err)
 	}
 
-	block, _, err := genesis.BuildGenesisFromSpec(&spec, db)
+	block, _, err := genesis.BuildGenesisFromSpec(&spec, db, nil)
 	if err != nil {
 		t.Fatalf("build genesis from spec: %v", err)
 	}

--- a/go.work.sum
+++ b/go.work.sum
@@ -549,6 +549,7 @@ github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245 h1:K1Xf3bKttbF
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=
 github.com/spf13/afero v1.10.0 h1:EaGW2JJh15aKOejeuJ+wpFSHnbd7GE6Wvp3TsNhb6LY=
@@ -560,6 +561,7 @@ github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GB
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=
 github.com/status-im/keycard-go v0.2.0/go.mod h1:wlp8ZLbsmrF6g6WjugPAx+IzoLrkdf9+mHxBEeo3Hbg=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/xhit/go-str2duration v1.2.0 h1:BcV5u025cITWxEQKGWr1URRzrcXtu7uk8+luz3Yuhwc=
 github.com/xhit/go-str2duration v1.2.0/go.mod h1:3cPSlfZlUHVlneIVfePFWcJZsuwf+P1v2SRTV4cUmp4=


### PR DESCRIPTION
## Summary
- allow validator specs to opt into local auto-population and resolve those entries before committing genesis state
- have the nhb daemon load the genesis file, fill the local validator fields, and persist a resolved copy in the data directory
- exercise both auto-populated and explicit validator paths in genesis tests and update the local genesis config to use the new flag

## Testing
- time go test -run TestResolveValidatorAutoPopulate ./core/genesis

------
https://chatgpt.com/codex/tasks/task_e_68e5406d487c832d9c47d601abfc7dea