### PR TITLE
Refactor lending server startup

### DIFF
--- a/services/lending/server/server.go
+++ b/services/lending/server/server.go
@@ -30,6 +30,21 @@ type Authorizer interface {
 	Authorize(context.Context) error
 }
 
+type interceptorAuthorizer struct{}
+
+// NewInterceptorAuthorizer constructs an Authorizer that trusts the
+// authentication context installed by the gRPC interceptors.
+func NewInterceptorAuthorizer() Authorizer {
+	return interceptorAuthorizer{}
+}
+
+func (interceptorAuthorizer) Authorize(ctx context.Context) error {
+	if isAuthenticated(ctx) {
+		return nil
+	}
+	return status.Error(codes.Unauthenticated, "authentication required")
+}
+
 // New constructs a new lending service instance.
 func New(engine engine.Engine, logger *slog.Logger, auth Authorizer) *Service {
 	if logger == nil {


### PR DESCRIPTION
## Summary
- initialize the lending engine node RPC client and wire it into the gRPC server with shared interceptor/TLS configuration
- add a lightweight localhost /healthz endpoint that probes the node via `nhb_getHeight`
- enforce interceptor-based authentication inside the lending service implementation

## Testing
- go build -v ./services/lending/...


------
https://chatgpt.com/codex/tasks/task_e_68e5c6d03668832d92f2c12ba1db2661