### PR TITLE
Document authenticated submission requirements for nhb_sendTransaction

### DIFF
--- a/docs/examples/wallet-lite.md
+++ b/docs/examples/wallet-lite.md
@@ -45,6 +45,9 @@ not yet consumed by the UI.
 * Claimable payloads are validated and normalised before hitting the RPC to avoid malformed requests.
 * The default production base URL is `https://nhbcoin.com`. Set `APP_PUBLIC_BASE` accordingly when
   hosting behind CloudFront or S3.
+* Follow the [authenticated transaction submission guide](../transactions/znhb-transfer.md#authenticated-submission)
+  when wiring send flows so `nhb_sendTransaction` continues to proxy through the server and the RPC
+  bearer token never leaves trusted infrastructure.
 
 ## Claimables Walkthrough
 


### PR DESCRIPTION
## Summary
- explain the bearer-token requirements for `nhb_sendTransaction` and link to the RPC/auth enforcement in the ZNHB transfer guide
- reference the consensus debit/credit processing paths for NHB and ZNHB transfers
- point Wallet Lite integrators to the new authenticated submission guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6094cc7ac832d8549b1bb8cd11404