### PR TITLE
Validate NHB transfer inputs

### DIFF
--- a/core/transfer_znhb_test.go
+++ b/core/transfer_znhb_test.go
@@ -299,60 +299,212 @@ func TestApplyTransferZNHB_Paused(t *testing.T) {
 }
 
 func TestTransferNHBNotAffectedByZNHBPause(t *testing.T) {
-	sp := newStakingStateProcessor(t)
-	sp.SetPauseView(pauseViewStub{modules: map[string]bool{moduleTransferZNHB: true}})
+	t.Run("SucceedsWhenZNHBPaused", func(t *testing.T) {
+		sp := newStakingStateProcessor(t)
+		sp.SetPauseView(pauseViewStub{modules: map[string]bool{moduleTransferZNHB: true}})
 
-	senderKey, err := crypto.GeneratePrivateKey()
-	if err != nil {
-		t.Fatalf("generate sender key: %v", err)
-	}
-	recipientKey, err := crypto.GeneratePrivateKey()
-	if err != nil {
-		t.Fatalf("generate recipient key: %v", err)
-	}
+		senderKey, err := crypto.GeneratePrivateKey()
+		if err != nil {
+			t.Fatalf("generate sender key: %v", err)
+		}
+		recipientKey, err := crypto.GeneratePrivateKey()
+		if err != nil {
+			t.Fatalf("generate recipient key: %v", err)
+		}
 
-	senderAddr := senderKey.PubKey().Address().Bytes()
-	recipientAddr := recipientKey.PubKey().Address().Bytes()
+		senderAddr := senderKey.PubKey().Address().Bytes()
+		recipientAddr := recipientKey.PubKey().Address().Bytes()
 
-	senderAccount := &types.Account{BalanceNHB: big.NewInt(1_000_000_000_000)}
-	if err := sp.setAccount(senderAddr, senderAccount); err != nil {
-		t.Fatalf("seed sender: %v", err)
-	}
-	if err := sp.setAccount(recipientAddr, &types.Account{BalanceNHB: big.NewInt(0)}); err != nil {
-		t.Fatalf("seed recipient: %v", err)
-	}
+		senderAccount := &types.Account{BalanceNHB: big.NewInt(50_000_000_000_000)}
+		if err := sp.setAccount(senderAddr, senderAccount); err != nil {
+			t.Fatalf("seed sender: %v", err)
+		}
+		if err := sp.setAccount(recipientAddr, &types.Account{BalanceNHB: big.NewInt(0)}); err != nil {
+			t.Fatalf("seed recipient: %v", err)
+		}
 
-	tx := &types.Transaction{
-		ChainID:  types.NHBChainID(),
-		Type:     types.TxTypeTransfer,
-		Nonce:    0,
-		To:       append([]byte(nil), recipientAddr...),
-		Value:    big.NewInt(1_000),
-		GasLimit: 21_000,
-		GasPrice: big.NewInt(1_000_000_000),
-	}
-	if err := tx.Sign(senderKey.PrivateKey); err != nil {
-		t.Fatalf("sign transaction: %v", err)
-	}
+		if _, err := sp.Commit(0); err != nil {
+			t.Fatalf("commit state: %v", err)
+		}
 
-	if err := sp.ApplyTransaction(tx); err != nil {
-		t.Fatalf("apply NHB transfer: %v", err)
-	}
+		tx := &types.Transaction{
+			ChainID:  types.NHBChainID(),
+			Type:     types.TxTypeTransfer,
+			Nonce:    0,
+			To:       append([]byte(nil), recipientAddr...),
+			Value:    big.NewInt(1_000),
+			GasLimit: 21_000,
+			GasPrice: big.NewInt(1_000_000_000),
+		}
+		if err := tx.Sign(senderKey.PrivateKey); err != nil {
+			t.Fatalf("sign transaction: %v", err)
+		}
 
-	recipientAccount, err := sp.getAccount(recipientAddr)
-	if err != nil {
-		t.Fatalf("load recipient: %v", err)
-	}
-	if recipientAccount.BalanceNHB.Cmp(big.NewInt(1_000)) != 0 {
-		t.Fatalf("expected recipient to receive 1000 NHB, got %s", recipientAccount.BalanceNHB)
-	}
-	updatedSender, err := sp.getAccount(senderAddr)
-	if err != nil {
-		t.Fatalf("load sender: %v", err)
-	}
-	if updatedSender.Nonce != 1 {
-		t.Fatalf("expected sender nonce incremented, got %d", updatedSender.Nonce)
-	}
+		if err := sp.ApplyTransaction(tx); err != nil {
+			t.Fatalf("apply NHB transfer: %v", err)
+		}
+
+		recipientAccount, err := sp.getAccount(recipientAddr)
+		if err != nil {
+			t.Fatalf("load recipient: %v", err)
+		}
+		if recipientAccount.BalanceNHB.Cmp(big.NewInt(1_000)) != 0 {
+			t.Fatalf("expected recipient to receive 1000 NHB, got %s", recipientAccount.BalanceNHB)
+		}
+		updatedSender, err := sp.getAccount(senderAddr)
+		if err != nil {
+			t.Fatalf("load sender: %v", err)
+		}
+		if updatedSender.Nonce != 1 {
+			t.Fatalf("expected sender nonce incremented, got %d", updatedSender.Nonce)
+		}
+	})
+
+	t.Run("ZeroValueRejected", func(t *testing.T) {
+		sp := newStakingStateProcessor(t)
+
+		senderKey, err := crypto.GeneratePrivateKey()
+		if err != nil {
+			t.Fatalf("generate sender key: %v", err)
+		}
+		recipientKey, err := crypto.GeneratePrivateKey()
+		if err != nil {
+			t.Fatalf("generate recipient key: %v", err)
+		}
+
+		senderAddr := senderKey.PubKey().Address().Bytes()
+		recipientAddr := recipientKey.PubKey().Address().Bytes()
+
+		senderAccount := &types.Account{BalanceNHB: big.NewInt(1_000_000)}
+		if err := sp.setAccount(senderAddr, senderAccount); err != nil {
+			t.Fatalf("seed sender: %v", err)
+		}
+		if err := sp.setAccount(recipientAddr, &types.Account{BalanceNHB: big.NewInt(0)}); err != nil {
+			t.Fatalf("seed recipient: %v", err)
+		}
+
+		if _, err := sp.Commit(0); err != nil {
+			t.Fatalf("commit state: %v", err)
+		}
+
+		tx := &types.Transaction{
+			ChainID:  types.NHBChainID(),
+			Type:     types.TxTypeTransfer,
+			Nonce:    0,
+			To:       append([]byte(nil), recipientAddr...),
+			Value:    big.NewInt(0),
+			GasLimit: 21_000,
+			GasPrice: big.NewInt(1),
+		}
+		if err := tx.Sign(senderKey.PrivateKey); err != nil {
+			t.Fatalf("sign transaction: %v", err)
+		}
+
+		err = sp.ApplyTransaction(tx)
+		if err == nil {
+			t.Fatalf("expected zero-value transfer to fail")
+		}
+		if !errors.Is(err, ErrInvalidTransaction) {
+			t.Fatalf("expected ErrInvalidTransaction, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "amount must be positive") {
+			t.Fatalf("expected amount validation error, got %v", err)
+		}
+	})
+
+	t.Run("ZeroAddressRejected", func(t *testing.T) {
+		sp := newStakingStateProcessor(t)
+
+		senderKey, err := crypto.GeneratePrivateKey()
+		if err != nil {
+			t.Fatalf("generate sender key: %v", err)
+		}
+
+		senderAddr := senderKey.PubKey().Address().Bytes()
+
+		senderAccount := &types.Account{BalanceNHB: big.NewInt(1_000_000)}
+		if err := sp.setAccount(senderAddr, senderAccount); err != nil {
+			t.Fatalf("seed sender: %v", err)
+		}
+
+		zeroAddr := make([]byte, common.AddressLength)
+		if _, err := sp.Commit(0); err != nil {
+			t.Fatalf("commit state: %v", err)
+		}
+
+		tx := &types.Transaction{
+			ChainID:  types.NHBChainID(),
+			Type:     types.TxTypeTransfer,
+			Nonce:    0,
+			To:       zeroAddr,
+			Value:    big.NewInt(1_000),
+			GasLimit: 21_000,
+			GasPrice: big.NewInt(1),
+		}
+		if err := tx.Sign(senderKey.PrivateKey); err != nil {
+			t.Fatalf("sign transaction: %v", err)
+		}
+
+		err = sp.ApplyTransaction(tx)
+		if err == nil {
+			t.Fatalf("expected zero-address transfer to fail")
+		}
+		if !errors.Is(err, ErrInvalidTransaction) {
+			t.Fatalf("expected ErrInvalidTransaction, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "recipient address invalid") {
+			t.Fatalf("expected recipient address validation error, got %v", err)
+		}
+	})
+
+	t.Run("SelfTransferAllowed", func(t *testing.T) {
+		sp := newStakingStateProcessor(t)
+
+		senderKey, err := crypto.GeneratePrivateKey()
+		if err != nil {
+			t.Fatalf("generate sender key: %v", err)
+		}
+		senderAddr := senderKey.PubKey().Address().Bytes()
+
+		initialBalance := big.NewInt(1_000_000)
+		senderAccount := &types.Account{BalanceNHB: new(big.Int).Set(initialBalance)}
+		if err := sp.setAccount(senderAddr, senderAccount); err != nil {
+			t.Fatalf("seed sender: %v", err)
+		}
+
+		if _, err := sp.Commit(0); err != nil {
+			t.Fatalf("commit state: %v", err)
+		}
+
+		tx := &types.Transaction{
+			ChainID:  types.NHBChainID(),
+			Type:     types.TxTypeTransfer,
+			Nonce:    0,
+			To:       append([]byte(nil), senderAddr...),
+			Value:    big.NewInt(500),
+			GasLimit: 21_000,
+			GasPrice: big.NewInt(1),
+		}
+		if err := tx.Sign(senderKey.PrivateKey); err != nil {
+			t.Fatalf("sign transaction: %v", err)
+		}
+
+		if err := sp.ApplyTransaction(tx); err != nil {
+			t.Fatalf("self-transfer should succeed, got %v", err)
+		}
+
+		updatedSender, err := sp.getAccount(senderAddr)
+		if err != nil {
+			t.Fatalf("load sender: %v", err)
+		}
+		if updatedSender.Nonce != 1 {
+			t.Fatalf("expected sender nonce incremented, got %d", updatedSender.Nonce)
+		}
+		expectedBalance := new(big.Int).Sub(initialBalance, big.NewInt(21_000))
+		if updatedSender.BalanceNHB.Cmp(expectedBalance) != 0 {
+			t.Fatalf("expected sender balance %s after gas, got %s", expectedBalance, updatedSender.BalanceNHB)
+		}
+	})
 }
 
 func TestApplyTransferZNHB_InvalidRecipient(t *testing.T) {


### PR DESCRIPTION
## Summary
- enforce NHB transfer recipient and value validation before invoking the EVM path
- surface invalid NHB transfer errors via ErrInvalidTransaction for consistent reporting
- add NHB transfer tests for zero-value, zero-address, and self-transfer cases

## Testing
- go test ./core -run TransferNHBNotAffectedByZNHBPause -count=1

------
https://chatgpt.com/codex/tasks/task_e_68e67ba83d9c832dac4a2b5f804730e5