### PR TITLE
Add CLI support for ZapNHB transfers

### DIFF
--- a/cmd/nhb-cli/send.go
+++ b/cmd/nhb-cli/send.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"strings"
+
+	"nhbchain/core/types"
+	"nhbchain/crypto"
+)
+
+const defaultZNHBGasLimit = 25000
+
+func runSendZNHBCommand(args []string) int {
+	fs := flag.NewFlagSet("send-znhb", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	var rpcFlag string
+	rpcFlag = rpcEndpoint
+	var gasLimit uint64
+	gasLimit = defaultZNHBGasLimit
+
+	fs.StringVar(&rpcFlag, "rpc", rpcEndpoint, "RPC endpoint (overrides RPC_URL)")
+	fs.Uint64Var(&gasLimit, "gas", defaultZNHBGasLimit, "Gas limit for the transaction")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		printSendZNHBUsage()
+		return 1
+	}
+
+	rpcEndpoint = strings.TrimSpace(rpcFlag)
+
+	positional := fs.Args()
+	if len(positional) != 3 {
+		fmt.Println("Error: expected recipient, amount, and key file.")
+		printSendZNHBUsage()
+		return 1
+	}
+
+	if gasLimit == 0 {
+		fmt.Println("Error: gas limit must be greater than zero.")
+		return 1
+	}
+
+	if err := sendZNHB(positional[0], positional[1], positional[2], gasLimit); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+func printSendZNHBUsage() {
+	fmt.Println("Usage: send-znhb [--rpc <url>] [--gas <limit>] <recipient> <amount> <key_file>")
+}
+
+func sendZNHB(recipient, amountStr, keyFile string, gasLimit uint64) error {
+	privKey, err := loadPrivateKey(keyFile)
+	if err != nil {
+		return fmt.Errorf("loading private key: %w", err)
+	}
+
+	dest, err := crypto.DecodeAddress(recipient)
+	if err != nil {
+		return fmt.Errorf("parsing recipient address: %w", err)
+	}
+
+	amount, ok := new(big.Int).SetString(strings.TrimSpace(amountStr), 10)
+	if !ok || amount.Sign() <= 0 {
+		return fmt.Errorf("amount must be a positive integer")
+	}
+
+	account, err := fetchAccount(privKey.PubKey().Address().String())
+	if err != nil {
+		return fmt.Errorf("fetching account details: %w", err)
+	}
+
+	tx := types.Transaction{
+		ChainID:  types.NHBChainID(),
+		Type:     types.TxTypeTransferZNHB,
+		Nonce:    account.Nonce,
+		To:       dest.Bytes(),
+		Value:    amount,
+		GasLimit: gasLimit,
+		GasPrice: big.NewInt(1),
+	}
+
+	if err := tx.Sign(privKey.PrivateKey); err != nil {
+		return fmt.Errorf("signing transaction: %w", err)
+	}
+
+	hash, err := sendTransaction(&tx)
+	if err != nil {
+		return fmt.Errorf("sending ZNHB transfer: %w", err)
+	}
+
+	fmt.Printf("Broadcasted ZNHB transfer: %s\n", hash)
+	return nil
+}

--- a/docs/cli/send.md
+++ b/docs/cli/send.md
@@ -1,0 +1,30 @@
+# `send-znhb` command
+
+The `send-znhb` subcommand broadcasts a ZapNHB transfer using the
+`TxTypeTransferZNHB` transaction type. It signs the payload with the
+provided key, submits it to the configured RPC endpoint, and prints the
+resulting transaction hash so you can track settlement.
+
+## Usage
+
+```bash
+./nhb-cli send-znhb [--rpc <url>] [--gas <limit>] <recipient> <amount> <key_file>
+```
+
+- `recipient` – Hex-encoded account address (either NHB bech32 or 0x).
+- `amount` – ZapNHB amount in wei.
+- `key_file` – Path to the locally stored wallet private key.
+- `--rpc` – Optional HTTP endpoint override. Defaults to `RPC_URL` env var
+  or `http://localhost:8080`.
+- `--gas` – Optional gas limit override. Defaults to `25000` if omitted.
+
+## Example
+
+```bash
+$ ./nhb-cli send-znhb nhb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq4u3h4 500000000000000000 wallet.key --rpc http://localhost:8080 --gas 32000
+Broadcasted ZNHB transfer: 0xa9a6f4d59e11cce45bfb0fb89f743ad39df0cedf0e09a0e02ff80db152df2b03
+```
+
+The CLI exits non-zero if the transaction fails to sign or the RPC
+returns an error. Monitor `nhb_getTransactionReceipt` using the hash to
+confirm inclusion.


### PR DESCRIPTION
## Summary
- add a dedicated `send-znhb` command that parses `--rpc`/`--gas`, signs a TxTypeTransferZNHB, and prints the transaction hash
- return the transaction hash from `sendTransaction` so callers can surface it and update CLI usage text
- document the new workflow, including sample output, under `docs/cli/send.md`

## Testing
- `go build ./cmd/nhb-cli`


------
https://chatgpt.com/codex/tasks/task_e_68e5eed85638832d95d04b5d8eaf003c