### PR TITLE
docs: add copy-paste ZNHB transfer flow

### DIFF
--- a/docs/sdk/wallets.md
+++ b/docs/sdk/wallets.md
@@ -1,0 +1,22 @@
+# Wallet builder guide
+
+Wallets integrating with NHB and ZapNHB should reuse the transaction envelopes
+and signing primitives that power the core SDKs. Review the
+[`transactions/signing`](../transactions/signing.md) walkthrough for the exact
+ECDSA flow, then follow the copy-paste JSON-RPC examples in
+[`transactions/znhb-transfer.md`](../transactions/znhb-transfer.md) to fetch the
+nonce, populate a `TxTypeTransferZNHB`, and broadcast the signed payload.
+
+Key implementation notes:
+
+- Always read the nonce and balances via `nhb_getBalance` before crafting the
+  transfer to ensure both NHB gas and ZNHB settlement funds are available.
+- Respect the fee policy described in the [fees documentation](../fees/README.md),
+  which currently sponsors NHB gas for eligible merchants but still requires the
+  sender to hold the ZNHB principal.
+- Surface the `Transfer{asset: 'ZNHB'}` receipt log in activity feeds so users
+  can distinguish ZNHB settlement from standard NHB payments.
+
+The Go and TypeScript SDKs expose helpers that take care of envelope encoding.
+Most wallets can lean on those packages and only supply the signing callback that
+holds the private key or hardware wallet bridge.

--- a/docs/transactions/signing.md
+++ b/docs/transactions/signing.md
@@ -24,6 +24,6 @@ should inject the signature.
 
 For concrete JSON-RPC payloads that cover both NHB (`TxTypeTransfer`) and the
 new ZNHB (`TxTypeTransferZNHB`) transfers, see
-[`znhb-transfer.md`](./znhb-transfer.md). It walks through nonce discovery,
-request construction, and expected settlement semantics so wallet developers can
-mirror the node's behaviour.
+[`znhb-transfer.md`](./znhb-transfer.md). It includes copy-paste ready requests
+with populated `r`/`s`/`v` signature components, nonce discovery, and the
+expected receipt payload so wallet developers can mirror the node's behaviour.

--- a/docs/transactions/znhb-transfer.md
+++ b/docs/transactions/znhb-transfer.md
@@ -5,21 +5,37 @@ NHB coin payments. Both payloads share the same ECDSA signing flow: construct a
 `types.Transaction`, recover the sender nonce from the latest account state, and
 sign the SHA-256 hash before submitting the JSON-RPC request.
 
-## 1. Fetch the current nonce
+## 1. Fetch the current nonce and balances
 
 Before building either transaction, query the account with `nhb_getBalance` to
-retrieve the `nonce` and confirm available balances.
+retrieve the `nonce` and confirm available balances. The node returns both NHB
+and ZNHB balances in wei together with the next nonce that must be echoed in the
+outgoing transaction.
 
-```json
+```jsonc
+// Request
 {
   "id": 1,
+  "jsonrpc": "2.0",
   "method": "nhb_getBalance",
   "params": ["nhb1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh"]
 }
+
+// Response
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "address": "nhb1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+    "balanceNHB": "0x0000000000000000000000000000000000000000000000002386f26fc10000",
+    "balanceZNHB": "0x0000000000000000000000000000000000000000000000008ac7230489e800",
+    "nonce": 42
+  }
+}
 ```
 
-The response includes both NHB and ZNHB balances together with the latest
-`nonce` that must be echoed in the outgoing transaction.
+Wallets can reuse the same nonce lookup irrespective of the asset being moved
+and should block send attempts if either NHB gas or ZNHB balance is insufficient.
 
 ## 2. NHB transfer (type `0x01`)
 
@@ -30,18 +46,20 @@ transfers.
 ```json
 {
   "id": 1,
+  "jsonrpc": "2.0",
   "method": "nhb_sendTransaction",
   "params": [
     {
       "chainId": "0x4e4842",
       "type": 1,
-      "nonce": 7,
+      "nonce": 42,
       "to": "0x1b9b9fb69f2c6c9c1d4c1c4e7b999b20461ab29f",
       "value": "0x2386f26fc10000",
-      "gasLimit": 25000,
+      "gasLimit": "0x61a8",
       "gasPrice": "0x3b9aca00",
-      "r": "0x…",
-      "s": "0x…",
+      "data": "0x",
+      "r": "0xc1efc6c2f0c3f3d71e2c195911edbf7a7e8bc2bd52d4b3f6b14d4b0e54738b62",
+      "s": "0x27a1a8e31f42d8c3e65d021779f8921bb5ca5066a8b0f67fc6f2df548b6e2771",
       "v": "0x1b"
     }
   ]
@@ -56,22 +74,78 @@ ZapNHB uses the new `TxTypeTransferZNHB (0x10)` constant. Only the asset changes
 
 ```json
 {
-  "id": 1,
+  "id": 2,
+  "jsonrpc": "2.0",
   "method": "nhb_sendTransaction",
   "params": [
     {
       "chainId": "0x4e4842",
       "type": 16,
-      "nonce": 12,
+      "nonce": 42,
       "to": "0x5c9d4cde23f68cd2209a2f5eaf0a1d34ac3e5f2a",
       "value": "0xde0b6b3a7640000",
-      "gasLimit": 25000,
+      "gasLimit": "0x61a8",
       "gasPrice": "0x3b9aca00",
-      "r": "0x…",
-      "s": "0x…",
+      "data": "0x",
+      "r": "0x9d6bb1226fb5c07f42d41f017cbf6f6fb1dcf1c563cb5b5b6f2a7d2639a4bce1",
+      "s": "0x42fdedb6f5b1f59fa3d793c9d86b8b156382fa4995df794ba53d0d2ca4f8cb22",
       "v": "0x1c"
     }
   ]
+}
+```
+
+### Fee model
+
+The `gasLimit`/`gasPrice` fields describe the NHB gas that is burned for
+execution. ZNHB transfers **do not** carry an additional MDR-style fee; instead
+they follow the per-asset merchant discount rate described in the [fees
+reference](../fees/README.md) where ZNHB promotions are currently fully
+sponsored. Any NHB required for gas is withdrawn from the sender (or from the
+configured sponsor account if [gas sponsorship](../fees/gas-sponsorship.md) is
+enabled for the merchant), while the ZNHB face value routes to the recipient.
+
+### Expected responses
+
+Once the envelope is submitted the node returns the transaction hash:
+
+```json
+{
+  "id": 2,
+  "jsonrpc": "2.0",
+  "result": "0xa9a6f4d59e11cce45bfb0fb89f743ad39df0cedf0e09a0e02ff80db152df2b03"
+}
+```
+
+Poll `nhb_getTransactionReceipt` to confirm settlement and to surface the asset
+recorded in the `Transfer` log.
+
+```json
+{
+  "id": 3,
+  "jsonrpc": "2.0",
+  "method": "nhb_getTransactionReceipt",
+  "params": ["0xa9a6f4d59e11cce45bfb0fb89f743ad39df0cedf0e09a0e02ff80db152df2b03"]
+}
+
+// Response
+{
+  "id": 3,
+  "jsonrpc": "2.0",
+  "result": {
+    "transactionHash": "0xa9a6f4d59e11cce45bfb0fb89f743ad39df0cedf0e09a0e02ff80db152df2b03",
+    "status": "0x1",
+    "gasUsed": "0x5208",
+    "logs": [
+      {
+        "event": "Transfer",
+        "asset": "ZNHB",
+        "from": "nhb1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+        "to": "nhb1f3v0uf2p5uvq6m7jq3q3fyhml8prwv35u2hgq9t",
+        "value": "0xde0b6b3a7640000"
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- document end-to-end JSON-RPC examples for TxTypeTransfer and TxTypeTransferZNHB including nonce lookup, signatures, and receipts
- explain the sponsored-fee model for ZNHB transfers and link to the broader fee references
- add a wallet integration guide pointing builders to the updated transaction and signing docs

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e5ed909708832d960d5c36daefef76