### PR TITLE
Add ZapNHB transfer transaction support

### DIFF
--- a/core/state_transition_transfer_test.go
+++ b/core/state_transition_transfer_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+func TestApplyTransferZNHB(t *testing.T) {
+	sp := newStakingStateProcessor(t)
+
+	senderKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate sender key: %v", err)
+	}
+	recipientKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate recipient key: %v", err)
+	}
+
+	senderAddr := senderKey.PubKey().Address().Bytes()
+	recipientAddr := recipientKey.PubKey().Address().Bytes()
+
+	senderAccount := &types.Account{
+		BalanceNHB:  big.NewInt(1_000),
+		BalanceZNHB: big.NewInt(600),
+		Stake:       big.NewInt(0),
+	}
+	if err := sp.setAccount(senderAddr, senderAccount); err != nil {
+		t.Fatalf("seed sender: %v", err)
+	}
+	recipientAccount := &types.Account{
+		BalanceNHB:  big.NewInt(0),
+		BalanceZNHB: big.NewInt(0),
+		Stake:       big.NewInt(0),
+	}
+	if err := sp.setAccount(recipientAddr, recipientAccount); err != nil {
+		t.Fatalf("seed recipient: %v", err)
+	}
+
+	tx := &types.Transaction{
+		ChainID:  types.NHBChainID(),
+		Type:     types.TxTypeTransferZNHB,
+		Nonce:    0,
+		To:       append([]byte(nil), recipientAddr...),
+		Value:    big.NewInt(250),
+		GasLimit: 25_000,
+		GasPrice: big.NewInt(1),
+	}
+	if err := tx.Sign(senderKey.PrivateKey); err != nil {
+		t.Fatalf("sign transaction: %v", err)
+	}
+
+	if err := sp.ApplyTransaction(tx); err != nil {
+		t.Fatalf("apply transaction: %v", err)
+	}
+
+	updatedSender, err := sp.getAccount(senderAddr)
+	if err != nil {
+		t.Fatalf("load sender: %v", err)
+	}
+	updatedRecipient, err := sp.getAccount(recipientAddr)
+	if err != nil {
+		t.Fatalf("load recipient: %v", err)
+	}
+
+	if updatedSender.BalanceZNHB.Cmp(big.NewInt(350)) != 0 {
+		t.Fatalf("expected sender ZNHB balance 350, got %s", updatedSender.BalanceZNHB)
+	}
+	if updatedSender.Nonce != 1 {
+		t.Fatalf("expected sender nonce 1, got %d", updatedSender.Nonce)
+	}
+	if updatedRecipient.BalanceZNHB.Cmp(big.NewInt(250)) != 0 {
+		t.Fatalf("expected recipient ZNHB balance 250, got %s", updatedRecipient.BalanceZNHB)
+	}
+	if updatedRecipient.Nonce != 0 {
+		t.Fatalf("expected recipient nonce to remain 0, got %d", updatedRecipient.Nonce)
+	}
+	if updatedSender.BalanceNHB.Cmp(big.NewInt(1_000)) != 0 {
+		t.Fatalf("expected sender NHB balance unchanged, got %s", updatedSender.BalanceNHB)
+	}
+}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -33,6 +33,7 @@ type TxType byte
 
 const (
 	TxTypeTransfer          TxType = 0x01 // A standard transfer of NHB
+	TxTypeTransferZNHB      TxType = 0x10 // A standard transfer of ZapNHB (ZNHB)
 	TxTypeRegisterIdentity  TxType = 0x02 // A transaction to claim a username
 	TxTypeCreateEscrow      TxType = 0x03 // Create escrow
 	TxTypeReleaseEscrow     TxType = 0x04 // NEW: Buyer releases funds to seller

--- a/docs/transactions/signing.md
+++ b/docs/transactions/signing.md
@@ -21,3 +21,9 @@ TypeScript clients should mirror this process, ensuring they serialise the
 in [`examples/txs/ts/supply.ts`](../../examples/txs/ts/supply.ts) computes the
 transaction digest and highlights the placeholder where wallet integrations
 should inject the signature.
+
+For concrete JSON-RPC payloads that cover both NHB (`TxTypeTransfer`) and the
+new ZNHB (`TxTypeTransferZNHB`) transfers, see
+[`znhb-transfer.md`](./znhb-transfer.md). It walks through nonce discovery,
+request construction, and expected settlement semantics so wallet developers can
+mirror the node's behaviour.

--- a/docs/transactions/znhb-transfer.md
+++ b/docs/transactions/znhb-transfer.md
@@ -1,0 +1,86 @@
+# NHB vs. ZNHB transfers
+
+ZapNHB (ZNHB) transfers use a dedicated transaction type alongside the existing
+NHB coin payments. Both payloads share the same ECDSA signing flow: construct a
+`types.Transaction`, recover the sender nonce from the latest account state, and
+sign the SHA-256 hash before submitting the JSON-RPC request.
+
+## 1. Fetch the current nonce
+
+Before building either transaction, query the account with `nhb_getBalance` to
+retrieve the `nonce` and confirm available balances.
+
+```json
+{
+  "id": 1,
+  "method": "nhb_getBalance",
+  "params": ["nhb1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh"]
+}
+```
+
+The response includes both NHB and ZNHB balances together with the latest
+`nonce` that must be echoed in the outgoing transaction.
+
+## 2. NHB transfer (type `0x01`)
+
+Standard NHB payments continue to use `TxTypeTransfer (0x01)` and execute on the
+EVM path. Loyalty rewards and merchant fee routing remain scoped to these
+transfers.
+
+```json
+{
+  "id": 1,
+  "method": "nhb_sendTransaction",
+  "params": [
+    {
+      "chainId": "0x4e4842",
+      "type": 1,
+      "nonce": 7,
+      "to": "0x1b9b9fb69f2c6c9c1d4c1c4e7b999b20461ab29f",
+      "value": "0x2386f26fc10000",
+      "gasLimit": 25000,
+      "gasPrice": "0x3b9aca00",
+      "r": "0x…",
+      "s": "0x…",
+      "v": "0x1b"
+    }
+  ]
+}
+```
+
+## 3. ZNHB transfer (type `0x10`)
+
+ZapNHB uses the new `TxTypeTransferZNHB (0x10)` constant. Only the asset changes
+— the fee path still burns NHB gas and no loyalty accrual is triggered. The
+`value` field is denominated in ZNHB wei and the recipient must be supplied.
+
+```json
+{
+  "id": 1,
+  "method": "nhb_sendTransaction",
+  "params": [
+    {
+      "chainId": "0x4e4842",
+      "type": 16,
+      "nonce": 12,
+      "to": "0x5c9d4cde23f68cd2209a2f5eaf0a1d34ac3e5f2a",
+      "value": "0xde0b6b3a7640000",
+      "gasLimit": 25000,
+      "gasPrice": "0x3b9aca00",
+      "r": "0x…",
+      "s": "0x…",
+      "v": "0x1c"
+    }
+  ]
+}
+```
+
+After signing, submit the payload through `nhb_sendTransaction`. Successful
+settlement debits the sender's `balanceZNHB`, credits the recipient (creating the
+account metadata if necessary), and increments the sender nonce. Gas charges are
+still paid in NHB, so wallets should confirm sufficient NHB balance alongside
+ZNHB holdings.
+
+For an end-to-end example that automates signing for either token, refer to the
+`send-znhb` command in `cmd/nhb-cli`, which reuses the same signing primitives
+exposed in the SDK.


### PR DESCRIPTION
## Summary
- add a TxTypeTransferZNHB constant and executeTransaction branch that routes to a new applyTransferZNHB helper which debits/credits ZNHB balances, advances the sender nonce, and records engagement
- extend state and RPC tests to cover ZNHB transfers alongside existing nonce replay checks and add a focused transfer test to ensure balances move correctly
- expose a send-znhb CLI command for constructing the new transaction type and document how to sign NHB versus ZNHB payloads

## Testing
- go test -v ./core -run TestApplyTransferZNHB
- go test -v ./core -run TestApplyTransactionRejectsNativeNonceReplay
- go test -v ./rpc -run TestHandleSendTransactionAcceptsZNHBTransfer
- go test ./cmd/nhb-cli


------
https://chatgpt.com/codex/tasks/task_e_68e5d4020890832db314f9439b4e9f0c