### PR TITLE
Add CLI support for NHB transfers

### DIFF
--- a/cmd/nhb-cli/main.go
+++ b/cmd/nhb-cli/main.go
@@ -93,6 +93,11 @@ func main() {
 			return
 		}
 		heartbeat(args[1])
+	case "send-nhb":
+		if code := runSendNHBCommand(args[1:]); code != 0 {
+			os.Exit(code)
+		}
+		return
 	case "send-znhb":
 		if code := runSendZNHBCommand(args[1:]); code != 0 {
 			os.Exit(code)

--- a/cmd/nhb-cli/send.go
+++ b/cmd/nhb-cli/send.go
@@ -12,37 +12,32 @@ import (
 	"nhbchain/crypto"
 )
 
-const defaultZNHBGasLimit = 25000
+const (
+	defaultNHBGasLimit  = 21000
+	defaultZNHBGasLimit = 25000
+)
+
+func runSendNHBCommand(args []string) int {
+	gasLimit, positional, err := parseSendCommandFlags("send-nhb", args, defaultNHBGasLimit)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		printSendNHBUsage()
+		return 1
+	}
+
+	if err := sendNHB(positional[0], positional[1], positional[2], gasLimit); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
 
 func runSendZNHBCommand(args []string) int {
-	fs := flag.NewFlagSet("send-znhb", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-
-	var rpcFlag string
-	rpcFlag = rpcEndpoint
-	var gasLimit uint64
-	gasLimit = defaultZNHBGasLimit
-
-	fs.StringVar(&rpcFlag, "rpc", rpcEndpoint, "RPC endpoint (overrides RPC_URL)")
-	fs.Uint64Var(&gasLimit, "gas", defaultZNHBGasLimit, "Gas limit for the transaction")
-
-	if err := fs.Parse(args); err != nil {
+	gasLimit, positional, err := parseSendCommandFlags("send-znhb", args, defaultZNHBGasLimit)
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		printSendZNHBUsage()
-		return 1
-	}
-
-	rpcEndpoint = strings.TrimSpace(rpcFlag)
-
-	positional := fs.Args()
-	if len(positional) != 3 {
-		fmt.Println("Error: expected recipient, amount, and key file.")
-		printSendZNHBUsage()
-		return 1
-	}
-
-	if gasLimit == 0 {
-		fmt.Println("Error: gas limit must be greater than zero.")
 		return 1
 	}
 
@@ -54,8 +49,88 @@ func runSendZNHBCommand(args []string) int {
 	return 0
 }
 
+func parseSendCommandFlags(name string, args []string, defaultGasLimit uint64) (uint64, []string, error) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	rpcFlag := rpcEndpoint
+	gasLimit := defaultGasLimit
+
+	fs.StringVar(&rpcFlag, "rpc", rpcEndpoint, "RPC endpoint (overrides RPC_URL)")
+	fs.Uint64Var(&gasLimit, "gas", defaultGasLimit, "Gas limit for the transaction")
+
+	if err := fs.Parse(args); err != nil {
+		return 0, nil, err
+	}
+
+	rpcEndpoint = strings.TrimSpace(rpcFlag)
+
+	positional := fs.Args()
+	if len(positional) != 3 {
+		return 0, nil, fmt.Errorf("Error: expected recipient, amount, and key file.")
+	}
+
+	if gasLimit == 0 {
+		return 0, nil, fmt.Errorf("Error: gas limit must be greater than zero.")
+	}
+
+	return gasLimit, positional, nil
+}
+
+func printSendUsage(command string) {
+	fmt.Printf("Usage: %s [--rpc <url>] [--gas <limit>] <recipient> <amount> <key_file>\n", command)
+}
+
+func printSendNHBUsage() {
+	printSendUsage("send-nhb")
+}
+
 func printSendZNHBUsage() {
-	fmt.Println("Usage: send-znhb [--rpc <url>] [--gas <limit>] <recipient> <amount> <key_file>")
+	printSendUsage("send-znhb")
+}
+
+func sendNHB(recipient, amountStr, keyFile string, gasLimit uint64) error {
+	privKey, err := loadPrivateKey(keyFile)
+	if err != nil {
+		return fmt.Errorf("loading private key: %w", err)
+	}
+
+	dest, err := crypto.DecodeAddress(recipient)
+	if err != nil {
+		return fmt.Errorf("parsing recipient address: %w", err)
+	}
+
+	amount, ok := new(big.Int).SetString(strings.TrimSpace(amountStr), 10)
+	if !ok || amount.Sign() <= 0 {
+		return fmt.Errorf("amount must be a positive integer")
+	}
+
+	account, err := fetchAccount(privKey.PubKey().Address().String())
+	if err != nil {
+		return fmt.Errorf("fetching account details: %w", err)
+	}
+
+	tx := types.Transaction{
+		ChainID:  types.NHBChainID(),
+		Type:     types.TxTypeTransfer,
+		Nonce:    account.Nonce,
+		To:       dest.Bytes(),
+		Value:    amount,
+		GasLimit: gasLimit,
+		GasPrice: big.NewInt(1),
+	}
+
+	if err := tx.Sign(privKey.PrivateKey); err != nil {
+		return fmt.Errorf("signing transaction: %w", err)
+	}
+
+	hash, err := sendTransaction(&tx)
+	if err != nil {
+		return fmt.Errorf("sending NHB transfer: %w", err)
+	}
+
+	fmt.Printf("Broadcasted NHB transfer: %s\n", hash)
+	return nil
 }
 
 func sendZNHB(recipient, amountStr, keyFile string, gasLimit uint64) error {

--- a/docs/cli/send.md
+++ b/docs/cli/send.md
@@ -1,30 +1,49 @@
-# `send-znhb` command
+# `send-nhb` and `send-znhb` commands
 
-The `send-znhb` subcommand broadcasts a ZapNHB transfer using the
-`TxTypeTransferZNHB` transaction type. It signs the payload with the
-provided key, submits it to the configured RPC endpoint, and prints the
-resulting transaction hash so you can track settlement.
+The `send-nhb` and `send-znhb` subcommands broadcast NHB and ZapNHB
+transfers respectively. Each command constructs the appropriate
+transaction type (`TxTypeTransfer` for NHB, `TxTypeTransferZNHB` for
+ZapNHB), signs it with the provided key, submits it to the configured RPC
+endpoint, and prints the resulting transaction hash so you can track
+settlement.
+
+Both helpers accept a `--rpc` flag to override the HTTP endpoint (falling
+back to the `RPC_URL` environment variable or `http://localhost:8080`)
+and a `--gas` flag to override the gas limit. If `--gas` is not supplied,
+`send-nhb` defaults to `21000` and `send-znhb` defaults to `25000`.
 
 ## Usage
+
+### Send NHB
+
+```bash
+./nhb-cli send-nhb [--rpc <url>] [--gas <limit>] <recipient> <amount> <key_file>
+```
+
+### Send ZapNHB
 
 ```bash
 ./nhb-cli send-znhb [--rpc <url>] [--gas <limit>] <recipient> <amount> <key_file>
 ```
 
-- `recipient` – Hex-encoded account address (either NHB bech32 or 0x).
-- `amount` – ZapNHB amount in wei.
-- `key_file` – Path to the locally stored wallet private key.
-- `--rpc` – Optional HTTP endpoint override. Defaults to `RPC_URL` env var
-  or `http://localhost:8080`.
-- `--gas` – Optional gas limit override. Defaults to `25000` if omitted.
+For both commands:
 
-## Example
+- `recipient` – Hex-encoded account address (either NHB bech32 or 0x).
+- `amount` – Transfer amount in wei.
+- `key_file` – Path to the locally stored wallet private key.
+- `--rpc` – Optional RPC endpoint override.
+- `--gas` – Optional gas limit override.
+
+## Examples
 
 ```bash
-$ ./nhb-cli send-znhb nhb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq4u3h4 500000000000000000 wallet.key --rpc http://localhost:8080 --gas 32000
+$ ./nhb-cli send-nhb nhb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq4u3h4 1000000000000000000 wallet.key --rpc http://localhost:8080
+Broadcasted NHB transfer: 0x4c1b9d265df98a6df6925c1370f9d8b2f047f53a6b0f39db16355e1c5fb2d3af
+
+$ ./nhb-cli send-znhb nhb1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq4u3h4 500000000000000000 wallet.key --gas 32000
 Broadcasted ZNHB transfer: 0xa9a6f4d59e11cce45bfb0fb89f743ad39df0cedf0e09a0e02ff80db152df2b03
 ```
 
 The CLI exits non-zero if the transaction fails to sign or the RPC
-returns an error. Monitor `nhb_getTransactionReceipt` using the hash to
-confirm inclusion.
+returns an error. Monitor `nhb_getTransactionReceipt` using the printed
+hash to confirm inclusion.


### PR DESCRIPTION
## Summary
- add a send-nhb CLI command that mirrors send-znhb
- share send flag parsing helpers and default NHB gas limit handling
- update the send command documentation for both NHB and ZNHB transfers

## Testing
- go build ./cmd/nhb-cli

------
https://chatgpt.com/codex/tasks/task_e_68e684992a00832d873dd85bc5f41e92