### PR TITLE
Run lending unit tests in CI and keep Helm lendingd disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go: ['1.23.0']
+        test_target: ['./...']
+        include:
+          - os: ubuntu-latest
+            go: '1.23.0'
+            test_target: ./services/lending/...
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
@@ -20,11 +25,13 @@ jobs:
       - name: Set Go flags
         run: echo "GOFLAGS=-buildvcs=false" >> "$GITHUB_ENV"
       - name: Tidy
+        if: matrix.test_target == './...'
         run: go mod tidy
       - name: Build
+        if: matrix.test_target == './...'
         run: go build -trimpath -ldflags="-s -w" -buildvcs=false -o bin/nhb ./cmd/nhb
-      - name: Test
-        run: go test ./...
+      - name: Test ${{ matrix.test_target }}
+        run: go test ${{ matrix.test_target }}
 
   bugcheck-linux:
     runs-on: ubuntu-latest

--- a/deploy/helm/values-prod.yaml
+++ b/deploy/helm/values-prod.yaml
@@ -1,0 +1,3 @@
+lendingd:
+  # preview until handlers GA
+  replicaCount: 0

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,3 @@
+lendingd:
+  # preview until handlers GA
+  replicaCount: 0


### PR DESCRIPTION
## Summary
- extend the CI matrix to run `go test` for the lending service alongside the existing unit suite
- add default Helm values that keep the lendingd deployment scaled to zero with a preview comment for production installs

## Testing
- not run (actionlint unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e5d2be0bdc832da5867318b43faaf9