### PR TITLE
Enforce ZNHB route wallet configuration

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestLoadParsesP2PSettings(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	keystorePath := filepath.Join(dir, "validator.keystore")
-        contents := fmt.Sprintf(`ListenAddress = "0.0.0.0:7000"
+	contents := fmt.Sprintf(`ListenAddress = "0.0.0.0:7000"
 RPCAddress = "0.0.0.0:9000"
 DataDir = "./data"
 GenesisFile = "genesis.json"
@@ -125,18 +126,18 @@ PEX = false
 	if cfg.RPCReadTimeout != 20 || cfg.RPCWriteTimeout != 18 {
 		t.Fatalf("unexpected RPC read/write timeouts: %d/%d", cfg.RPCReadTimeout, cfg.RPCWriteTimeout)
 	}
-        if cfg.RPCIdleTimeout != 45 {
-                t.Fatalf("unexpected RPC idle timeout: %d", cfg.RPCIdleTimeout)
-        }
-        if !cfg.RPCAllowInsecure {
-                t.Fatalf("expected RPCAllowInsecure to be true")
-        }
-        if cfg.RPCTLSCertFile != "/path/to/cert.pem" || cfg.RPCTLSKeyFile != "/path/to/key.pem" {
-                t.Fatalf("unexpected RPC TLS paths: %s %s", cfg.RPCTLSCertFile, cfg.RPCTLSKeyFile)
-        }
-        if cfg.RPCTLSClientCAFile != "/path/to/clients.pem" {
-                t.Fatalf("unexpected RPC client CA file: %s", cfg.RPCTLSClientCAFile)
-        }
+	if cfg.RPCIdleTimeout != 45 {
+		t.Fatalf("unexpected RPC idle timeout: %d", cfg.RPCIdleTimeout)
+	}
+	if !cfg.RPCAllowInsecure {
+		t.Fatalf("expected RPCAllowInsecure to be true")
+	}
+	if cfg.RPCTLSCertFile != "/path/to/cert.pem" || cfg.RPCTLSKeyFile != "/path/to/key.pem" {
+		t.Fatalf("unexpected RPC TLS paths: %s %s", cfg.RPCTLSCertFile, cfg.RPCTLSKeyFile)
+	}
+	if cfg.RPCTLSClientCAFile != "/path/to/clients.pem" {
+		t.Fatalf("unexpected RPC client CA file: %s", cfg.RPCTLSClientCAFile)
+	}
 	if header := cfg.NetworkSecurity.AuthorizationHeaderName(); header != "x-test-token" {
 		t.Fatalf("unexpected auth header: %s", header)
 	}
@@ -382,7 +383,7 @@ ValidatorKeystorePath = "%s"
 	}
 
 	want := defaultGlobalConfig()
-	if cfg.Global != want {
+	if !reflect.DeepEqual(cfg.Global, want) {
 		t.Fatalf("unexpected global defaults: %+v", cfg.Global)
 	}
 }

--- a/config/types.go
+++ b/config/types.go
@@ -1,6 +1,9 @@
 package config
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 const (
 	DefaultFreeTierTxPerMonth = uint64(100)
@@ -72,6 +75,27 @@ type Fees struct {
 	MDRBasisPoints     uint32
 	OwnerWallet        string
 	Assets             []FeeAsset
+}
+
+// RouteWalletByAsset returns a normalised map of asset identifiers to the
+// configured route wallet. Empty wallet entries are omitted.
+func (f Fees) RouteWalletByAsset() map[string]string {
+	if len(f.Assets) == 0 {
+		return map[string]string{}
+	}
+	wallets := make(map[string]string, len(f.Assets))
+	for _, asset := range f.Assets {
+		name := strings.ToUpper(strings.TrimSpace(asset.Asset))
+		if name == "" {
+			continue
+		}
+		wallet := strings.TrimSpace(asset.OwnerWallet)
+		if wallet == "" {
+			continue
+		}
+		wallets[name] = wallet
+	}
+	return wallets
 }
 
 // Consensus controls the BFT round timeouts.

--- a/config/validate.go
+++ b/config/validate.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"nhbchain/consensus"
+	"nhbchain/native/fees"
 )
 
 var (
@@ -31,6 +33,19 @@ func ValidateConfig(g Global) error {
 	}
 	if _, err := g.PaymasterLimits(); err != nil {
 		return fmt.Errorf("paymaster: %w", err)
+	}
+	znhbEnabled := false
+	for _, asset := range g.Fees.Assets {
+		if strings.EqualFold(strings.TrimSpace(asset.Asset), fees.AssetZNHB) {
+			znhbEnabled = true
+			break
+		}
+	}
+	if znhbEnabled {
+		wallets := g.Fees.RouteWalletByAsset()
+		if strings.TrimSpace(wallets[fees.AssetZNHB]) == "" {
+			return fmt.Errorf("fees: route_wallet_by_asset.%s must be configured when %s fees are enabled", fees.AssetZNHB, fees.AssetZNHB)
+		}
 	}
 	return nil
 }

--- a/docs/fees/routing.md
+++ b/docs/fees/routing.md
@@ -18,6 +18,30 @@ requirements change. Domains now expose an asset map that binds every accepted
 currency (NHB, ZNHB, and future additions) to a specific MDR basis-point value
 and routing wallet, making fee distribution explicit on a per-asset basis.
 
+### Minimal configuration snippet
+
+Production validators must configure explicit route wallets for both NHB and ZNHB
+assets. The snippet below can be dropped into `config.toml` and edited with the
+correct bech32 addresses.
+
+```toml
+[global.fees]
+free_tier_tx_per_month = 100
+mdr_basis_points = 150
+
+[[global.fees.assets]]
+asset = "NHB"
+owner_wallet = "nhb1exampleownerwalletxxxxxxxxxxxxxxxxxxxx"
+
+[[global.fees.assets]]
+asset = "ZNHB"
+owner_wallet = "znhb1exampleproceedswalletxxxxxxxxxxxxxxxx"
+```
+
+The second entry satisfies the `fees.route_wallet_by_asset.ZNHB` requirement. If
+it is omitted while ZNHB fees remain enabled, the node refuses to start so that
+fees never route to an empty account.
+
 ## Routing flow
 
 The runtime enforces deterministic routing whenever a transaction includes a fee

--- a/tests/config/invariants_test.go
+++ b/tests/config/invariants_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"nhbchain/config"
+	"nhbchain/native/fees"
 )
 
 func TestValidateConfig(t *testing.T) {
@@ -130,6 +131,53 @@ func TestValidateConfig(t *testing.T) {
 				Blocks:  config.Blocks{MaxTxs: 0},
 			},
 			wantErr: true,
+		},
+		{
+			name: "znhb wallet missing",
+			cfg: config.Global{
+				Governance: config.Governance{
+					QuorumBPS:        6000,
+					PassThresholdBPS: 5000,
+					VotingPeriodSecs: config.MinVotingPeriodSeconds,
+				},
+				Slashing: config.Slashing{
+					MinWindowSecs: 1,
+					MaxWindowSecs: 10,
+				},
+				Mempool: config.Mempool{MaxBytes: 1},
+				Blocks:  config.Blocks{MaxTxs: 1},
+				Fees: config.Fees{
+					Assets: []config.FeeAsset{
+						{Asset: fees.AssetZNHB, MDRBasisPoints: config.DefaultMDRBasisPoints},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "znhb wallet configured",
+			cfg: config.Global{
+				Governance: config.Governance{
+					QuorumBPS:        6000,
+					PassThresholdBPS: 5000,
+					VotingPeriodSecs: config.MinVotingPeriodSeconds,
+				},
+				Slashing: config.Slashing{
+					MinWindowSecs: 1,
+					MaxWindowSecs: 10,
+				},
+				Mempool: config.Mempool{MaxBytes: 1},
+				Blocks:  config.Blocks{MaxTxs: 1},
+				Fees: config.Fees{
+					Assets: []config.FeeAsset{
+						{
+							Asset:          fees.AssetZNHB,
+							MDRBasisPoints: config.DefaultMDRBasisPoints,
+							OwnerWallet:    "znhb1configuredwallet",
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/tests/gov/invariants_test.go
+++ b/tests/gov/invariants_test.go
@@ -26,8 +26,8 @@ func testBaseline() govcfg.Baseline {
 			FreeTierTxPerMonth: config.DefaultFreeTierTxPerMonth,
 			MDRBasisPoints:     config.DefaultMDRBasisPoints,
 			Assets: []govcfg.FeeAssetBaseline{
-				{Asset: fees.AssetNHB, MDRBasisPoints: config.DefaultMDRBasisPoints},
-				{Asset: fees.AssetZNHB, MDRBasisPoints: config.DefaultMDRBasisPoints},
+				{Asset: fees.AssetNHB, MDRBasisPoints: config.DefaultMDRBasisPoints, OwnerWallet: "nhb1ownerwalletbaseline"},
+				{Asset: fees.AssetZNHB, MDRBasisPoints: config.DefaultMDRBasisPoints, OwnerWallet: "znhb1proceedswalletbaseline"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- ensure the config validator requires a ZNHB route wallet whenever the asset is enabled
- add a helper to normalise fee route wallets and document the minimal production snippet
- extend config and governance invariant tests to cover the new requirement

## Testing
- go test ./config -run TestValidateConfig -count=1
- go test ./tests/config -run TestValidateConfig -count=1
- go test ./tests/gov -run TestPreflight -count=1

------
https://chatgpt.com/codex/tasks/task_e_68e64d3439a0832d87f5e3727db33023