### PR TITLE
Document authenticated NHB and ZNHB submission

### DIFF
--- a/docs/examples/wallet-lite.md
+++ b/docs/examples/wallet-lite.md
@@ -37,6 +37,10 @@ The application does not call the identity gateway directly; email hashing happe
 `IDENTITY_EMAIL_SALT`. `NHB_WS_URL` is read from the root environment for future live updates but is
 not yet consumed by the UI.
 
+For future send capabilities, follow the [authenticated submission flow for
+`nhb_sendTransaction`](../transactions/znhb-transfer.md#authenticated-submission)
+so the RPC bearer token remains confined to server-side routes.
+
 ## Security Posture
 
 * Private keys live only in client state. Refreshing the page clears them.


### PR DESCRIPTION
## Summary
- document that nhb_sendTransaction requires a bearer token and should be proxied through server-side helpers
- describe where ledger debits/credits happen for NHB and ZNHB transfers in the state processor
- cross-link the wallet-lite example to the authenticated submission guidance

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e605e243c0832d8d930d2e92f97064