### PR TITLE
docs: document lending gRPC API and add SDK examples

### DIFF
--- a/sdk/examples/lending/go/main.go
+++ b/sdk/examples/lending/go/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"nhbchain/sdk/lending"
+)
+
+func main() {
+	endpoint := flag.String("endpoint", "localhost:9090", "lending gRPC endpoint (host:port)")
+	account := flag.String("account", "nhb1exampleaccount", "account address to act on")
+	market := flag.String("market", "nhb", "market symbol (e.g. nhb)")
+	supplyAmt := flag.String("supply", "500", "amount to supply in base units")
+	borrowAmt := flag.String("borrow", "100", "amount to borrow in base units")
+	repayAmt := flag.String("repay", "50", "amount to repay in base units")
+	insecure := flag.Bool("insecure", true, "dial without TLS (development only)")
+	timeout := flag.Duration("timeout", 5*time.Second, "per-RPC timeout")
+	flag.Parse()
+
+	ctx := context.Background()
+
+	dialOpts := []lending.DialOption{}
+	if *insecure {
+		dialOpts = append(dialOpts, lending.WithInsecure())
+	}
+
+	connCtx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+
+	client, err := lending.Dial(connCtx, *endpoint, dialOpts...)
+	if err != nil {
+		log.Fatalf("dial lending service: %v", err)
+	}
+	defer client.Close()
+
+	fmt.Printf("Connected to %s\n", *endpoint)
+
+	listCtx, cancelList := context.WithTimeout(ctx, *timeout)
+	markets, err := client.ListMarkets(listCtx)
+	cancelList()
+	if err != nil {
+		log.Fatalf("list markets: %v", err)
+	}
+	fmt.Printf("Available markets:\n")
+	for _, m := range markets {
+		fmt.Printf("- %s (%s)\n", m.GetKey().GetSymbol(), m.GetBaseAsset())
+	}
+	if len(markets) == 0 {
+		fmt.Println("(none returned – check node configuration)")
+	}
+
+	supplyCtx, cancelSupply := context.WithTimeout(ctx, *timeout)
+	supplied, err := client.SupplyAsset(supplyCtx, *account, *market, *supplyAmt)
+	cancelSupply()
+	if err != nil {
+		log.Fatalf("supply asset: %v", err)
+	}
+	fmt.Printf(
+		"Supplied %s %s. Total supplied: %s (health factor: %s)\n",
+		*supplyAmt,
+		*market,
+		supplied.GetSupplied(),
+		supplied.GetHealthFactor(),
+	)
+
+	borrowCtx, cancelBorrow := context.WithTimeout(ctx, *timeout)
+	borrowed, err := client.BorrowAsset(borrowCtx, *account, *market, *borrowAmt)
+	cancelBorrow()
+	if err != nil {
+		log.Fatalf("borrow asset: %v", err)
+	}
+	fmt.Printf("Borrowed %s. Total borrowed: %s\n", *borrowAmt, borrowed.GetBorrowed())
+
+	repayCtx, cancelRepay := context.WithTimeout(ctx, *timeout)
+	repaid, err := client.RepayAsset(repayCtx, *account, *market, *repayAmt)
+	cancelRepay()
+	if err != nil {
+		log.Fatalf("repay asset: %v", err)
+	}
+	fmt.Printf("Repaid %s. Total borrowed: %s\n", *repayAmt, repaid.GetBorrowed())
+
+	posCtx, cancelPos := context.WithTimeout(ctx, *timeout)
+	position, err := client.GetPosition(posCtx, *account)
+	cancelPos()
+	if err != nil {
+		log.Fatalf("get position: %v", err)
+	}
+
+	fmt.Println("Final account position:")
+	fmt.Printf("  Supplied: %s\n", position.GetSupplied())
+	fmt.Printf("  Borrowed: %s\n", position.GetBorrowed())
+	fmt.Printf("  Collateral: %s\n", position.GetCollateral())
+	fmt.Printf("  Health factor: %s\n", position.GetHealthFactor())
+}

--- a/sdk/examples/lending/ts/README.md
+++ b/sdk/examples/lending/ts/README.md
@@ -1,0 +1,70 @@
+# Lending gRPC client (TypeScript)
+
+This example shows how to call the `lending.v1.LendingService` from TypeScript.  The repository ships
+Node-oriented stubs generated with [`ts-proto`](https://github.com/stephenh/ts-proto) under
+[`clients/ts/lending/v1`](../../../clients/ts/lending/v1).  The stubs target `@grpc/grpc-js`, so they
+can be used directly from Node.js services or from tools that support the standard gRPC protocol.
+
+## Prerequisites
+
+- Node.js 18+
+- `npm install @grpc/grpc-js @bufbuild/protobuf`
+- Access to a running lendingd gRPC endpoint (default `localhost:9090`)
+
+## Minimal Node usage
+
+```ts
+import { credentials } from "@grpc/grpc-js";
+import { LendingServiceClient, ListMarketsRequest } from "nhbchain/clients/ts/lending/v1/lending";
+
+const client = new LendingServiceClient(
+  "localhost:9090",
+  credentials.createInsecure(), // use createSsl for TLS-enabled endpoints
+);
+
+const request: ListMarketsRequest = {};
+client.listMarkets(request, (err, response) => {
+  if (err) {
+    console.error("listMarkets failed", err);
+    return;
+  }
+  console.log("markets", response?.markets);
+});
+```
+
+When connecting to a TLS-enabled endpoint replace `createInsecure()` with `credentials.createSsl()`
+and provide the certificate chain issued by the gateway.
+
+## Browser usage
+
+Browsers cannot speak HTTP/2 gRPC directly.  To call the service from the browser you have two
+options:
+
+1. **grpc-web proxy** – Run a sidecar such as [`improbable-eng/grpcwebproxy`](https://github.com/improbable-eng/grpcwebproxy)
+   or Envoy with the [gRPC-Web filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/grpc_web_filter)
+   to translate between gRPC-Web and standard gRPC.
+2. **Custom gateway** – Expose the required RPCs over REST or WebSockets and forward them to the gRPC
+   service, reusing the same protobuf messages.
+
+If you choose the grpc-web proxy approach, point your web application at the proxy address (e.g.
+`http://localhost:8080`) and configure it to forward requests to `localhost:9090`.  Many libraries,
+including [`@bufbuild/connect-web`](https://connect.build/docs/web/clients/), can generate browser
+clients that speak the grpc-web protocol; reuse the protobuf schema in `proto/lending/v1/lending.proto`
+when generating those bindings.
+
+## Authentication
+
+Production deployments typically require per-RPC metadata for authentication.  With `@grpc/grpc-js`
+you can attach metadata using the optional `Metadata` argument:
+
+```ts
+import { Metadata } from "@grpc/grpc-js";
+
+const metadata = new Metadata();
+metadata.add("authorization", "Bearer <token>");
+client.getPosition({ account: "nhb1..." }, metadata, (err, response) => {
+  /* ... */
+});
+```
+
+Ensure your proxy (if any) forwards those headers to avoid `UNAUTHENTICATED` responses.


### PR DESCRIPTION
## Summary
- document each LendingService RPC with request/response tables, common errors, and grpcurl usage examples
- add a Go example that exercises supply, borrow, repay, and position lookups using the SDK client
- provide TypeScript guidance for using the generated gRPC stubs and grpc-web proxy setups

## Testing
- go build ./sdk/examples/lending/go

------
https://chatgpt.com/codex/tasks/task_e_68e5d13b5bbc832dbf33682ab898ff5e