### PR TITLE
Refactor lending engine to use JSON-RPC adapter

### DIFF
--- a/services/lending/engine/engine.go
+++ b/services/lending/engine/engine.go
@@ -1,10 +1,6 @@
 package engine
 
-import (
-	"context"
-
-	"nhbchain/native/lending"
-)
+import "context"
 
 // Engine describes the operations required by the lending gRPC surface.
 type Engine interface {
@@ -19,20 +15,84 @@ type Engine interface {
 	GetHealth(ctx context.Context, addr string) (Health, error)
 }
 
-// Market mirrors the JSON payload returned by the legacy RPC handler.
+// Market mirrors the payload returned by the node JSON-RPC handlers.
 type Market struct {
-	Market         *lending.Market        `json:"market"`
-	RiskParameters lending.RiskParameters `json:"riskParameters"`
+	Market         *MarketSnapshot `json:"market,omitempty"`
+	RiskParameters RiskParameters  `json:"riskParameters"`
+}
+
+// MarketSnapshot captures the accounting state for a lending market using
+// decimal encoded strings.
+type MarketSnapshot struct {
+	PoolID            string `json:"poolID"`
+	TotalNHBSupplied  string `json:"totalNHBSupplied"`
+	TotalSupplyShares string `json:"totalSupplyShares"`
+	TotalNHBBorrowed  string `json:"totalNHBBorrowed"`
+	SupplyIndex       string `json:"supplyIndex"`
+	BorrowIndex       string `json:"borrowIndex"`
+	ReserveFactor     uint64 `json:"reserveFactor"`
+	LastUpdateBlock   uint64 `json:"lastUpdateBlock"`
+}
+
+// RiskParameters exposes the governance controlled safety configuration.
+type RiskParameters struct {
+	MaxLTV               uint64         `json:"maxLTV"`
+	LiquidationThreshold uint64         `json:"liquidationThreshold"`
+	LiquidationBonus     uint64         `json:"liquidationBonus"`
+	DeveloperFeeCapBps   uint64         `json:"developerFeeCapBps"`
+	BorrowCaps           BorrowCaps     `json:"borrowCaps"`
+	Oracle               OracleConfig   `json:"oracle"`
+	Pauses               ActionPauses   `json:"pauses"`
+	CircuitBreakerActive bool           `json:"circuitBreakerActive"`
+	CollateralRouting    CollateralFlow `json:"collateralRouting"`
+}
+
+// BorrowCaps aggregates per-block and total borrow ceilings.
+type BorrowCaps struct {
+	PerBlock       string `json:"perBlock"`
+	Total          string `json:"total"`
+	UtilisationBps uint64 `json:"utilisationBps"`
+}
+
+// OracleConfig describes the accepted freshness window for oracle updates.
+type OracleConfig struct {
+	MaxAgeBlocks    uint64 `json:"maxAgeBlocks"`
+	MaxDeviationBps uint64 `json:"maxDeviationBps"`
+}
+
+// ActionPauses captures fine grained pause switches for market operations.
+type ActionPauses struct {
+	Supply    bool `json:"supply"`
+	Borrow    bool `json:"borrow"`
+	Repay     bool `json:"repay"`
+	Liquidate bool `json:"liquidate"`
+}
+
+// CollateralFlow reports the liquidation routing configuration when available.
+type CollateralFlow struct {
+	LiquidatorBps uint64 `json:"liquidatorBps"`
+	DeveloperBps  uint64 `json:"developerBps"`
+	ProtocolBps   uint64 `json:"protocolBps"`
 }
 
 // Position reflects the structure returned by lending_getUserAccount.
 type Position struct {
-	Account *lending.UserAccount `json:"account"`
+	Account *AccountSnapshot `json:"account,omitempty"`
+}
+
+// AccountSnapshot captures on-ledger balances using decimal encoded strings.
+type AccountSnapshot struct {
+	Address        string `json:"address,omitempty"`
+	CollateralZNHB string `json:"collateralZNHB"`
+	SupplyShares   string `json:"supplyShares"`
+	DebtNHB        string `json:"debtNHB"`
+	ScaledDebt     string `json:"scaledDebt,omitempty"`
 }
 
 // Health combines the market snapshot and user account used for risk checks.
 type Health struct {
-	Market         *lending.Market        `json:"market"`
-	RiskParameters lending.RiskParameters `json:"riskParameters"`
-	Account        *lending.UserAccount   `json:"account"`
+	Market         *MarketSnapshot  `json:"market,omitempty"`
+	RiskParameters RiskParameters   `json:"riskParameters"`
+	Account        *AccountSnapshot `json:"account,omitempty"`
+	HealthFactor   string           `json:"healthFactor"`
 }


### PR DESCRIPTION
## Summary
- redefine the Engine contracts to use JSON-RPC friendly market, position, and health payloads
- replace the node-backed engine adapter with an rpcclient-powered implementation that calls the node JSON-RPC methods
- adjust the server conversion helpers to work with the new string based snapshots returned from the adapter

## Testing
- go build ./services/lending/...


------
https://chatgpt.com/codex/tasks/task_e_68e5be437490832d8078b4a3d961f590