### PR TITLE
Add gateway transaction route for ZNHB sends

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -208,6 +208,13 @@ func main() {
 				RateLimitKey:   "gov",
 			},
 			{
+				Name:         "transactions",
+				Prefix:       "/v1/transactions",
+				Target:       servicesByName["consensusd"].BaseURL,
+				RequireAuth:  true,
+				RateLimitKey: "consensus",
+			},
+			{
 				Name:         "consensus",
 				Prefix:       "/v1/consensus",
 				Target:       servicesByName["consensusd"].BaseURL,

--- a/docs/examples/wallets.md
+++ b/docs/examples/wallets.md
@@ -1,0 +1,55 @@
+# Wallet gateway examples
+
+This page collects ready-made calls for wallet backends that proxy signed
+transactions through the gateway. All examples assume the gateway is reachable
+at `https://app.nhbcoin.com`, the consensus node expects bearer authentication,
+and the wallet server holds the `NHB_RPC_TOKEN` secret.
+
+## Sending a ZNHB transfer with `curl`
+
+```bash
+curl -s \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $NHB_RPC_TOKEN" \
+  -d '{
+        "jsonrpc":"2.0",
+        "id":99,
+        "method":"nhb_sendTransaction",
+        "params":[
+          {
+            "chainId":"0x4e4842",
+            "type":16,
+            "nonce":7,
+            "to":"0x1b9b9fb69f2c6c9c1d4c1c4e7b999b20461ab29f",
+            "value":"0x2386f26fc10000",
+            "gasLimit":"0x61a8",
+            "gasPrice":"0x3b9aca00",
+            "data":"0x",
+            "r":"0xc1efc6c2f0c3f3d71e2c195911edbf7a7e8bc2bd52d4b3f6b14d4b0e54738b62",
+            "s":"0x27a1a8e31f42d8c3e65d021779f8921bb5ca5066a8b0f67fc6f2df548b6e2771",
+            "v":"0x1b"
+          }
+        ]
+      }' \
+  https://app.nhbcoin.com/v1/transactions/send
+```
+
+Successful requests return the JSON-RPC response from the node, confirming that
+the transaction hit the mempool. Any `401` or `429` errors indicate the standard
+authentication and rate limit guards are still enforced through the gateway.
+
+## Sending the same payload with Postman
+
+1. Create a `POST` request pointing at
+   `https://app.nhbcoin.com/v1/transactions/send`.
+2. Add headers: `Content-Type: application/json` and
+   `Authorization: Bearer {{NHB_RPC_TOKEN}}`.
+3. Switch the body to **raw** JSON and paste the transaction payload.
+4. Send the request; Postman will display the JSON-RPC response returned by the
+   validator node.
+
+These flows match the expectations outlined in
+[`docs/transactions/znhb-transfer.md`](../transactions/znhb-transfer.md), but
+move through the hardened gateway path so the bearer token never leaves your
+backend.

--- a/docs/gateway/transactions.md
+++ b/docs/gateway/transactions.md
@@ -1,0 +1,84 @@
+# Transaction submission via the gateway
+
+The gateway exposes a scoped `/v1/transactions/send` endpoint that proxies
+`nhb_sendTransaction` to the consensus node. Requests are authenticated with the
+same bearer token as the legacy JSON-RPC surface and retain the node-level rate
+limits and duplicate detection so wallets do not lose existing safeguards.
+
+- **Method:** `POST`
+- **Path:** `/v1/transactions/send`
+- **Auth:** `Authorization: Bearer <NHB_RPC_TOKEN>`
+- **Rate limit:** Shares the standard transaction limiter applied by the node.
+
+The gateway validates the transaction payload before forwarding it. Both the
+classic NHB transfer (`TxTypeTransfer`) and the new ZNHB transfer
+(`TxTypeTransferZNHB`) are accepted; other transaction types are rejected with a
+`400` response.
+
+## Request format
+
+Send the same JSON-RPC payload that validator nodes accept. The gateway will
+normalise the payload (defaulting `jsonrpc` to `2.0` and `method` to
+`nhb_sendTransaction` when omitted) before relaying the call.
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "nhb_sendTransaction",
+  "params": [
+    {
+      "chainId": "0x4e4842",
+      "type": 16,
+      "nonce": 42,
+      "to": "0x5c9d4cde23f68cd2209a2f5eaf0a1d34ac3e5f2a",
+      "value": "0xde0b6b3a7640000",
+      "gasLimit": "0x61a8",
+      "gasPrice": "0x3b9aca00",
+      "data": "0x",
+      "r": "0x9d6bb1226fb5c07f42d41f017cbf6f6fb1dcf1c563cb5b5b6f2a7d2639a4bce1",
+      "s": "0x42fdedb6f5b1f59fa3d793c9d86b8b156382fa4995df794ba53d0d2ca4f8cb22",
+      "v": "0x1c"
+    }
+  ]
+}
+```
+
+## Example: ZNHB transfer with `curl`
+
+```bash
+curl -s \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $NHB_RPC_TOKEN" \
+  -d @znhb-transfer.json \
+  https://app.nhbcoin.com/v1/transactions/send
+```
+
+Where `znhb-transfer.json` contains the JSON-RPC payload shown above. The
+response mirrors the node output, for example:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "Transaction received by node."
+}
+```
+
+## Example: ZNHB transfer via Postman
+
+1. Create a new `POST` request to `https://app.nhbcoin.com/v1/transactions/send`.
+2. Under **Headers** add `Authorization: Bearer {{NHB_RPC_TOKEN}}` and
+   `Content-Type: application/json`.
+3. Paste the JSON-RPC payload into the **Body** tab (`raw`, `JSON`).
+4. Send the request. A successful submission returns the same JSON payload as
+   the underlying node, while authentication failures return `401`.
+
+## Error responses
+
+| Condition                                | HTTP | Body                                              |
+| ---------------------------------------- | ---- | ------------------------------------------------- |
+| Missing or malformed payload             | 400  | `{ "error": "request body is empty" }`          |
+| Unsupported transaction type             | 400  | `{ "error": "unsupported transaction type 0x.." }` |
+| Upstream node rejected or throttled call | 4xx  | JSON-RPC error forwarded from the node            |

--- a/gateway/routes/router.go
+++ b/gateway/routes/router.go
@@ -61,6 +61,14 @@ func New(cfg Config) (http.Handler, error) {
 			}
 			lendingBridge = lr
 		}
+		var txBridge *transactionsRoutes
+		if route.Name == "transactions" {
+			tr, err := newTransactionsRoutes(route.Target)
+			if err != nil {
+				return nil, fmt.Errorf("configure transaction routes: %w", err)
+			}
+			txBridge = tr
+		}
 		r.Route(route.Prefix, func(sr chi.Router) {
 			if cfg.RateLimiter != nil && route.RateLimitKey != "" {
 				sr.Use(cfg.RateLimiter.Middleware(route.RateLimitKey))
@@ -73,6 +81,9 @@ func New(cfg Config) (http.Handler, error) {
 			}
 			if lendingBridge != nil {
 				lendingBridge.mount(sr)
+			}
+			if txBridge != nil {
+				txBridge.mount(sr)
 			}
 			sr.Handle("/*", proxy)
 			sr.Handle("/", proxy)

--- a/gateway/routes/transactions.go
+++ b/gateway/routes/transactions.go
@@ -1,0 +1,185 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"nhbchain/core/types"
+)
+
+const transactionsRequestLimit = 1 << 20 // 1 MiB
+
+// transactionsRoutes proxies nhb_sendTransaction requests to the consensus RPC
+// while validating supported transaction types.
+type transactionsRoutes struct {
+	target  *url.URL
+	client  *http.Client
+	timeout time.Duration
+}
+
+type sendTransactionRequest struct {
+	JSONRPC string            `json:"jsonrpc,omitempty"`
+	ID      json.RawMessage   `json:"id,omitempty"`
+	Method  string            `json:"method,omitempty"`
+	Params  []json.RawMessage `json:"params"`
+}
+
+func newTransactionsRoutes(target *url.URL) (*transactionsRoutes, error) {
+	if target == nil {
+		return nil, fmt.Errorf("nil transactions target")
+	}
+	cloned := *target
+	if strings.TrimSpace(cloned.Scheme) == "" {
+		return nil, fmt.Errorf("transactions target scheme required")
+	}
+	if strings.TrimSpace(cloned.Host) == "" {
+		return nil, fmt.Errorf("transactions target host required")
+	}
+	if strings.TrimSpace(cloned.Path) == "" {
+		cloned.Path = "/"
+	}
+	return &transactionsRoutes{
+		target:  &cloned,
+		client:  &http.Client{Timeout: 15 * time.Second},
+		timeout: 10 * time.Second,
+	}, nil
+}
+
+func (tr *transactionsRoutes) mount(r chi.Router) {
+	r.Post("/send", tr.send)
+}
+
+func (tr *transactionsRoutes) send(w http.ResponseWriter, r *http.Request) {
+	if tr == nil || tr.target == nil {
+		writeInternalError(w, errors.New("transactions route misconfigured"))
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, transactionsRequestLimit))
+	if err != nil {
+		writeBadRequest(w, fmt.Errorf("read request body: %w", err))
+		return
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		writeBadRequest(w, errors.New("request body is empty"))
+		return
+	}
+
+	var req sendTransactionRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		writeBadRequest(w, fmt.Errorf("decode request: %w", err))
+		return
+	}
+	if strings.TrimSpace(req.Method) == "" {
+		req.Method = "nhb_sendTransaction"
+	}
+	if req.Method != "nhb_sendTransaction" {
+		writeBadRequest(w, fmt.Errorf("unsupported method %q", req.Method))
+		return
+	}
+	if req.JSONRPC == "" {
+		req.JSONRPC = "2.0"
+	}
+	if len(req.Params) == 0 {
+		writeBadRequest(w, errors.New("transaction parameter required"))
+		return
+	}
+
+	var tx types.Transaction
+	if err := json.Unmarshal(req.Params[0], &tx); err != nil {
+		writeBadRequest(w, fmt.Errorf("decode transaction: %w", err))
+		return
+	}
+	switch tx.Type {
+	case types.TxTypeTransfer, types.TxTypeTransferZNHB:
+	default:
+		writeBadRequest(w, fmt.Errorf("unsupported transaction type 0x%x", byte(tx.Type)))
+		return
+	}
+
+	forwardBody, err := json.Marshal(req)
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("encode upstream request: %w", err))
+		return
+	}
+
+	ctx, cancel := tr.context(r.Context())
+	defer cancel()
+
+	forwardReq, err := http.NewRequestWithContext(ctx, http.MethodPost, tr.target.String(), bytes.NewReader(forwardBody))
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("build upstream request: %w", err))
+		return
+	}
+	forwardReq.Header.Set("Content-Type", "application/json")
+	if auth := strings.TrimSpace(r.Header.Get("Authorization")); auth != "" {
+		forwardReq.Header.Set("Authorization", auth)
+	}
+	if chainID := strings.TrimSpace(r.Header.Get("X-Chain-Id")); chainID != "" {
+		forwardReq.Header.Set("X-Chain-Id", chainID)
+	}
+	forwarded := strings.TrimSpace(r.Header.Get("X-Forwarded-For"))
+	if remote := clientIP(r.RemoteAddr); remote != "" {
+		if forwarded != "" {
+			forwarded = fmt.Sprintf("%s, %s", forwarded, remote)
+		} else {
+			forwarded = remote
+		}
+	}
+	if forwarded != "" {
+		forwardReq.Header.Set("X-Forwarded-For", forwarded)
+	}
+
+	resp, err := tr.client.Do(forwardReq)
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("forward request: %w", err))
+		return
+	}
+	defer resp.Body.Close()
+
+	copyHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func (tr *transactionsRoutes) context(parent context.Context) (context.Context, context.CancelFunc) {
+	timeout := tr.timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
+func copyHeaders(dst, src http.Header) {
+	for key, values := range src {
+		// Skip Content-Length to allow Go's http server to set it automatically.
+		if strings.EqualFold(key, "Content-Length") {
+			continue
+		}
+		dst.Del(key)
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}
+
+func clientIP(addr string) string {
+	host := strings.TrimSpace(addr)
+	if host == "" {
+		return ""
+	}
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	return strings.TrimSpace(host)
+}


### PR DESCRIPTION
## Summary
- add a dedicated /v1/transactions/send handler that proxies nhb_sendTransaction while allowing TxTypeTransferZNHB payloads
- register the transactions route in the gateway configuration so it reuses existing auth and rate limits
- document the new gateway flow with curl/Postman wallet examples covering ZNHB transfers

## Testing
- go test ./gateway/...

------
https://chatgpt.com/codex/tasks/task_e_68e640591ef4832dafb2bdd0c3fc2037