### PR TITLE
Map lending engine errors to gRPC statuses

### DIFF
--- a/services/lending/server/errors.go
+++ b/services/lending/server/errors.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"nhbchain/services/lending/engine"
+)
+
+func toStatus(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, engine.ErrNotFound):
+		return status.Errorf(codes.NotFound, "resource not found")
+	case errors.Is(err, engine.ErrPaused):
+		return status.Errorf(codes.Unavailable, "operation paused")
+	case errors.Is(err, engine.ErrUnauthorized):
+		return status.Errorf(codes.PermissionDenied, "unauthorized")
+	case errors.Is(err, engine.ErrInvalidAmount):
+		return status.Errorf(codes.InvalidArgument, "invalid amount")
+	case errors.Is(err, engine.ErrInsufficientCollateral):
+		return status.Errorf(codes.ResourceExhausted, "insufficient collateral")
+	case errors.Is(err, engine.ErrInternal):
+		return status.Errorf(codes.Internal, "internal error")
+	default:
+		return status.Errorf(codes.Internal, "internal error")
+	}
+}

--- a/services/lending/server/errors_test.go
+++ b/services/lending/server/errors_test.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"nhbchain/services/lending/engine"
+)
+
+func TestToStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		err     error
+		code    codes.Code
+		message string
+	}{
+		{
+			name:    "not found",
+			err:     fmt.Errorf("wrap: %w", engine.ErrNotFound),
+			code:    codes.NotFound,
+			message: "resource not found",
+		},
+		{
+			name:    "paused",
+			err:     fmt.Errorf("wrap: %w", engine.ErrPaused),
+			code:    codes.Unavailable,
+			message: "operation paused",
+		},
+		{
+			name:    "unauthorized",
+			err:     fmt.Errorf("wrap: %w", engine.ErrUnauthorized),
+			code:    codes.PermissionDenied,
+			message: "unauthorized",
+		},
+		{
+			name:    "invalid amount",
+			err:     fmt.Errorf("wrap: %w", engine.ErrInvalidAmount),
+			code:    codes.InvalidArgument,
+			message: "invalid amount",
+		},
+		{
+			name:    "insufficient collateral",
+			err:     fmt.Errorf("wrap: %w", engine.ErrInsufficientCollateral),
+			code:    codes.ResourceExhausted,
+			message: "insufficient collateral",
+		},
+		{
+			name:    "internal",
+			err:     fmt.Errorf("wrap: %w", engine.ErrInternal),
+			code:    codes.Internal,
+			message: "internal error",
+		},
+		{
+			name:    "unknown",
+			err:     errors.New("boom"),
+			code:    codes.Internal,
+			message: "internal error",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := toStatus(tc.err)
+			if tc.err == nil {
+				if got != nil {
+					t.Fatalf("expected nil for nil error, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil error")
+			}
+			st := status.Convert(got)
+			if st.Code() != tc.code {
+				t.Fatalf("expected code %s, got %s", tc.code, st.Code())
+			}
+			if st.Message() != tc.message {
+				t.Fatalf("expected message %q, got %q", tc.message, st.Message())
+			}
+		})
+	}
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+		if toStatus(nil) != nil {
+			t.Fatal("expected nil for nil error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add a server-level toStatus helper that maps engine sentinel errors onto gRPC codes with an internal fallback
- route translateEngineError through the helper so handlers consistently report the mapped codes while logging internal failures
- cover the new mapping logic with a table-driven unit test for each sentinel scenario

## Testing
- go test services/lending/server/errors_test.go services/lending/server/errors.go

------
https://chatgpt.com/codex/tasks/task_e_68e5b260a0c8832db1e4a535430fb09b