### PR TITLE
feat: add lending gRPC gateway routes

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -181,7 +181,7 @@ func main() {
 		rateLimits["consensus"] = middleware.RateLimit{RatePerSecond: 4, Burst: 40}
 	}
 
-	router := routes.New(routes.Config{
+	router, err := routes.New(routes.Config{
 		Routes: []routes.ServiceRoute{
 			{
 				Name:           "lending",
@@ -226,6 +226,10 @@ func main() {
 			AllowCredentials: false,
 		},
 	})
+
+	if err != nil {
+		logger.Fatalf("configure routes: %v", err)
+	}
 
 	handler := http.Handler(router)
 	if cfg.Observability.Tracing {

--- a/docs/api/lending-grpc.md
+++ b/docs/api/lending-grpc.md
@@ -1,0 +1,214 @@
+# Lending gRPC Gateway
+
+The gateway exposes a JSON-over-HTTP surface for the [`lending.v1.LendingService`](../../proto/lending/v1/lending.proto).
+Each endpoint maps directly to a gRPC method and forwards requests to `lendingd` using the same authentication and
+rate-limiting middleware as the legacy REST endpoints.
+
+All requests and responses use JSON encodings of the underlying protobuf messages. Examples below illustrate the wire
+format and reference the relevant message types.
+
+## List markets
+
+- **Method**: `GET /v1/lending/markets`
+- **gRPC method**: `ListMarkets(ListMarketsRequest) returns (ListMarketsResponse)`
+- **Description**: Retrieves the catalog of supported lending markets.
+
+**Response example (`ListMarketsResponse`)**
+
+```json
+{
+  "markets": [
+    {
+      "key": {"symbol": "nhb"},
+      "baseAsset": "unhb",
+      "collateralFactor": "0.5",
+      "reserveFactor": "0.1",
+      "liquidityIndex": "1.000000000000000000",
+      "borrowIndex": "1.000000000000000000"
+    }
+  ]
+}
+```
+
+## Get market
+
+- **Method**: `POST /v1/lending/markets/get`
+- **gRPC method**: `GetMarket(GetMarketRequest) returns (GetMarketResponse)`
+- **Description**: Fetches a single market by its symbol.
+
+**Request example (`GetMarketRequest`)**
+
+```json
+{
+  "key": {"symbol": "nhb"}
+}
+```
+
+**Response example (`GetMarketResponse`)**
+
+```json
+{
+  "market": {
+    "key": {"symbol": "nhb"},
+    "baseAsset": "unhb",
+    "collateralFactor": "0.5",
+    "reserveFactor": "0.1",
+    "liquidityIndex": "1.000000000000000000",
+    "borrowIndex": "1.000000000000000000"
+  }
+}
+```
+
+## Get position
+
+- **Method**: `POST /v1/lending/positions/get`
+- **gRPC method**: `GetPosition(GetPositionRequest) returns (GetPositionResponse)`
+- **Description**: Returns the current lending position for a borrower account.
+
+**Request example (`GetPositionRequest`)**
+
+```json
+{
+  "account": "nhb1exampleaccount"
+}
+```
+
+**Response example (`GetPositionResponse`)**
+
+```json
+{
+  "position": {
+    "account": "nhb1exampleaccount",
+    "supplied": "1000",
+    "borrowed": "250",
+    "collateral": "400",
+    "healthFactor": "1.8"
+  }
+}
+```
+
+## Supply asset
+
+- **Method**: `POST /v1/lending/supply`
+- **gRPC method**: `SupplyAsset(SupplyAssetRequest) returns (SupplyAssetResponse)`
+- **Description**: Supplies liquidity to a market.
+
+**Request example (`SupplyAssetRequest`)**
+
+```json
+{
+  "account": "nhb1exampleaccount",
+  "market": {"symbol": "nhb"},
+  "amount": "500"
+}
+```
+
+**Response example (`SupplyAssetResponse`)**
+
+```json
+{
+  "position": {
+    "account": "nhb1exampleaccount",
+    "supplied": "1500",
+    "borrowed": "250",
+    "collateral": "400",
+    "healthFactor": "2.1"
+  }
+}
+```
+
+## Withdraw asset
+
+- **Method**: `POST /v1/lending/withdraw`
+- **gRPC method**: `WithdrawAsset(WithdrawAssetRequest) returns (WithdrawAssetResponse)`
+- **Description**: Withdraws previously supplied liquidity.
+
+**Request example (`WithdrawAssetRequest`)**
+
+```json
+{
+  "account": "nhb1exampleaccount",
+  "market": {"symbol": "nhb"},
+  "amount": "200"
+}
+```
+
+**Response example (`WithdrawAssetResponse`)**
+
+```json
+{
+  "position": {
+    "account": "nhb1exampleaccount",
+    "supplied": "1300",
+    "borrowed": "250",
+    "collateral": "400",
+    "healthFactor": "1.9"
+  }
+}
+```
+
+## Borrow asset
+
+- **Method**: `POST /v1/lending/borrow`
+- **gRPC method**: `BorrowAsset(BorrowAssetRequest) returns (BorrowAssetResponse)`
+- **Description**: Borrows from a market using the caller's collateral.
+
+**Request example (`BorrowAssetRequest`)**
+
+```json
+{
+  "account": "nhb1exampleaccount",
+  "market": {"symbol": "nhb"},
+  "amount": "100"
+}
+```
+
+**Response example (`BorrowAssetResponse`)**
+
+```json
+{
+  "position": {
+    "account": "nhb1exampleaccount",
+    "supplied": "1300",
+    "borrowed": "350",
+    "collateral": "400",
+    "healthFactor": "1.6"
+  }
+}
+```
+
+## Repay asset
+
+- **Method**: `POST /v1/lending/repay`
+- **gRPC method**: `RepayAsset(RepayAssetRequest) returns (RepayAssetResponse)`
+- **Description**: Repays an outstanding borrowed amount.
+
+**Request example (`RepayAssetRequest`)**
+
+```json
+{
+  "account": "nhb1exampleaccount",
+  "market": {"symbol": "nhb"},
+  "amount": "75"
+}
+```
+
+**Response example (`RepayAssetResponse`)**
+
+```json
+{
+  "position": {
+    "account": "nhb1exampleaccount",
+    "supplied": "1300",
+    "borrowed": "275",
+    "collateral": "400",
+    "healthFactor": "1.8"
+  }
+}
+```
+
+> **Note**
+>
+> The gateway validates JSON bodies against the protobuf schemas and surfaces gRPC errors using HTTP status codes.
+> Refer to [`proto/lending/v1/lending.proto`](../../proto/lending/v1/lending.proto) for the authoritative
+> message definitions.

--- a/gateway/routes/lending.go
+++ b/gateway/routes/lending.go
@@ -1,0 +1,324 @@
+package routes
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	lendingv1 "nhbchain/proto/lending/v1"
+)
+
+const lendingRequestLimit = 1 << 20 // 1 MiB
+
+// lendingRoutes wires HTTP handlers to the LendingService gRPC API.
+type lendingRoutes struct {
+	client    lendingv1.LendingServiceClient
+	marshal   protojson.MarshalOptions
+	unmarshal protojson.UnmarshalOptions
+	timeout   time.Duration
+}
+
+func newLendingRoutes(target *url.URL) (*lendingRoutes, error) {
+	if target == nil {
+		return nil, fmt.Errorf("nil lending target")
+	}
+	conn, err := dialLending(target)
+	if err != nil {
+		return nil, fmt.Errorf("dial lending service: %w", err)
+	}
+	return &lendingRoutes{
+		client:    lendingv1.NewLendingServiceClient(conn),
+		marshal:   protojson.MarshalOptions{EmitUnpopulated: true},
+		unmarshal: protojson.UnmarshalOptions{DiscardUnknown: true},
+		timeout:   10 * time.Second,
+	}, nil
+}
+
+func (lr *lendingRoutes) mount(r chi.Router) {
+	r.Get("/markets", lr.listMarkets)
+	r.Post("/markets/get", lr.getMarket)
+	r.Post("/positions/get", lr.getPosition)
+	r.Post("/supply", lr.supplyAsset)
+	r.Post("/withdraw", lr.withdrawAsset)
+	r.Post("/borrow", lr.borrowAsset)
+	r.Post("/repay", lr.repayAsset)
+}
+
+func (lr *lendingRoutes) context(parent context.Context) (context.Context, context.CancelFunc) {
+	timeout := lr.timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
+func (lr *lendingRoutes) listMarkets(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := lr.context(r.Context())
+	defer cancel()
+
+	resp, err := lr.client.ListMarkets(ctx, &lendingv1.ListMarketsRequest{})
+	if err != nil {
+		writeGRPCError(w, err)
+		return
+	}
+	writeProtoJSON(w, lr.marshal, resp)
+}
+
+func (lr *lendingRoutes) getMarket(w http.ResponseWriter, r *http.Request) {
+	req := &lendingv1.GetMarketRequest{}
+	if err := lr.decodeRequest(r, req); err != nil {
+		writeBadRequest(w, err)
+		return
+	}
+
+	ctx, cancel := lr.context(r.Context())
+	defer cancel()
+
+	resp, err := lr.client.GetMarket(ctx, req)
+	if err != nil {
+		writeGRPCError(w, err)
+		return
+	}
+	writeProtoJSON(w, lr.marshal, resp)
+}
+
+func (lr *lendingRoutes) getPosition(w http.ResponseWriter, r *http.Request) {
+	req := &lendingv1.GetPositionRequest{}
+	if err := lr.decodeRequest(r, req); err != nil {
+		writeBadRequest(w, err)
+		return
+	}
+
+	ctx, cancel := lr.context(r.Context())
+	defer cancel()
+
+	resp, err := lr.client.GetPosition(ctx, req)
+	if err != nil {
+		writeGRPCError(w, err)
+		return
+	}
+	writeProtoJSON(w, lr.marshal, resp)
+}
+
+func (lr *lendingRoutes) supplyAsset(w http.ResponseWriter, r *http.Request) {
+	req := &lendingv1.SupplyAssetRequest{}
+	if err := lr.decodeRequest(r, req); err != nil {
+		writeBadRequest(w, err)
+		return
+	}
+
+	ctx, cancel := lr.context(r.Context())
+	defer cancel()
+
+	resp, err := lr.client.SupplyAsset(ctx, req)
+	if err != nil {
+		writeGRPCError(w, err)
+		return
+	}
+	writeProtoJSON(w, lr.marshal, resp)
+}
+
+func (lr *lendingRoutes) withdrawAsset(w http.ResponseWriter, r *http.Request) {
+	req := &lendingv1.WithdrawAssetRequest{}
+	if err := lr.decodeRequest(r, req); err != nil {
+		writeBadRequest(w, err)
+		return
+	}
+
+	ctx, cancel := lr.context(r.Context())
+	defer cancel()
+
+	resp, err := lr.client.WithdrawAsset(ctx, req)
+	if err != nil {
+		writeGRPCError(w, err)
+		return
+	}
+	writeProtoJSON(w, lr.marshal, resp)
+}
+
+func (lr *lendingRoutes) borrowAsset(w http.ResponseWriter, r *http.Request) {
+	req := &lendingv1.BorrowAssetRequest{}
+	if err := lr.decodeRequest(r, req); err != nil {
+		writeBadRequest(w, err)
+		return
+	}
+
+	ctx, cancel := lr.context(r.Context())
+	defer cancel()
+
+	resp, err := lr.client.BorrowAsset(ctx, req)
+	if err != nil {
+		writeGRPCError(w, err)
+		return
+	}
+	writeProtoJSON(w, lr.marshal, resp)
+}
+
+func (lr *lendingRoutes) repayAsset(w http.ResponseWriter, r *http.Request) {
+	req := &lendingv1.RepayAssetRequest{}
+	if err := lr.decodeRequest(r, req); err != nil {
+		writeBadRequest(w, err)
+		return
+	}
+
+	ctx, cancel := lr.context(r.Context())
+	defer cancel()
+
+	resp, err := lr.client.RepayAsset(ctx, req)
+	if err != nil {
+		writeGRPCError(w, err)
+		return
+	}
+	writeProtoJSON(w, lr.marshal, resp)
+}
+
+func (lr *lendingRoutes) decodeRequest(r *http.Request, msg proto.Message) error {
+	if r.Body == nil {
+		return errors.New("missing request body")
+	}
+	defer r.Body.Close()
+
+	reader := io.LimitReader(r.Body, lendingRequestLimit)
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("read request body: %w", err)
+	}
+	if len(data) == 0 {
+		return errors.New("request body is empty")
+	}
+	if err := lr.unmarshal.Unmarshal(data, msg); err != nil {
+		return fmt.Errorf("decode request: %w", err)
+	}
+	return nil
+}
+
+func writeProtoJSON(w http.ResponseWriter, marshal protojson.MarshalOptions, msg proto.Message) {
+	w.Header().Set("Content-Type", "application/json")
+	payload, err := marshal.Marshal(msg)
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("marshal response: %w", err))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(payload)
+}
+
+func writeBadRequest(w http.ResponseWriter, err error) {
+	writeJSONError(w, http.StatusBadRequest, err)
+}
+
+func writeInternalError(w http.ResponseWriter, err error) {
+	writeJSONError(w, http.StatusInternalServerError, err)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	message := strings.TrimSpace(err.Error())
+	if message == "" {
+		message = http.StatusText(status)
+	}
+	payload, marshalErr := json.Marshal(map[string]string{"error": message})
+	if marshalErr != nil {
+		replacer := strings.NewReplacer(
+			"\\", "\\\\",
+			"\"", "\\\"",
+			"\n", "\\n",
+			"\r", "\\r",
+			"\t", "\\t",
+		)
+		fallback := fmt.Sprintf("{\"error\":\"%s\"}", replacer.Replace(message))
+		payload = []byte(fallback)
+	}
+	_, _ = w.Write(payload)
+}
+
+func writeGRPCError(w http.ResponseWriter, err error) {
+	if err == nil {
+		writeInternalError(w, errors.New("unknown gRPC error"))
+		return
+	}
+	st, ok := grpcstatus.FromError(err)
+	if !ok {
+		writeInternalError(w, err)
+		return
+	}
+	statusCode := mapGRPCCode(st.Code())
+	writeJSONError(w, statusCode, errors.New(st.Message()))
+}
+
+func mapGRPCCode(code codes.Code) int {
+	switch code {
+	case codes.OK:
+		return http.StatusOK
+	case codes.InvalidArgument, codes.FailedPrecondition, codes.OutOfRange:
+		return http.StatusBadRequest
+	case codes.Unauthenticated:
+		return http.StatusUnauthorized
+	case codes.PermissionDenied:
+		return http.StatusForbidden
+	case codes.NotFound:
+		return http.StatusNotFound
+	case codes.AlreadyExists, codes.Aborted:
+		return http.StatusConflict
+	case codes.ResourceExhausted:
+		return http.StatusTooManyRequests
+	case codes.Unavailable:
+		return http.StatusServiceUnavailable
+	case codes.DeadlineExceeded:
+		return http.StatusGatewayTimeout
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func dialLending(target *url.URL) (*grpc.ClientConn, error) {
+	scheme := strings.ToLower(target.Scheme)
+	host := target.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("lending target host is empty")
+	}
+	port := target.Port()
+	if port == "" {
+		switch scheme {
+		case "https", "grpcs":
+			port = "443"
+		case "http", "grpc":
+			port = "80"
+		}
+	}
+	address := target.Host
+	if port != "" {
+		address = net.JoinHostPort(host, port)
+	}
+
+	var creds credentials.TransportCredentials
+	switch scheme {
+	case "https", "grpcs":
+		tlsConfig := &tls.Config{ServerName: host}
+		creds = credentials.NewTLS(tlsConfig)
+	case "http", "grpc":
+		creds = insecure.NewCredentials()
+	default:
+		return nil, fmt.Errorf("unsupported lending target scheme %q", target.Scheme)
+	}
+
+	return grpc.Dial(address, grpc.WithTransportCredentials(creds))
+}


### PR DESCRIPTION
## Summary
- add an HTTP-to-gRPC bridge for the lending service so the gateway can forward JSON requests to lendingd
- document the new /v1/lending endpoints with example payloads that map to the protobuf API

## Testing
- go build ./gateway/...


------
https://chatgpt.com/codex/tasks/task_e_68e5cf3a8428832db5e64af2c6146e8d