### PR TITLE
Add per-asset fee configuration and routing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"nhbchain/consensus"
 	"nhbchain/core/genesis"
 	"nhbchain/crypto"
+	"nhbchain/native/fees"
 	"nhbchain/native/governance"
 	"nhbchain/native/lending"
 	"nhbchain/native/potso"
@@ -155,6 +156,10 @@ func defaultGlobalConfig() Global {
 		Fees: Fees{
 			FreeTierTxPerMonth: DefaultFreeTierTxPerMonth,
 			MDRBasisPoints:     DefaultMDRBasisPoints,
+			Assets: []FeeAsset{
+				{Asset: fees.AssetNHB, MDRBasisPoints: DefaultMDRBasisPoints},
+				{Asset: fees.AssetZNHB, MDRBasisPoints: DefaultMDRBasisPoints},
+			},
 		},
 	}
 }
@@ -569,6 +574,9 @@ func (cfg *Config) ensureGlobalDefaults(meta toml.MetaData) {
 	}
 	if !meta.IsDefined("global", "fees", "OwnerWallet") {
 		cfg.Global.Fees.OwnerWallet = defaults.Fees.OwnerWallet
+	}
+	if len(cfg.Global.Fees.Assets) == 0 {
+		cfg.Global.Fees.Assets = append([]FeeAsset{}, defaults.Fees.Assets...)
 	}
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -59,11 +59,19 @@ type PaymasterAutoTopUpGovernance struct {
 	ApproverRole string
 }
 
+// FeeAsset captures per-asset MDR and routing configuration.
+type FeeAsset struct {
+	Asset          string
+	MDRBasisPoints uint32
+	OwnerWallet    string
+}
+
 // Fees captures default fee policy settings applied across domains.
 type Fees struct {
 	FreeTierTxPerMonth uint64
 	MDRBasisPoints     uint32
 	OwnerWallet        string
+	Assets             []FeeAsset
 }
 
 // Consensus controls the BFT round timeouts.

--- a/core/events/fees.go
+++ b/core/events/fees.go
@@ -19,6 +19,7 @@ const (
 type FeeApplied struct {
 	Payer             [20]byte
 	Domain            string
+	Asset             string
 	Gross             *big.Int
 	Fee               *big.Int
 	Net               *big.Int
@@ -43,6 +44,9 @@ func (e FeeApplied) Event() *types.Event {
 	}
 	if domain := strings.TrimSpace(e.Domain); domain != "" {
 		attrs["domain"] = domain
+	}
+	if asset := strings.TrimSpace(e.Asset); asset != "" {
+		attrs["asset"] = strings.ToUpper(asset)
 	}
 	if e.Gross != nil {
 		attrs["grossWei"] = e.Gross.String()

--- a/core/node.go
+++ b/core/node.go
@@ -679,6 +679,7 @@ func (n *Node) globalConfigSnapshot() config.Global {
 			FreeTierTxPerMonth: n.globalCfg.Fees.FreeTierTxPerMonth,
 			MDRBasisPoints:     n.globalCfg.Fees.MDRBasisPoints,
 			OwnerWallet:        n.globalCfg.Fees.OwnerWallet,
+			Assets:             append([]config.FeeAsset{}, n.globalCfg.Fees.Assets...),
 		},
 	}
 	return snapshot

--- a/docs/fees/policy.md
+++ b/docs/fees/policy.md
@@ -42,6 +42,11 @@ the merchant leg before settlement. The withheld amount is routed according to
 the [fee routing policy](./routing.md).
 * **Pass-through sponsorship:** If a merchant funds the transaction directly,
 the MDR still applies unless the merchant wallet is on the *exemptions* list.
+* **Asset-specific overrides:** Each fee domain advertises the assets it
+  accepts (e.g. NHB, ZNHB) and maps them to bespoke MDR basis points and routing
+  wallets. Governance can, for example, charge 150 bps on NHB while routing
+  ZNHB through a different wallet at 200 bps. Omitted asset entries fall back to
+  the domain default.
 
 ## Minimum and maximum fee guards
 

--- a/docs/fees/routing.md
+++ b/docs/fees/routing.md
@@ -14,7 +14,9 @@ on-chain accounts that receive the proceeds.
 
 Each wallet address is stored in the `FeePolicy` module parameters. Governance
 proposals can rotate the addresses or adjust the split ratios when treasury
-requirements change.
+requirements change. Domains now expose an asset map that binds every accepted
+currency (NHB, ZNHB, and future additions) to a specific MDR basis-point value
+and routing wallet, making fee distribution explicit on a per-asset basis.
 
 ## Routing flow
 

--- a/native/gov/validate.go
+++ b/native/gov/validate.go
@@ -60,6 +60,14 @@ type FeesBaseline struct {
 	FreeTierTxPerMonth uint64
 	MDRBasisPoints     uint32
 	OwnerWallet        string
+	Assets             []FeeAssetBaseline
+}
+
+// FeeAssetBaseline mirrors config.FeeAsset using primitive types.
+type FeeAssetBaseline struct {
+	Asset          string
+	MDRBasisPoints uint32
+	OwnerWallet    string
 }
 
 // GovernanceDelta represents proposed changes to governance thresholds and
@@ -117,6 +125,7 @@ func PreflightBaselineApply(cur Baseline, delta PolicyDelta) error {
 			FreeTierTxPerMonth: cur.Fees.FreeTierTxPerMonth,
 			MDRBasisPoints:     cur.Fees.MDRBasisPoints,
 			OwnerWallet:        cur.Fees.OwnerWallet,
+			Assets:             feeAssetsFromBaseline(cur.Fees.Assets),
 		},
 	}, delta)
 }
@@ -153,4 +162,19 @@ func applyDelta(cur config.Global, delta PolicyDelta) config.Global {
 		}
 	}
 	return candidate
+}
+
+func feeAssetsFromBaseline(list []FeeAssetBaseline) []config.FeeAsset {
+	if len(list) == 0 {
+		return nil
+	}
+	assets := make([]config.FeeAsset, len(list))
+	for i := range list {
+		assets[i] = config.FeeAsset{
+			Asset:          list[i].Asset,
+			MDRBasisPoints: list[i].MDRBasisPoints,
+			OwnerWallet:    list[i].OwnerWallet,
+		}
+	}
+	return assets
 }

--- a/tests/gov/invariants_test.go
+++ b/tests/gov/invariants_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"nhbchain/config"
+	"nhbchain/native/fees"
 	govcfg "nhbchain/native/gov"
 )
 
@@ -24,6 +25,10 @@ func testBaseline() govcfg.Baseline {
 		Fees: govcfg.FeesBaseline{
 			FreeTierTxPerMonth: config.DefaultFreeTierTxPerMonth,
 			MDRBasisPoints:     config.DefaultMDRBasisPoints,
+			Assets: []govcfg.FeeAssetBaseline{
+				{Asset: fees.AssetNHB, MDRBasisPoints: config.DefaultMDRBasisPoints},
+				{Asset: fees.AssetZNHB, MDRBasisPoints: config.DefaultMDRBasisPoints},
+			},
 		},
 	}
 }

--- a/tests/posreadiness/fees/fees_test.go
+++ b/tests/posreadiness/fees/fees_test.go
@@ -26,9 +26,13 @@ func TestSponsorshipCapsAndRouting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate merchant key: %v", err)
 	}
-	routeKey, err := crypto.GeneratePrivateKey()
+	routeNHBKey, err := crypto.GeneratePrivateKey()
 	if err != nil {
-		t.Fatalf("generate route key: %v", err)
+		t.Fatalf("generate NHB route key: %v", err)
+	}
+	routeZNHBKey, err := crypto.GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("generate ZNHB route key: %v", err)
 	}
 
 	startBalance := big.NewInt(5_000_000)
@@ -38,40 +42,49 @@ func TestSponsorshipCapsAndRouting(t *testing.T) {
 	if err := seedAccount(node, merchantKey, big.NewInt(0)); err != nil {
 		t.Fatalf("seed merchant: %v", err)
 	}
-	if err := seedAccount(node, routeKey, big.NewInt(0)); err != nil {
-		t.Fatalf("seed route wallet: %v", err)
+	if err := seedAccount(node, routeNHBKey, big.NewInt(0)); err != nil {
+		t.Fatalf("seed NHB route wallet: %v", err)
+	}
+	if err := seedAccount(node, routeZNHBKey, big.NewInt(0)); err != nil {
+		t.Fatalf("seed ZNHB route wallet: %v", err)
 	}
 
 	if _, err := chain.FinalizeTxs(); err != nil {
 		t.Fatalf("commit seed block: %v", err)
 	}
 
-	var routeWallet [20]byte
-	copy(routeWallet[:], routeKey.PubKey().Address().Bytes())
+	var routeWalletNHB, routeWalletZNHB [20]byte
+	copy(routeWalletNHB[:], routeNHBKey.PubKey().Address().Bytes())
+	copy(routeWalletZNHB[:], routeZNHBKey.PubKey().Address().Bytes())
 	policy := fees.Policy{
 		Version: 1,
 		Domains: map[string]fees.DomainPolicy{
 			fees.DomainPOS: {
 				FreeTierTxPerMonth: 2,
 				MDRBasisPoints:     150,
-				OwnerWallet:        routeWallet,
+				OwnerWallet:        routeWalletNHB,
+				Assets: map[string]fees.AssetPolicy{
+					fees.AssetNHB:  {MDRBasisPoints: 150, OwnerWallet: routeWalletNHB},
+					fees.AssetZNHB: {MDRBasisPoints: 200, OwnerWallet: routeWalletZNHB},
+				},
 			},
 		},
 	}
 	node.SetFeePolicy(policy)
 
-	value := big.NewInt(1_000)
+	valueNHB := big.NewInt(1_000)
+	valueZNHB := big.NewInt(2_000)
 	merchantAddr := merchantKey.PubKey().Address().Bytes()
 
-	grossTotal := big.NewInt(0)
-	expectedFee := big.NewInt(0)
-	expectedNet := big.NewInt(0)
+	grossNHB := big.NewInt(0)
+	feeNHB := big.NewInt(0)
+	netNHB := big.NewInt(0)
 
 	for i := uint64(0); i < 3; i++ {
-		tx := buildPOSTransfer(t, payerKey, merchantAddr, i, value)
+		tx := buildPOSTransfer(t, payerKey, merchantAddr, i, valueNHB)
 		prev := len(node.Events())
 		if _, err := chain.FinalizeTxs(tx); err != nil {
-			t.Fatalf("finalize tx %d: %v", i, err)
+			t.Fatalf("finalize NHB tx %d: %v", i, err)
 		}
 		var feeEvt *types.Event
 		newEvents := node.Events()[prev:]
@@ -82,65 +95,144 @@ func TestSponsorshipCapsAndRouting(t *testing.T) {
 			}
 		}
 		if feeEvt == nil {
-			t.Fatalf("expected fee event for tx %d", i)
+			t.Fatalf("expected fee event for NHB tx %d", i)
+		}
+		if asset := feeEvt.Attributes["asset"]; asset != "NHB" {
+			t.Fatalf("unexpected asset tag for NHB tx %d: %s", i, asset)
 		}
 		feeWei := feeEvt.Attributes["feeWei"]
+		grossNHB.Add(grossNHB, valueNHB)
 		if i < 2 {
 			if feeWei != "0" {
-				t.Fatalf("expected free-tier fee 0 for tx %d, got %s", i, feeWei)
+				t.Fatalf("expected free-tier fee 0 for NHB tx %d, got %s", i, feeWei)
 			}
-		} else {
-			if feeWei == "0" {
-				t.Fatalf("expected fee after free-tier exhaustion")
-			}
+			netNHB.Add(netNHB, valueNHB)
+			continue
 		}
-		grossTotal.Add(grossTotal, value)
-		if i >= 2 {
-			feeAmount := new(big.Int)
-			if _, ok := feeAmount.SetString(feeWei, 10); !ok {
-				t.Fatalf("parse fee: %s", feeWei)
-			}
-			expectedFee.Add(expectedFee, feeAmount)
-			net := new(big.Int).Sub(value, feeAmount)
-			expectedNet.Add(expectedNet, net)
-		} else {
-			expectedNet.Add(expectedNet, value)
+		feeAmount := new(big.Int)
+		if _, ok := feeAmount.SetString(feeWei, 10); !ok {
+			t.Fatalf("parse fee: %s", feeWei)
 		}
+		feeNHB.Add(feeNHB, feeAmount)
+		netNHB.Add(netNHB, new(big.Int).Sub(valueNHB, feeAmount))
 	}
 
-	merchantBalance := accountBalance(t, node, merchantKey.PubKey().Address().Bytes())
-	expectedMerchant := new(big.Int).Set(expectedNet)
-	if merchantBalance.Cmp(expectedMerchant) != 0 {
-		t.Fatalf("merchant balance mismatch: got %s want %s", merchantBalance.String(), expectedMerchant.String())
+	if err := node.WithState(func(m *nhbstate.Manager) error {
+		acct, err := m.GetAccount(payerKey.PubKey().Address().Bytes())
+		if err != nil {
+			return err
+		}
+		acct.BalanceZNHB = big.NewInt(0).Mul(valueZNHB, big.NewInt(10))
+		return m.PutAccount(payerKey.PubKey().Address().Bytes(), acct)
+	}); err != nil {
+		t.Fatalf("top up payer ZNHB: %v", err)
 	}
 
-	routeBalance := accountBalance(t, node, routeKey.PubKey().Address().Bytes())
-	if routeBalance.Cmp(expectedFee) != 0 {
-		t.Fatalf("route wallet balance mismatch: got %s want %s", routeBalance.String(), expectedFee.String())
+	grossZNHB := big.NewInt(0)
+	feeZNHB := big.NewInt(0)
+	netZNHB := big.NewInt(0)
+
+	for j := uint64(0); j < 2; j++ {
+		nonce := j + 3
+		tx := buildPOSTransferZNHB(t, payerKey, merchantAddr, nonce, valueZNHB)
+		prev := len(node.Events())
+		if _, err := chain.FinalizeTxs(tx); err != nil {
+			t.Fatalf("finalize ZNHB tx %d: %v", j, err)
+		}
+		var feeEvt *types.Event
+		newEvents := node.Events()[prev:]
+		for idx := range newEvents {
+			if newEvents[idx].Type == "fees.applied" {
+				copyEvt := newEvents[idx]
+				feeEvt = &copyEvt
+			}
+		}
+		if feeEvt == nil {
+			t.Fatalf("expected fee event for ZNHB tx %d", j)
+		}
+		if asset := feeEvt.Attributes["asset"]; asset != "ZNHB" {
+			t.Fatalf("unexpected asset tag for ZNHB tx %d: %s", j, asset)
+		}
+		feeWei := feeEvt.Attributes["feeWei"]
+		if feeWei == "0" {
+			t.Fatalf("expected ZNHB fee to apply after free-tier exhaustion")
+		}
+		grossZNHB.Add(grossZNHB, valueZNHB)
+		feeAmount := new(big.Int)
+		if _, ok := feeAmount.SetString(feeWei, 10); !ok {
+			t.Fatalf("parse ZNHB fee: %s", feeWei)
+		}
+		feeZNHB.Add(feeZNHB, feeAmount)
+		netZNHB.Add(netZNHB, new(big.Int).Sub(valueZNHB, feeAmount))
+	}
+
+	merchantNHB := accountBalance(t, node, merchantKey.PubKey().Address().Bytes(), fees.AssetNHB)
+	if merchantNHB.Cmp(netNHB) != 0 {
+		t.Fatalf("merchant NHB balance mismatch: got %s want %s", merchantNHB, netNHB)
+	}
+	merchantZNHB := accountBalance(t, node, merchantKey.PubKey().Address().Bytes(), fees.AssetZNHB)
+	if merchantZNHB.Cmp(netZNHB) != 0 {
+		t.Fatalf("merchant ZNHB balance mismatch: got %s want %s", merchantZNHB, netZNHB)
+	}
+
+	routeNHB := accountBalance(t, node, routeNHBKey.PubKey().Address().Bytes(), fees.AssetNHB)
+	if routeNHB.Cmp(feeNHB) != 0 {
+		t.Fatalf("route NHB balance mismatch: got %s want %s", routeNHB, feeNHB)
+	}
+	routeZNHB := accountBalance(t, node, routeZNHBKey.PubKey().Address().Bytes(), fees.AssetZNHB)
+	if routeZNHB.Cmp(feeZNHB) != 0 {
+		t.Fatalf("route ZNHB balance mismatch: got %s want %s", routeZNHB, feeZNHB)
 	}
 
 	totals, err := node.FeesTotals("pos")
 	if err != nil {
 		t.Fatalf("fees totals query: %v", err)
 	}
-	if len(totals) != 1 {
-		t.Fatalf("expected single totals record, got %d", len(totals))
+	if len(totals) != 2 {
+		t.Fatalf("expected two totals records, got %d", len(totals))
 	}
-	record := totals[0]
-	if record.Gross == nil || record.Gross.Cmp(grossTotal) != 0 {
-		t.Fatalf("gross mismatch: got %v want %v", record.Gross, grossTotal)
+	records := make(map[string]fees.Totals, len(totals))
+	for i := range totals {
+		records[totals[i].Asset] = totals[i]
 	}
-	if record.Fee == nil || record.Fee.Cmp(expectedFee) != 0 {
-		t.Fatalf("fee mismatch: got %v want %v", record.Fee, expectedFee)
+	nhbRecord, ok := records[fees.AssetNHB]
+	if !ok {
+		t.Fatalf("missing NHB totals record")
 	}
-	if record.Net == nil || record.Net.Cmp(expectedNet) != 0 {
-		t.Fatalf("net mismatch: got %v want %v", record.Net, expectedNet)
+	if nhbRecord.Gross == nil || nhbRecord.Gross.Cmp(grossNHB) != 0 {
+		t.Fatalf("NHB gross mismatch: got %v want %v", nhbRecord.Gross, grossNHB)
 	}
-	if record.Domain != fees.DomainPOS {
-		t.Fatalf("unexpected domain: %s", record.Domain)
+	if nhbRecord.Fee == nil || nhbRecord.Fee.Cmp(feeNHB) != 0 {
+		t.Fatalf("NHB fee mismatch: got %v want %v", nhbRecord.Fee, feeNHB)
 	}
-	if record.Wallet != routeWallet {
-		t.Fatalf("unexpected wallet: got %x want %x", record.Wallet, routeWallet)
+	if nhbRecord.Net == nil || nhbRecord.Net.Cmp(netNHB) != 0 {
+		t.Fatalf("NHB net mismatch: got %v want %v", nhbRecord.Net, netNHB)
+	}
+	if nhbRecord.Domain != fees.DomainPOS {
+		t.Fatalf("unexpected NHB domain: %s", nhbRecord.Domain)
+	}
+	if nhbRecord.Wallet != routeWalletNHB {
+		t.Fatalf("unexpected NHB wallet: got %x want %x", nhbRecord.Wallet, routeWalletNHB)
+	}
+
+	znhbRecord, ok := records[fees.AssetZNHB]
+	if !ok {
+		t.Fatalf("missing ZNHB totals record")
+	}
+	if znhbRecord.Gross == nil || znhbRecord.Gross.Cmp(grossZNHB) != 0 {
+		t.Fatalf("ZNHB gross mismatch: got %v want %v", znhbRecord.Gross, grossZNHB)
+	}
+	if znhbRecord.Fee == nil || znhbRecord.Fee.Cmp(feeZNHB) != 0 {
+		t.Fatalf("ZNHB fee mismatch: got %v want %v", znhbRecord.Fee, feeZNHB)
+	}
+	if znhbRecord.Net == nil || znhbRecord.Net.Cmp(netZNHB) != 0 {
+		t.Fatalf("ZNHB net mismatch: got %v want %v", znhbRecord.Net, netZNHB)
+	}
+	if znhbRecord.Domain != fees.DomainPOS {
+		t.Fatalf("unexpected ZNHB domain: %s", znhbRecord.Domain)
+	}
+	if znhbRecord.Wallet != routeWalletZNHB {
+		t.Fatalf("unexpected ZNHB wallet: got %x want %x", znhbRecord.Wallet, routeWalletZNHB)
 	}
 }
 
@@ -164,14 +256,47 @@ func buildPOSTransfer(t *testing.T, key *crypto.PrivateKey, to []byte, nonce uin
 	return tx
 }
 
-func accountBalance(t *testing.T, node *core.Node, addr []byte) *big.Int {
+func buildPOSTransferZNHB(t *testing.T, key *crypto.PrivateKey, to []byte, nonce uint64, value *big.Int) *types.Transaction {
+	if len(to) == 0 {
+		t.Fatalf("recipient required")
+	}
+	tx := &types.Transaction{
+		ChainID:         types.NHBChainID(),
+		Type:            types.TxTypeTransferZNHB,
+		Nonce:           nonce,
+		To:              append([]byte(nil), to...),
+		Value:           new(big.Int).Set(value),
+		GasLimit:        21000,
+		GasPrice:        big.NewInt(1),
+		MerchantAddress: fees.DomainPOS,
+	}
+	if err := tx.Sign(key.PrivateKey); err != nil {
+		t.Fatalf("sign znhb tx: %v", err)
+	}
+	return tx
+}
+
+func accountBalance(t *testing.T, node *core.Node, addr []byte, asset string) *big.Int {
 	var balance *big.Int
 	err := node.WithState(func(m *nhbstate.Manager) error {
 		account, err := m.GetAccount(addr)
 		if err != nil {
 			return err
 		}
-		balance = new(big.Int).Set(account.BalanceNHB)
+		switch asset {
+		case fees.AssetZNHB:
+			if account.BalanceZNHB != nil {
+				balance = new(big.Int).Set(account.BalanceZNHB)
+			} else {
+				balance = big.NewInt(0)
+			}
+		default:
+			if account.BalanceNHB != nil {
+				balance = new(big.Int).Set(account.BalanceNHB)
+			} else {
+				balance = big.NewInt(0)
+			}
+		}
 		return nil
 	})
 	if err != nil {

--- a/tests/posreadiness/fees/reconcile_test.go
+++ b/tests/posreadiness/fees/reconcile_test.go
@@ -75,6 +75,9 @@ func TestFeeEventReconciliation(t *testing.T) {
 				FreeTierTxPerMonth: 0,
 				MDRBasisPoints:     200,
 				OwnerWallet:        routeWallet,
+				Assets: map[string]fees.AssetPolicy{
+					fees.AssetNHB: {MDRBasisPoints: 200, OwnerWallet: routeWallet},
+				},
 			},
 		},
 	}
@@ -103,6 +106,9 @@ func TestFeeEventReconciliation(t *testing.T) {
 			if evt.Attributes["ownerWallet"] != expectedRouteHex {
 				continue
 			}
+			if asset := evt.Attributes["asset"]; asset != "NHB" {
+				continue
+			}
 			feeStr, ok := evt.Attributes["feeWei"]
 			if !ok {
 				continue
@@ -120,7 +126,7 @@ func TestFeeEventReconciliation(t *testing.T) {
 		t.Fatalf("expected positive fee total from events")
 	}
 
-	routeBalance := accountBalance(t, node, routeKey.PubKey().Address().Bytes())
+	routeBalance := accountBalance(t, node, routeKey.PubKey().Address().Bytes(), fees.AssetNHB)
 	if routeBalance.Sign() == 0 {
 		t.Fatalf("route balance should be positive")
 	}


### PR DESCRIPTION
## Summary
- add per-asset fee policy configuration and asset aware apply logic
- route fees by asset during state transitions and emit asset tagged events
- persist and test asset specific fee totals, updating docs and readiness tests

## Testing
- go test ./tests/fees -run TestApplySelectsAssetPolicy -count=1

------
https://chatgpt.com/codex/tasks/task_e_68e5dd08b41c832db025906014fef143